### PR TITLE
Windows環境でテストが失敗する問題を修正

### DIFF
--- a/src/test/java/org/seasar/doma/jdbc/CallerCommenterTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/CallerCommenterTest.java
@@ -27,7 +27,7 @@ public class CallerCommenterTest extends TestCase {
         CommentContext context = new CommentContext("class", "method",
                 new MockConfig(), null);
         String actual = commenter.comment("select * from emp", context);
-        assertEquals("/** class.method */\nselect * from emp", actual);
+        assertEquals("/** class.method */" + System.lineSeparator() + "select * from emp", actual);
     }
 
 }


### PR DESCRIPTION
String.format("%n") は、環境によって改行文字が変わります。
Windows 環境の場合、"\n" では無く "\r\n" になりテストが失敗してしまいます。
ですので System#lineSeparator を使うように修正しました。