### PR TITLE
プロジェクトの名前を"doma"に設定しました

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'doma'


### PR DESCRIPTION
これまではプロジェクトをcloneした先のディレクトリの名前が
プロジェクト名として使用されていました。

例えば `git clone git@github.com:domaframework/doma.git doma2`
とした場合は doma2 という名前のディレクトリにcloneされます。
この状態でビルドするとプロジェクト名が doma2 と認識されていました。

settings.gradleを追加してプロジェクト名を明記する事でディレクトリを
どのような名前にしていても doma というプロジェクト名でビルドできる
ようにしました。
- 参考 http://gradle.monochromeroad.com/docs/userguide/build_lifecycle.html#sub:modifying_element_of_the_project_tree
