### PR TITLE
EntityListenerをConfig.getEntityListener()で取得するようにしました

### DIFF
--- a/docs/sources/config.rst
+++ b/docs/sources/config.rst
@@ -218,6 +218,16 @@ SELECT時のフェッチサイズをあらわす ``int`` を ``getFetchSize`` �
 この値は :doc:`query/batch-insert` 、:doc:`query/batch-update` 、:doc:`query/batch-delete`
 においてデフォルト値として使われます。
 
+エンティティリスナーの取得
+--------------------------
+
+``EntityListener`` を ``getEntityListener`` メソッドで返して下さい。
+``getEntityListener`` メソッドは ``EntityListener`` 実装クラスの ``Class`` と ``EntityListener`` 実装クラスのインスタンスを返す ``Supplier``
+を引数に取り、デフォルトの実装では ``Supplier.get`` メソッドを実行して得たインスタンスを返します。
+
+``EntityListener`` 実装クラスのインスタンスをDIコンテナから取得したいなど、
+インスタンス取得方法をカスタマイズする場合は設定してください。
+
 JDBC ドライバのロード
 =====================
 

--- a/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
+++ b/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
@@ -25,6 +25,7 @@ import org.seasar.doma.jdbc.ClassHelper;
 import org.seasar.doma.jdbc.CommandImplementors;
 import org.seasar.doma.jdbc.Commenter;
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.ConfigException;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.MapKeyNaming;
 import org.seasar.doma.jdbc.QueryImplementors;
@@ -150,7 +151,13 @@ public class RuntimeConfig implements Config {
     @Override
     public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
             Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
-        return config.getEntityListener(listenerClass, listenerSupplier);
+        LISTENER listener = config.getEntityListener(listenerClass,
+                listenerSupplier);
+        if (listener == null) {
+            throw new ConfigException(config.getClass().getName(),
+                    "getEntityListener");
+        }
+        return listener;
     }
 
 }

--- a/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
+++ b/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
@@ -17,6 +17,8 @@ package org.seasar.doma.internal;
 
 import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
+import java.util.function.Supplier;
+
 import javax.sql.DataSource;
 
 import org.seasar.doma.jdbc.ClassHelper;
