### PR TITLE
StringUtilのfromCamelCaseToSnakeCaseで、カラム名に数字が含まれている場合意図している結果にならない

### DIFF
--- a/src/main/java/org/seasar/doma/internal/util/StringUtil.java
+++ b/src/main/java/org/seasar/doma/internal/util/StringUtil.java
@@ -19,15 +19,15 @@ import java.nio.CharBuffer;
 
 /**
  * {@link String} のユーティリティクラスです。
- *
+ * 
  * @author taedium
- *
+ * 
  */
 public final class StringUtil {
 
     /**
      * 先頭の文字を大文字に変換します。
-     *
+     * 
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -44,7 +44,7 @@ public final class StringUtil {
 
     /**
      * 先頭の文字を小文字に変換します。
-     *
+     * 
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -61,7 +61,7 @@ public final class StringUtil {
 
     /**
      * アンダースコア区切りの文字列をキャメルケースの文字列に変換します。
-     *
+     * 
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -86,7 +86,7 @@ public final class StringUtil {
 
     /**
      * キャメルケースをアンダースコア区切りの大文字に変換します。
-     *
+     * 
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -115,7 +115,7 @@ public final class StringUtil {
 
     /**
      * 文字列が空白文字だけからなるかどうかを返します。
-     *
+     * 
      * @param text
      *            文字列
      * @return 文字列が空白文字のみを含む場合 {@code true}

--- a/src/main/java/org/seasar/doma/internal/util/StringUtil.java
+++ b/src/main/java/org/seasar/doma/internal/util/StringUtil.java
@@ -19,15 +19,15 @@ import java.nio.CharBuffer;
 
 /**
  * {@link String} のユーティリティクラスです。
- * 
+ *
  * @author taedium
- * 
+ *
  */
 public final class StringUtil {
 
     /**
      * 先頭の文字を大文字に変換します。
-     * 
+     *
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -44,7 +44,7 @@ public final class StringUtil {
 
     /**
      * 先頭の文字を小文字に変換します。
-     * 
+     *
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -61,7 +61,7 @@ public final class StringUtil {
 
     /**
      * アンダースコア区切りの文字列をキャメルケースの文字列に変換します。
-     * 
+     *
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -86,7 +86,7 @@ public final class StringUtil {
 
     /**
      * キャメルケースをアンダースコア区切りの大文字に変換します。
-     * 
+     *
      * @param text
      *            文字列
      * @return 変換された文字列。 ただし、{@code text} が {@code null} の場合は {@code null}、
@@ -104,7 +104,7 @@ public final class StringUtil {
             buf.mark();
             if (buf.hasRemaining()) {
                 char c2 = buf.get();
-                if (Character.isLowerCase(c) && Character.isUpperCase(c2)) {
+                if ((Character.isLowerCase(c) || Character.isDigit(c)) && Character.isUpperCase(c2)) {
                     result.append("_");
                 }
                 buf.reset();
@@ -115,7 +115,7 @@ public final class StringUtil {
 
     /**
      * 文字列が空白文字だけからなるかどうかを返します。
-     * 
+     *
      * @param text
      *            文字列
      * @return 文字列が空白文字のみを含む場合 {@code true}

--- a/src/test/java/org/seasar/doma/internal/util/StringUtilTest.java
+++ b/src/test/java/org/seasar/doma/internal/util/StringUtilTest.java
@@ -19,7 +19,7 @@ import junit.framework.TestCase;
 
 /**
  * @author taedium
- * 
+ *
  */
 public class StringUtilTest extends TestCase {
 
@@ -44,6 +44,7 @@ public class StringUtilTest extends TestCase {
         assertEquals("aaa_bbb_ccc",
                 StringUtil.fromCamelCaseToSnakeCase("aaaBbbCcc"));
         assertEquals("abc", StringUtil.fromCamelCaseToSnakeCase("abc"));
+        assertEquals("aa1_bbb_ccc", StringUtil.fromCamelCaseToSnakeCase("aa1BbbCcc"));
     }
 
     public void testIsWhitespace() throws Exception {


### PR DESCRIPTION
以下のパターンでは、「img1_file」となる事を期待しているが、「img1file」となる。
```
String img1File;
```
下記が 「false」となるため、うまく変換できていないようです。
```
Character.isLowerCase('1')
```

Columnアノテーションのname指定で逃げれるので現状は問題ありません。