### PR TITLE
/*%expand と */ の間のスペースはaliasとみなさないようにしました

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
@@ -15,7 +15,7 @@
  */
 package org.seasar.doma.internal.jdbc.sql;
 
-import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+import static org.seasar.doma.internal.util.AssertionUtil.*;
 
 import java.util.Deque;
 import java.util.Iterator;
@@ -52,6 +52,7 @@ import org.seasar.doma.internal.jdbc.sql.node.SqlLocation;
 import org.seasar.doma.internal.jdbc.sql.node.WhereClauseNode;
 import org.seasar.doma.internal.jdbc.sql.node.WhitespaceNode;
 import org.seasar.doma.internal.jdbc.sql.node.WordNode;
+import org.seasar.doma.internal.util.StringUtil;
 import org.seasar.doma.jdbc.JdbcException;
 import org.seasar.doma.jdbc.SqlNode;
 import org.seasar.doma.message.Message;
@@ -451,7 +452,7 @@ public class SqlParser {
 
     protected void parseExpandBlockComment() {
         String alias = tokenType.extract(token);
-        if (alias.isEmpty()) {
+        if (alias.isEmpty() || StringUtil.isWhitespace(alias)) {
             alias = "\"\"";
         }
         ExpandNode node = new ExpandNode(getLocation(), alias, token);

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
@@ -280,6 +280,18 @@ public class SqlParserTest extends TestCase {
         assertEquals("select bbb, ccc from aaa", sql.getFormattedSql());
     }
 
+    public void testExpand_withSpace() throws Exception {
+        ExpressionEvaluator evaluator = new ExpressionEvaluator();
+        String testSql = "select /*%expand */* from aaa";
+        SqlParser parser = new SqlParser(testSql);
+        SqlNode sqlNode = parser.parse();
+        PreparedSql sql = new NodePreparedSqlBuilder(config, SqlKind.SELECT,
+                "dummyPath", evaluator, SqlLogType.FORMATTED,
+                node -> Arrays.asList("bbb", "ccc")).build(sqlNode);
+        assertEquals("select bbb, ccc from aaa", sql.getRawSql());
+        assertEquals("select bbb, ccc from aaa", sql.getFormattedSql());
+    }
+
     public void testExpand_alias() throws Exception {
         ExpressionEvaluator evaluator = new ExpressionEvaluator();
         String testSql = "select /*%expand \"a\"*/* from aaa a";


### PR DESCRIPTION
これまでは /%expand と */ の間にスペースがある場合にそのスペースを
aliasとみなしてExpandNodeを組み立てていましたが、それが原因で実行時に
AbstractSelectQuery#prepare()でNullPointerExceptionが発生していました。

例えば次のようなSQLが該当します。

```
SELECT /*%expand */*
  FROM Hoge
```

このSQLを含むSQLファイルに対応したDaoのメソッドを実行すると
NullPointerExceptionが発生します。
次にスタックトレースを抜粋します。

```
java.lang.NullPointerException
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitExpandNode(NodePreparedSqlBuilder.java:582)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitExpandNode(NodePreparedSqlBuilder.java:82)
        at org.seasar.doma.internal.jdbc.sql.node.ExpandNode.accept(ExpandNode.java:63)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitSelectClauseNode(NodePreparedSqlBuilder.java:438)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitSelectClauseNode(NodePreparedSqlBuilder.java:82)
        at org.seasar.doma.internal.jdbc.sql.node.SelectClauseNode.accept(SelectClauseNode.java:40)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitSelectStatementNode(NodePreparedSqlBuilder.java:428)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitSelectStatementNode(NodePreparedSqlBuilder.java:82)
        at org.seasar.doma.internal.jdbc.sql.node.SelectStatementNode.accept(SelectStatementNode.java:124)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitAnonymousNode(NodePreparedSqlBuilder.java:146)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.visitAnonymousNode(NodePreparedSqlBuilder.java:82)
        at org.seasar.doma.internal.jdbc.sql.node.AnonymousNode.accept(AnonymousNode.java:35)
        at org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder.build(NodePreparedSqlBuilder.java:137)
        at org.seasar.doma.jdbc.query.SqlFileSelectQuery.lambda$prepareSql$13(SqlFileSelectQuery.java:51)
        at org.seasar.doma.jdbc.query.SqlFileSelectQuery$$Lambda$6/1027007693.apply(Unknown Source)
        at org.seasar.doma.jdbc.query.AbstractSelectQuery.buildSql(AbstractSelectQuery.java:113)
        at org.seasar.doma.jdbc.query.SqlFileSelectQuery.prepareSql(SqlFileSelectQuery.java:47)
        at org.seasar.doma.jdbc.query.AbstractSelectQuery.prepare(AbstractSelectQuery.java:90)
        at org.seasar.doma.jdbc.query.SqlFileSelectQuery.prepare(SqlFileSelectQuery.java:39)
```

この問題を解決するため /*%expand と */ の間にスペースのみがある場合は
aliasとみなさないように修正しました。