@@ -31,6 +33,7 @@ import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.UnknownColumnHandler;
 import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.entity.EntityListener;
 import org.seasar.doma.jdbc.tx.TransactionManager;
 
 /**
@@ -142,6 +145,12 @@ public class RuntimeConfig implements Config {
     @Override
     public int getBatchSize() {
         return config.getBatchSize();
+    }
+
+    @Override
+    public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
+            Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
+        return config.getEntityListener(listenerClass, listenerSupplier);
     }
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/Config.java
+++ b/src/main/java/org/seasar/doma/jdbc/Config.java
@@ -17,12 +17,14 @@ package org.seasar.doma.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+import java.util.function.Supplier;
 
 import javax.sql.DataSource;
 
 import org.seasar.doma.DomaIllegalArgumentException;
 import org.seasar.doma.jdbc.command.Command;
 import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.entity.EntityListener;
 import org.seasar.doma.jdbc.query.Query;
 import org.seasar.doma.jdbc.tx.TransactionManager;
 import org.seasar.doma.message.Message;
@@ -226,6 +228,29 @@ public interface Config {
      */
     default int getBatchSize() {
         return 0;
+    }
+
+    /**
+     * {@link EntityListener} のインスタンスを取得します。
+     * <p>
+     * デフォルトの実装では単純に {@link Supplier#get()} を実行して取得したインスタンスを返します。
+     * 
+     * {@link EntityListener} をDIコンテナで管理したい場合などはこのメソッドをオーバーライドし、
+     * DIコンテナから取得したインスタンスを返すようにしてください。
+     * 
+     * @param listenerClass
+     *            {@link EntityListener} の実装クラス
+     * @param listenerSupplier
+     *            {@link EntityListener} のインスタンスを返す {@link Supplier}
+     * @param <ENTITY>
+     *            エンティティの型
+     * @param <LISTENER>
+     *            リスナーの型
+     * @return {@link EntityListener} のインスタンス
+     */
+    default <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
+            Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
+        return listenerSupplier.get();
     }
 
     /**

--- a/src/test/java/org/seasar/doma/internal/RuntimeConfigTest.java
+++ b/src/test/java/org/seasar/doma/internal/RuntimeConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal;
+
+import java.util.function.Supplier;
+
+import javax.sql.DataSource;
+
+import junit.framework.TestCase;
+
+import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.ConfigException;
+import org.seasar.doma.jdbc.SimpleDataSource;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.StandardDialect;
+import org.seasar.doma.jdbc.entity.EntityListener;
+
+/**
+ * @author backpaper0
+ *
+ */
+public class RuntimeConfigTest extends TestCase {
+
+    public void testGetEntityListener() throws Exception {
+        Config originalConfig = new MockConfig() {
+
+            @Override
+            public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
+                    Class<LISTENER> listenerClass,
+                    Supplier<LISTENER> listenerSupplier) {
+                return listenerSupplier.get();
+            }
+        };
+
+        RuntimeConfig runtimeConfig = new RuntimeConfig(originalConfig);
+
+        MockEntityListener entityListener = runtimeConfig.getEntityListener(
+                MockEntityListener.class, MockEntityListener::new);
+        assertNotNull(entityListener);
+    }
+
+    public void testGetEntityListenerNullCheck() throws Exception {
+        Config originalConfig = new MockConfig() {
+
+            @Override
+            public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
+                    Class<LISTENER> listenerClass,
+                    Supplier<LISTENER> listenerSupplier) {
+                return null;
+            }
+        };
+
+        RuntimeConfig runtimeConfig = new RuntimeConfig(originalConfig);
+
+        try {
+            runtimeConfig.getEntityListener(MockEntityListener.class,
+                    MockEntityListener::new);
+            fail();
+        } catch (ConfigException e) {
+            assertEquals(originalConfig.getClass().getName(), e.getClassName());
+            assertEquals("getEntityListener", e.getMethodName());
+        }
+    }
+
+    private interface MockConfig extends Config {
+
+        @Override
+        default Dialect getDialect() {
+            return new StandardDialect();
+        }
+
+        @Override
+        default DataSource getDataSource() {
+            return new SimpleDataSource();
+        }
+    }
+
+    private static class MockEntityListener implements EntityListener<Object> {
+    }
+}

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Abstract.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Abstract.txt
@@ -13,7 +13,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     /** the id */
     public final org.seasar.doma.jdbc.entity.AssignedIdPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.AbstractEntity, java.lang.Integer, Object> $id = new org.seasar.doma.jdbc.entity.AssignedIdPropertyType<>(org.seasar.doma.internal.apt.entity.AbstractEntity.class, java.lang.Integer.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null, "id", "id", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.AbstractEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.AbstractEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -36,7 +36,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.AbstractEntity, ?>> __entityPropertyTypeMap;
 
     private _AbstractEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.AbstractEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "AbstractEntity";
@@ -90,33 +90,51 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -176,6 +194,10 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
      */
     public static _AbstractEntity newInstance() {
         return new _AbstractEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.AbstractEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_BytesProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_BytesProperty.txt
@@ -13,7 +13,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     /** the bytes */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.BytesPropertyEntity, byte[], Object> $bytes = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.BytesPropertyEntity.class, byte[].class, byte[].class, () -> new org.seasar.doma.wrapper.BytesWrapper(), null, null, "bytes", "bytes", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.BytesPropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -36,7 +36,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.BytesPropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _BytesPropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.BytesPropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "BytesPropertyEntity";
@@ -89,33 +89,51 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -177,6 +195,10 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
      */
     public static _BytesPropertyEntity newInstance() {
         return new _BytesPropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Dept.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Dept.txt
@@ -16,7 +16,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     /** the branch */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.Dept, java.lang.String, org.seasar.doma.internal.apt.entity.Branch> $branch = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.Dept.class, org.seasar.doma.internal.apt.entity.Branch.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, __.org.seasar.doma.internal.apt.entity._Branch.getSingletonInternal(), "branch", "branch", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Dept> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Dept>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -39,7 +39,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.Dept, ?>> __entityPropertyTypeMap;
 
     private _Dept() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Dept>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "Dept";
@@ -95,33 +95,51 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Dept> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -183,6 +201,10 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
      */
     public static _Dept newInstance() {
         return new _Dept();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Dept> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_DomainProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_DomainProperty.txt
@@ -27,7 +27,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     /** the ver */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.DomainPropertyEntity, java.lang.Integer, org.seasar.doma.internal.apt.entity.Ver> $ver = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.DomainPropertyEntity.class,  org.seasar.doma.internal.apt.entity.Ver.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, org.seasar.doma.internal.apt.entity._Ver.getSingletonInternal(), "ver", "ver", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.DomainPropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -50,7 +50,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.DomainPropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _DomainPropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.DomainPropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "DomainPropertyEntity";
@@ -108,33 +108,51 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -196,6 +214,10 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
      */
     public static _DomainPropertyEntity newInstance() {
         return new _DomainPropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Emp.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Emp.txt
@@ -35,7 +35,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     /** the object */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.Emp, java.lang.Object, Object> $object = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.Emp.class, java.lang.Object.class, java.lang.Object.class, () -> new org.seasar.doma.wrapper.ObjectWrapper(), null, null, "object", "object", true, true, false);
 
-    private final org.seasar.doma.internal.apt.entity.EmpListener __listener;
+    private final java.util.function.Supplier<org.seasar.doma.internal.apt.entity.EmpListener> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -58,7 +58,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.Emp, ?>> __entityPropertyTypeMap;
 
     private _Emp() {
-        __listener = new org.seasar.doma.internal.apt.entity.EmpListener();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "Emp";
@@ -120,33 +120,51 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Emp> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -215,6 +233,10 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
      */
     public static _Emp newInstance() {
         return new _Emp();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.internal.apt.entity.EmpListener listener = new org.seasar.doma.internal.apt.entity.EmpListener();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_EnumProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_EnumProperty.txt
@@ -16,7 +16,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     /** the hoge */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.EnumPropertyEntity, org.seasar.doma.internal.apt.entity.EnumPropertyEntity.Hoge, Object> $hoge = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.EnumPropertyEntity.class, org.seasar.doma.internal.apt.entity.EnumPropertyEntity.Hoge.class, org.seasar.doma.internal.apt.entity.EnumPropertyEntity.Hoge.class, () -> new org.seasar.doma.wrapper.EnumWrapper<org.seasar.doma.internal.apt.entity.EnumPropertyEntity.Hoge>(org.seasar.doma.internal.apt.entity.EnumPropertyEntity.Hoge.class), null, null, "hoge", "hoge", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.EnumPropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -39,7 +39,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.EnumPropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _EnumPropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.EnumPropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "EnumPropertyEntity";
@@ -95,33 +95,51 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -183,6 +201,10 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
      */
     public static _EnumPropertyEntity newInstance() {
         return new _EnumPropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Extends.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Extends.txt
@@ -19,7 +19,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     /** the ccc */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.ChildEntity, java.lang.String, Object> $ccc = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.ChildEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "ccc", "ccc", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ChildEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ChildEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.ChildEntity, ?>> __entityPropertyTypeMap;
 
     private _ChildEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ChildEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "ChildEntity";
@@ -99,33 +99,51 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -187,6 +205,10 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
      */
     public static _ChildEntity newInstance() {
         return new _ChildEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ChildEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerInherited.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerInherited.txt
@@ -19,7 +19,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     /** the ccc */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.Child2InheritingEntity, java.lang.String, Object> $ccc = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.Child2InheritingEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "ccc", "ccc", true, true, false);
 
-    private final org.seasar.doma.internal.apt.entity.Parent2EntityListener<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.internal.apt.entity.Parent2EntityListener<org.seasar.doma.internal.apt.entity.Child2InheritingEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.Child2InheritingEntity, ?>> __entityPropertyTypeMap;
 
     private _Child2InheritingEntity() {
-        __listener = new org.seasar.doma.internal.apt.entity.Parent2EntityListener<org.seasar.doma.internal.apt.entity.Child2InheritingEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "Child2InheritingEntity";
@@ -99,33 +99,51 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -187,6 +205,10 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
      */
     public static _Child2InheritingEntity newInstance() {
         return new _Child2InheritingEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.internal.apt.entity.Parent2EntityListener<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> listener = new org.seasar.doma.internal.apt.entity.Parent2EntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerNoInherited.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerNoInherited.txt
@@ -16,7 +16,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     /** the bbb */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<org.seasar.doma.internal.apt.entity.Parent2Entity, org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity, java.lang.Integer, Object> $bbb = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity.class, java.lang.Integer.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), org.seasar.doma.internal.apt.entity._Parent2Entity.getSingletonInternal().$bbb, null, "bbb", "bbb", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -39,7 +39,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity, ?>> __entityPropertyTypeMap;
 
     private _Child2NoInheritingEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "Child2NoInheritingEntity";
@@ -94,33 +94,51 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -182,6 +200,10 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
      */
     public static _Child2NoInheritingEntity newInstance() {
         return new _Child2NoInheritingEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsWithOriginalStates.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsWithOriginalStates.txt
@@ -21,7 +21,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     /** the ccc */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity, java.lang.String, Object> $ccc = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "ccc", "ccc", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -44,7 +44,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity, ?>> __entityPropertyTypeMap;
 
     private _OriginalStatesChildEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "OriginalStatesChildEntity";
@@ -101,33 +101,51 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -194,6 +212,10 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
      */
     public static _OriginalStatesChildEntity newInstance() {
         return new _OriginalStatesChildEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener1.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener1.txt
@@ -10,7 +10,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
 
     private static final _GenericListener1Entity __singleton = new _GenericListener1Entity();
 
-    private final org.seasar.doma.internal.apt.entity.GenericListener1<org.seasar.doma.internal.apt.entity.GenericListener1Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.internal.apt.entity.GenericListener1<org.seasar.doma.internal.apt.entity.GenericListener1Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.GenericListener1Entity, ?>> __entityPropertyTypeMap;
 
     private _GenericListener1Entity() {
-        __listener = new org.seasar.doma.internal.apt.entity.GenericListener1<org.seasar.doma.internal.apt.entity.GenericListener1Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "GenericListener1Entity";
@@ -84,33 +84,51 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
      */
     public static _GenericListener1Entity newInstance() {
         return new _GenericListener1Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.internal.apt.entity.GenericListener1<org.seasar.doma.internal.apt.entity.GenericListener1Entity> listener = new org.seasar.doma.internal.apt.entity.GenericListener1<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener3.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener3.txt
@@ -10,7 +10,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
 
     private static final _GenericListener3Entity __singleton = new _GenericListener3Entity();
 
-    private final org.seasar.doma.internal.apt.entity.GenericListener3<org.seasar.doma.internal.apt.entity.GenericListener3Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.internal.apt.entity.GenericListener3<org.seasar.doma.internal.apt.entity.GenericListener3Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.GenericListener3Entity, ?>> __entityPropertyTypeMap;
 
     private _GenericListener3Entity() {
-        __listener = new org.seasar.doma.internal.apt.entity.GenericListener3<org.seasar.doma.internal.apt.entity.GenericListener3Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "GenericListener3Entity";
@@ -84,33 +84,51 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
      */
     public static _GenericListener3Entity newInstance() {
         return new _GenericListener3Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.internal.apt.entity.GenericListener3<org.seasar.doma.internal.apt.entity.GenericListener3Entity> listener = new org.seasar.doma.internal.apt.entity.GenericListener3<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener6.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener6.txt
@@ -10,7 +10,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
 
     private static final _GenericListener6Entity __singleton = new _GenericListener6Entity();
 
-    private final org.seasar.doma.internal.apt.entity.GenericListener6<org.seasar.doma.internal.apt.entity.GenericListener6Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.internal.apt.entity.GenericListener6<org.seasar.doma.internal.apt.entity.GenericListener6Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.GenericListener6Entity, ?>> __entityPropertyTypeMap;
 
     private _GenericListener6Entity() {
-        __listener = new org.seasar.doma.internal.apt.entity.GenericListener6<org.seasar.doma.internal.apt.entity.GenericListener6Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "GenericListener6Entity";
@@ -84,33 +84,51 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
+        Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
      */
     public static _GenericListener6Entity newInstance() {
         return new _GenericListener6Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.internal.apt.entity.GenericListener6<org.seasar.doma.internal.apt.entity.GenericListener6Entity> listener = new org.seasar.doma.internal.apt.entity.GenericListener6<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
@@ -19,7 +19,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     /** the ccc */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.ImmutableChildEntity, java.lang.String, Object> $ccc = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.ImmutableChildEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "ccc", "ccc", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableChildEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.ImmutableChildEntity, ?>> __entityPropertyTypeMap;
 
     private _ImmutableChildEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableChildEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = true;
         __name = "ImmutableChildEntity";
@@ -99,33 +99,51 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
      */
     public static _ImmutableChildEntity newInstance() {
         return new _ImmutableChildEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
@@ -19,7 +19,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     /** the ccc */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.ImmutableEntity, java.lang.Integer, Object> $ccc = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.ImmutableEntity.class, java.lang.Integer.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null, "ccc", "ccc", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.ImmutableEntity, ?>> __entityPropertyTypeMap;
 
     private _ImmutableEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = true;
         __name = "ImmutableEntity";
@@ -99,33 +99,51 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
      */
     public static _ImmutableEntity newInstance() {
         return new _ImmutableEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ImmutableEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType1.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType1.txt
@@ -10,7 +10,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
 
     private static final _NamingType1Entity __singleton = new _NamingType1Entity();
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType1Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType1Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.NamingType1Entity, ?>> __entityPropertyTypeMap;
 
     private _NamingType1Entity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType1Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.UPPER_CASE;
         __immutable = false;
         __name = "NamingType1Entity";
@@ -84,33 +84,51 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
      */
     public static _NamingType1Entity newInstance() {
         return new _NamingType1Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType1Entity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType2.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType2.txt
@@ -10,7 +10,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
 
     private static final _NamingType2Entity __singleton = new _NamingType2Entity();
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType2Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType2Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.NamingType2Entity, ?>> __entityPropertyTypeMap;
 
     private _NamingType2Entity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType2Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.UPPER_CASE;
         __immutable = false;
         __name = "NamingType2Entity";
@@ -84,33 +84,51 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
      */
     public static _NamingType2Entity newInstance() {
         return new _NamingType2Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType2Entity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType3.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType3.txt
@@ -10,7 +10,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
 
     private static final _NamingType3Entity __singleton = new _NamingType3Entity();
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType3Entity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType3Entity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -33,7 +33,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.NamingType3Entity, ?>> __entityPropertyTypeMap;
 
     private _NamingType3Entity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType3Entity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "NamingType3Entity";
@@ -84,33 +84,51 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -172,6 +190,10 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
      */
     public static _NamingType3Entity newInstance() {
         return new _NamingType3Entity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.NamingType3Entity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Optional.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Optional.txt
@@ -28,7 +28,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     /** the version */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.OptionalEntity, java.lang.Long, Object> $version = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.OptionalEntity.class,  java.util.Optional.class, java.lang.Long.class, () -> new org.seasar.doma.wrapper.LongWrapper(), null, null, "version", "version", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -51,7 +51,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.OptionalEntity, ?>> __entityPropertyTypeMap;
 
     private _OptionalEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "OptionalEntity";
@@ -115,33 +115,51 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -203,6 +221,10 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
      */
     public static _OptionalEntity newInstance() {
         return new _OptionalEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalDouble.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalDouble.txt
@@ -19,7 +19,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     /** the version */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.OptionalDoubleEntity, java.lang.Double, Object> $version = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity.class,  java.util.OptionalDouble.class, java.lang.Double.class, () -> new org.seasar.doma.wrapper.DoubleWrapper(), null, null, "version", "version", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity, ?>> __entityPropertyTypeMap;
 
     private _OptionalDoubleEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "OptionalDoubleEntity";
@@ -100,33 +100,51 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
      */
     public static _OptionalDoubleEntity newInstance() {
         return new _OptionalDoubleEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalInt.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalInt.txt
@@ -19,7 +19,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     /** the version */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.OptionalIntEntity, java.lang.Integer, Object> $version = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.OptionalIntEntity.class,  java.util.OptionalInt.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null, "version", "version", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalIntEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalIntEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.OptionalIntEntity, ?>> __entityPropertyTypeMap;
 
     private _OptionalIntEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalIntEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "OptionalIntEntity";
@@ -100,33 +100,51 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
      */
     public static _OptionalIntEntity newInstance() {
         return new _OptionalIntEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalIntEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalLong.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalLong.txt
@@ -19,7 +19,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     /** the version */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.OptionalLongEntity, java.lang.Long, Object> $version = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.OptionalLongEntity.class,  java.util.OptionalLong.class, java.lang.Long.class, () -> new org.seasar.doma.wrapper.LongWrapper(), null, null, "version", "version", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalLongEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalLongEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.OptionalLongEntity, ?>> __entityPropertyTypeMap;
 
     private _OptionalLongEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalLongEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "OptionalLongEntity";
@@ -100,33 +100,51 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
      */
     public static _OptionalLongEntity newInstance() {
         return new _OptionalLongEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.OptionalLongEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ParameterizedProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ParameterizedProperty.txt
@@ -13,7 +13,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     /** the wight */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity, java.lang.Integer, org.seasar.doma.internal.apt.entity.Weight<java.lang.Integer>> $wight = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity.class, org.seasar.doma.internal.apt.entity.Weight.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, org.seasar.doma.internal.apt.entity._Weight.<java.lang.Integer>getSingletonInternal(), "wight", "wight", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -36,7 +36,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _ParameterizedPropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "ParameterizedPropertyEntity";
@@ -89,33 +89,51 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -177,6 +195,10 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
      */
     public static _ParameterizedPropertyEntity newInstance() {
         return new _ParameterizedPropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrimitiveProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrimitiveProperty.txt
@@ -19,7 +19,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     /** the version */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity, java.lang.Long, Object> $version = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity.class,  java.lang.Long.class, java.lang.Long.class, () -> new org.seasar.doma.wrapper.LongWrapper(), null, null, "version", "version", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _PrimitivePropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "PrimitivePropertyEntity";
@@ -100,33 +100,51 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
      */
     public static _PrimitivePropertyEntity newInstance() {
         return new _PrimitivePropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
@@ -15,7 +15,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     /** the name */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity, java.lang.String, Object> $name = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "name", "name", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -38,7 +38,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity, ?>> __entityPropertyTypeMap;
 
     private _PrivateOriginalStatesEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "PrivateOriginalStatesEntity";
@@ -91,33 +91,51 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -182,6 +200,10 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
      */
     public static _PrivateOriginalStatesEntity newInstance() {
         return new _PrivateOriginalStatesEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivatePropertyEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivatePropertyEntity.txt
@@ -13,7 +13,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     /** the name */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.PrivatePropertyEntity, java.lang.String, Object> $name = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity.class, java.lang.String.class, java.lang.String.class, () -> new org.seasar.doma.wrapper.StringWrapper(), null, null, "name", "name", true, true, false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -36,7 +36,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _PrivatePropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "PrivatePropertyEntity";
@@ -89,33 +89,51 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -177,6 +195,10 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
      */
     public static _PrivatePropertyEntity newInstance() {
         return new _PrivatePropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Quote.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Quote.txt
@@ -19,7 +19,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     /** the version */
     public final org.seasar.doma.jdbc.entity.DefaultPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.QuoteEntity, java.lang.Integer, Object> $version = new org.seasar.doma.jdbc.entity.DefaultPropertyType<>(org.seasar.doma.internal.apt.entity.QuoteEntity.class, java.lang.Integer.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null, "version", "version", true, true, true);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.QuoteEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.QuoteEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -42,7 +42,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.QuoteEntity, ?>> __entityPropertyTypeMap;
 
     private _QuoteEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.QuoteEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "QuoteEntity";
@@ -100,33 +100,51 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -188,6 +206,10 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
      */
     public static _QuoteEntity newInstance() {
         return new _QuoteEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.QuoteEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_TransientProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_TransientProperty.txt
@@ -13,7 +13,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     /** the id */
     public final org.seasar.doma.jdbc.entity.VersionPropertyType<java.lang.Object, org.seasar.doma.internal.apt.entity.TransientPropertyEntity, java.lang.Integer, Object> $id = new org.seasar.doma.jdbc.entity.VersionPropertyType<>(org.seasar.doma.internal.apt.entity.TransientPropertyEntity.class,  java.lang.Integer.class, java.lang.Integer.class, () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null, "id", "id", false);
 
-    private final org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> __listener;
+    private final java.util.function.Supplier<org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.TransientPropertyEntity>> __listenerSupplier;
 
     private final org.seasar.doma.jdbc.entity.NamingType __namingType;
 
@@ -36,7 +36,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     private final java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.entity.TransientPropertyEntity, ?>> __entityPropertyTypeMap;
 
     private _TransientPropertyEntity() {
-        __listener = new org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.TransientPropertyEntity>();
+        __listenerSupplier = () -> ListenerHolder.listener;
         __namingType = org.seasar.doma.jdbc.entity.NamingType.NONE;
         __immutable = false;
         __name = "TransientPropertyEntity";
@@ -89,33 +89,51 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
         return __isQuoteRequired;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
+        Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 
@@ -177,6 +195,10 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
      */
     public static _TransientPropertyEntity newInstance() {
         return new _TransientPropertyEntity();
+    }
+
+    private static class ListenerHolder {
+        private static org.seasar.doma.jdbc.entity.NullEntityListener<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> listener = new org.seasar.doma.jdbc.entity.NullEntityListener<>();
     }
 
 }


### PR DESCRIPTION
これまで`EntityListener`実装クラスは`EntityType`実装クラスのコンストラクタ内でインスタンス化していました。
そのためDIコンテナを使用している場合に`EntityListener`実装クラスへはDIコンテナ管理オブジェクトをインジェクションできませんでした。

この課題に対応するため`Config`に新たに`getEntityListener(Class, Supplier)`を追加し、`EntityListener`実装クラスのインスタンス取得処理をフックできるようにしました。

このプルリクエストを投げるにあたって何点か気になる事があります。

まず今回新たに追加した`CacheSupplier`の例外処理ですが、`DomaException`でラップして再スローしています。
これは`DomaException`のサブクラスを作成した方が良いでしょうか？

また`Message`に新たに`DOMA5003`および`DOMA5004`を追加しましたが、これらのメッセージは適切でしょうか？

最後に、ジェネリックな`EntityListener`実装クラスの`Class`インスタンスを取得する際、次のコードのようにキャストを二回重ねています。

```java
Class<FooListener<Bar>> __listenerClass = (Class<FooListener<Bar>>) (Class<?>) FooListener.class;
```

これは`FooListener.class`をそのままでは`Class<FooListener<Bar>>`にキャストできないため一旦`Class<?>`へキャストしています。
この二回のキャストで目的は達しているのですが、より良い方法はないものでしょうか？

