### PR TITLE
[WIP] 検索条件のバインド変数が null の場合に自動で SQL の IS NULL へ書き換える

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/SimpleSqlNodeVisitor.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/SimpleSqlNodeVisitor.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.internal.jdbc.sql;
 
 import org.seasar.doma.internal.jdbc.sql.node.AnonymousNode;
+import org.seasar.doma.internal.jdbc.sql.node.BinaryOperatorNode;
 import org.seasar.doma.internal.jdbc.sql.node.BindVariableNode;
 import org.seasar.doma.internal.jdbc.sql.node.CommentNode;
 import org.seasar.doma.internal.jdbc.sql.node.ElseNode;
@@ -147,6 +148,11 @@ public class SimpleSqlNodeVisitor<R, P> implements SqlNodeVisitor<R, P> {
 
     @Override
     public R visitLogicalOperatorNode(LogicalOperatorNode node, P p) {
+        return defaultAction(node, p);
+    }
+
+    @Override
+    public R visitBinaryOperatorNode(BinaryOperatorNode node, P p) {
         return defaultAction(node, p);
     }
 

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlTokenType.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlTokenType.java
@@ -138,6 +138,10 @@ public enum SqlTokenType {
 
     OTHER,
 
+    EQ_OP,
+
+    NE_OP,
+
     WHITESPACE,
 
     EOL,

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlTokenizer.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlTokenizer.java
@@ -26,6 +26,7 @@ import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EMBEDDED_VARIABLE_B
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.END_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EOF;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EOL;
+import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EQ_OP;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EXCEPT_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EXPAND_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.FOR_BLOCK_COMMENT;
@@ -37,6 +38,7 @@ import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.IF_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.INTERSECT_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.LINE_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.MINUS_WORD;
+import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.NE_OP;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.OPENED_PARENS;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.ORDER_BY_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.OR_WORD;
@@ -324,7 +326,10 @@ public class SqlTokenizer {
     }
 
     protected void peekTwoChars(char c, char c2) {
-        if ((c == 'o' || c == 'O') && (c2 == 'r' || c2 == 'R')) {
+        if ((c == '<' && c2 == '>') || (c == '!' && c2 == '=')) {
+            type = NE_OP;
+            return;
+        } else if ((c == 'o' || c == 'O') && (c2 == 'r' || c2 == 'R')) {
             type = OR_WORD;
             if (isWordTerminated()) {
                 return;
@@ -461,6 +466,8 @@ public class SqlTokenizer {
     protected void peekOneChar(char c) {
         if (isWhitespace(c)) {
             type = WHITESPACE;
+        } else if (c == '=') {
+            type = EQ_OP;
         } else if (c == '(') {
             type = OPENED_PARENS;
         } else if (c == ')') {

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/BinaryOperatorNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/BinaryOperatorNode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal.jdbc.sql.node;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import org.seasar.doma.DomaNullPointerException;
+import org.seasar.doma.jdbc.SqlNodeVisitor;
+
+/**
+ * @author nakamura-to
+ * 
+ */
+public class BinaryOperatorNode extends AbstractSqlNode {
+
+    protected final String op;
+
+    protected final OpKind opKind;
+
+    public BinaryOperatorNode(String op, OpKind opKind) {
+        assertNotNull(op, opKind);
+        this.op = op;
+        this.opKind = opKind;
+    }
+
+    public String getOp() {
+        return op;
+    }
+
+    public OpKind getOpKind() {
+        return opKind;
+    }
+
+    @Override
+    public <R, P> R accept(SqlNodeVisitor<R, P> visitor, P p) {
+        if (visitor == null) {
+            throw new DomaNullPointerException("visitor");
+        }
+        return visitor.visitBinaryOperatorNode(this, p);
+    }
+
+    public enum OpKind {
+        EQ, NE
+    }
+}

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/BindVariableNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/BindVariableNode.java
@@ -34,6 +34,8 @@ public class BindVariableNode extends AbstractSqlNode {
 
     protected ParensNode parensNode;
 
+    protected BinaryOperatorNode.OpKind opKind;
+
     public BindVariableNode(SqlLocation location, String variableName,
             String text) {
         assertNotNull(location, variableName, text);
@@ -90,6 +92,14 @@ public class BindVariableNode extends AbstractSqlNode {
 
     public boolean isParensNodeIgnored() {
         return parensNode != null;
+    }
+
+    public BinaryOperatorNode.OpKind getOpKind() {
+        return opKind;
+    }
+
+    public void setOpKind(BinaryOperatorNode.OpKind opKind) {
+        this.opKind = opKind;
     }
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/SqlNodeVisitor.java
+++ b/src/main/java/org/seasar/doma/jdbc/SqlNodeVisitor.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.jdbc;
 
 import org.seasar.doma.internal.jdbc.sql.node.AnonymousNode;
+import org.seasar.doma.internal.jdbc.sql.node.BinaryOperatorNode;
 import org.seasar.doma.internal.jdbc.sql.node.BindVariableNode;
 import org.seasar.doma.internal.jdbc.sql.node.CommentNode;
 import org.seasar.doma.internal.jdbc.sql.node.ElseNode;
@@ -94,6 +95,8 @@ public interface SqlNodeVisitor<R, P> {
     R visitIfNode(IfNode node, P p);
 
     R visitLogicalOperatorNode(LogicalOperatorNode node, P p);
+
+    R visitBinaryOperatorNode(BinaryOperatorNode node, P p);
 
     R visitOrderByClauseNode(OrderByClauseNode node, P p);
 

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
@@ -110,6 +110,42 @@ public class SqlParserTest extends TestCase {
         assertEquals(0, sql.getParameters().size());
     }
 
+    public void testBindVariable_rewriting_eq() throws Exception {
+        ExpressionEvaluator evaluator = new ExpressionEvaluator();
+        evaluator.add("name", new Value(String.class, null));
+        evaluator.add("salary", new Value(BigDecimal.class, null));
+        String testSql = "select * from aaa where ename = /*name*/'aaa' and sal = /*salary*/-2000";
+        SqlParser parser = new SqlParser(testSql);
+        SqlNode sqlNode = parser.parse();
+        PreparedSql sql = new NodePreparedSqlBuilder(config, SqlKind.SELECT,
+                "dummyPath", evaluator).build(sqlNode);
+        assertEquals(
+                "select * from aaa where ename   is null and sal   is null",
+                sql.getRawSql());
+        assertEquals(
+                "select * from aaa where ename   is null and sal   is null",
+                sql.getFormattedSql());
+        assertEquals(0, sql.getParameters().size());
+    }
+
+    public void testBindVariable_rewriting_ne() throws Exception {
+        ExpressionEvaluator evaluator = new ExpressionEvaluator();
+        evaluator.add("name", new Value(String.class, null));
+        evaluator.add("salary", new Value(BigDecimal.class, null));
+        String testSql = "select * from aaa where ename <> /*name*/'aaa' and sal != /*salary*/-2000";
+        SqlParser parser = new SqlParser(testSql);
+        SqlNode sqlNode = parser.parse();
+        PreparedSql sql = new NodePreparedSqlBuilder(config, SqlKind.SELECT,
+                "dummyPath", evaluator).build(sqlNode);
+        assertEquals(
+                "select * from aaa where ename   is not null and sal   is not null",
+                sql.getRawSql());
+        assertEquals(
+                "select * from aaa where ename   is not null and sal   is not null",
+                sql.getFormattedSql());
+        assertEquals(0, sql.getParameters().size());
+    }
+
     public void testBindVariable_endsWithBindVariableComment() throws Exception {
         ExpressionEvaluator evaluator = new ExpressionEvaluator();
         evaluator.add("name", new Value(String.class, "hoge"));

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlTokenizerTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlTokenizerTest.java
@@ -22,6 +22,7 @@ import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.DELIMITER;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.END_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EOF;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EOL;
+import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EQ_OP;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EXCEPT_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.EXPAND_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.FOR_BLOCK_COMMENT;
@@ -33,6 +34,7 @@ import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.IF_BLOCK_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.INTERSECT_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.LINE_COMMENT;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.MINUS_WORD;
+import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.NE_OP;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.ORDER_BY_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.OR_WORD;
 import static org.seasar.doma.internal.jdbc.sql.SqlTokenType.OTHER;
@@ -276,6 +278,30 @@ public class SqlTokenizerTest extends TestCase {
         SqlTokenizer tokenizer = new SqlTokenizer("or");
         assertEquals(OR_WORD, tokenizer.next());
         assertEquals("or", tokenizer.getToken());
+        assertEquals(EOF, tokenizer.next());
+        assertNull(tokenizer.getToken());
+    }
+
+    public void testEq() throws Exception {
+        SqlTokenizer tokenizer = new SqlTokenizer("=");
+        assertEquals(EQ_OP, tokenizer.next());
+        assertEquals("=", tokenizer.getToken());
+        assertEquals(EOF, tokenizer.next());
+        assertNull(tokenizer.getToken());
+    }
+
+    public void testNe() throws Exception {
+        SqlTokenizer tokenizer = new SqlTokenizer("<>");
+        assertEquals(NE_OP, tokenizer.next());
+        assertEquals("<>", tokenizer.getToken());
+        assertEquals(EOF, tokenizer.next());
+        assertNull(tokenizer.getToken());
+    }
+
+    public void testNe2() throws Exception {
+        SqlTokenizer tokenizer = new SqlTokenizer("!=");
+        assertEquals(NE_OP, tokenizer.next());
+        assertEquals("!=", tokenizer.getToken());
         assertEquals(EOF, tokenizer.next());
         assertNull(tokenizer.getToken());
     }


### PR DESCRIPTION
バインド変数の値が 非 `null` であれば `=` による比較、`null` であれば `IS NULL` 句による比較をしたいといった場合、これまではSQLファイル上で明示的な条件分岐が必要でした。

``` sql
select * from emp where 
/*%if name != null*/
  ename = /*name*/'hoge'
/*%else */
  and
  ename is null
/*%end */
```

この記述は煩雑なので、自動で `IS NULL` への書き換えを行います。
この Pull Request をマージすると次のように書いても上記と同等の意味になります。

``` sql
select * from emp where ename = /*name*/'hoge'
```

また、 同様に、`<>` や `!=` による比較は、 `IS NOT NULL` を使った比較に書き換えます。

この自動書き換えは、次の条件を満たした場合にのみ行います。
- `SELECT` 、`WHERE` 、 `HAVING` 句の中
- `=` 、 `<>` 、`!=` といった演算子の直後でバインド変数が使われている（ただし、演算子とバインド変数の間に空白が入っても良い）
