### PR TITLE
イミュータブルなエンティティの取得でNullPointerException が発生するバグを修正しました fix #63

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/EntityTypeGenerator.java
+++ b/src/main/java/org/seasar/doma/internal/apt/EntityTypeGenerator.java
@@ -610,7 +610,7 @@ public class EntityTypeGenerator extends AbstractGenerator {
                         .getAllPropertyMetasInCtorArgsOrder().iterator(); it
                         .hasNext();) {
                     EntityPropertyMeta propertyMeta = it.next();
-                    iprint("        (%1$s)__args.get(\"%2$s\").get()",
+                    iprint("        (%1$s)(__args.containsKey(\"%2$s\") ? __args.get(\"%2$s\").get() : null)",
                             TypeMirrorUtil.boxIfPrimitive(
                                     propertyMeta.getType(), env),
                             propertyMeta.getName());

--- a/src/test/java/example/entity/ImmutableEmp.java
+++ b/src/test/java/example/entity/ImmutableEmp.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package example.entity;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+import org.seasar.doma.Entity;
+import org.seasar.doma.Id;
+import org.seasar.doma.Version;
+import org.seasar.doma.jdbc.entity.NamingType;
+
+@Entity(naming = NamingType.SNAKE_UPPER_CASE, immutable = true)
+public class ImmutableEmp implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    final Integer id;
+
+    final String name;
+
+    final BigDecimal salary;
+
+    @Version
+    final Integer version;
+
+    public ImmutableEmp(Integer id, String name, BigDecimal salary,
+            Integer version) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.salary = salary;
+        this.version = version;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public BigDecimal getSalary() {
+        return salary;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+}

--- a/src/test/java/example/entity/_ImmutableEmp.java
+++ b/src/test/java/example/entity/_ImmutableEmp.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package example.entity;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import org.seasar.doma.jdbc.entity.AbstractEntityType;
+import org.seasar.doma.jdbc.entity.AssignedIdPropertyType;
+import org.seasar.doma.jdbc.entity.DefaultPropertyType;
+import org.seasar.doma.jdbc.entity.EntityPropertyType;
+import org.seasar.doma.jdbc.entity.GeneratedIdPropertyType;
+import org.seasar.doma.jdbc.entity.NamingType;
+import org.seasar.doma.jdbc.entity.PostDeleteContext;
+import org.seasar.doma.jdbc.entity.PostInsertContext;
+import org.seasar.doma.jdbc.entity.PostUpdateContext;
+import org.seasar.doma.jdbc.entity.PreDeleteContext;
+import org.seasar.doma.jdbc.entity.PreInsertContext;
+import org.seasar.doma.jdbc.entity.PreUpdateContext;
+import org.seasar.doma.jdbc.entity.Property;
+import org.seasar.doma.jdbc.entity.VersionPropertyType;
+
+@Generated("")
+public class _ImmutableEmp extends AbstractEntityType<ImmutableEmp> {
+
+    private static _ImmutableEmp singleton = new _ImmutableEmp();
+
+    public final AssignedIdPropertyType<Object, ImmutableEmp, Integer, Object> id = new AssignedIdPropertyType<>(
+            ImmutableEmp.class, Integer.class, Integer.class,
+            () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null,
+            "id", "ID", false);
+
+    public final DefaultPropertyType<Object, ImmutableEmp, String, Object> name = new DefaultPropertyType<>(
+            ImmutableEmp.class, String.class, String.class,
+            () -> new org.seasar.doma.wrapper.StringWrapper(), null, null,
+            "name", "NAME", true, true, false);
+
+    public final DefaultPropertyType<Object, ImmutableEmp, BigDecimal, BigDecimal> salary = new DefaultPropertyType<>(
+            ImmutableEmp.class, BigDecimal.class, BigDecimal.class,
+            () -> new org.seasar.doma.wrapper.BigDecimalWrapper(), null, null,
+            "salary", "SALARY", true, true, false);
+
+    public final VersionPropertyType<Object, ImmutableEmp, Integer, Integer> version = new VersionPropertyType<>(
+            ImmutableEmp.class, Integer.class, Integer.class,
+            () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null,
+            "version", "VERSION", false);
+
+    private final String __name = "Emp";
+
+    private final String __catalogName = null;
+
+    private final String __schemaName = null;
+
+    private final String __tableName = "EMP";
+
+    private final NamingType __namingType = NamingType.UPPER_CASE;
+
+    private final List<EntityPropertyType<ImmutableEmp, ?>> __idPropertyTypes;
+
+    private final List<EntityPropertyType<ImmutableEmp, ?>> __entityPropertyTypes;
+
+    private final Map<String, EntityPropertyType<ImmutableEmp, ?>> __entityPropertyTypeMap;
+
+    private _ImmutableEmp() {
+        List<EntityPropertyType<ImmutableEmp, ?>> __idList = new ArrayList<>();
+        __idList.add(id);
+        __idPropertyTypes = Collections.unmodifiableList(__idList);
+        List<EntityPropertyType<ImmutableEmp, ?>> __list = new ArrayList<>();
+        __list.add(id);
+        __list.add(name);
+        __list.add(salary);
+        __list.add(version);
+        __entityPropertyTypes = Collections.unmodifiableList(__list);
+        Map<String, EntityPropertyType<ImmutableEmp, ?>> __map = new HashMap<>();
+        __map.put("id", id);
+        __map.put("name", name);
+        __map.put("salary", salary);
+        __map.put("version", version);
+        __entityPropertyTypeMap = Collections.unmodifiableMap(__map);
+    }
+
+    @Override
+    public boolean isImmutable() {
+        return false;
+    }
+
+    @Override
+    public ImmutableEmp newEntity(Map<String, Property<ImmutableEmp, ?>> args) {
+        return new ImmutableEmp((Integer) (args.containsKey("id") ? args.get(
+                "id").get() : null), (String) (args.containsKey("name") ? args
+                .get("name").get() : null),
+                (BigDecimal) (args.containsKey("salary") ? args.get("salary")
+                        .get() : null),
+                (Integer) (args.containsKey("version") ? args.get("version")
+                        .get() : null));
+    }
+
+    @Override
+    public Class<ImmutableEmp> getEntityClass() {
+        return ImmutableEmp.class;
+    }
+
+    @Override
+    public String getName() {
+        return __name;
+    }
+
+    @Override
+    public List<EntityPropertyType<ImmutableEmp, ?>> getEntityPropertyTypes() {
+        return __entityPropertyTypes;
+    }
+
+    @Override
+    public EntityPropertyType<ImmutableEmp, ?> getEntityPropertyType(
+            String propertyName) {
+        return __entityPropertyTypeMap.get(propertyName);
+    }
+
+    @Override
+    public void saveCurrentStates(ImmutableEmp __entity) {
+    }
+
+    @Override
+    public ImmutableEmp getOriginalStates(ImmutableEmp entity) {
+        return null;
+    }
+
+    @Override
+    public GeneratedIdPropertyType<Object, ImmutableEmp, ?, ?> getGeneratedIdPropertyType() {
+        return null;
+    }
+
+    @Override
+    public VersionPropertyType<Object, ImmutableEmp, ?, ?> getVersionPropertyType() {
+        return version;
+    }
+
+    @Override
+    public List<EntityPropertyType<ImmutableEmp, ?>> getIdPropertyTypes() {
+        return __idPropertyTypes;
+    }
+
+    @Override
+    public void preInsert(ImmutableEmp entity,
+            PreInsertContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public void preUpdate(ImmutableEmp entity,
+            PreUpdateContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public void preDelete(ImmutableEmp entity,
+            PreDeleteContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public void postInsert(ImmutableEmp entity,
+            PostInsertContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public void postUpdate(ImmutableEmp entity,
+            PostUpdateContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public void postDelete(ImmutableEmp entity,
+            PostDeleteContext<ImmutableEmp> context) {
+    }
+
+    @Override
+    public String getCatalogName() {
+        return __catalogName;
+    }
+
+    @Override
+    public String getSchemaName() {
+        return __schemaName;
+    }
+
+    @Override
+    public String getTableName() {
+        return __tableName;
+    }
+
+    @Override
+    public NamingType getNamingType() {
+        return __namingType;
+    }
+
+    @Override
+    public boolean isQuoteRequired() {
+        return false;
+    }
+
+    public static _ImmutableEmp getSingletonInternal() {
+        return singleton;
+    }
+}

--- a/src/test/java/org/seasar/doma/jdbc/entity/EntityTypeTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/entity/EntityTypeTest.java
@@ -15,9 +15,15 @@
  */
 package org.seasar.doma.jdbc.entity;
 
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
 import junit.framework.TestCase;
 import example.entity.Emp;
+import example.entity.ImmutableEmp;
 import example.entity._Emp;
+import example.entity._ImmutableEmp;
 
 /**
  * @author nakamura-to
@@ -28,5 +34,31 @@ public class EntityTypeTest extends TestCase {
     public void test() throws Exception {
         EntityType<Emp> entityType = _Emp.getSingletonInternal();
         entityType.getQualifiedTableName();
+    }
+
+    public void testImmutable_newEntity() throws Exception {
+        ImmutableEmp emp = new ImmutableEmp(99, "hoge", BigDecimal.ONE, 1);
+        EntityType<ImmutableEmp> entityType = _ImmutableEmp
+                .getSingletonInternal();
+        Map<String, Property<ImmutableEmp, ?>> args = new HashMap<>();
+
+        EntityPropertyType<ImmutableEmp, ?> idType = entityType
+                .getEntityPropertyType("id");
+        Property<ImmutableEmp, ?> id = idType.createProperty();
+        id.load(emp);
+        args.put(idType.getName(), id);
+
+        EntityPropertyType<ImmutableEmp, ?> salaryType = entityType
+                .getEntityPropertyType("salary");
+        Property<ImmutableEmp, ?> salary = salaryType.createProperty();
+        salary.load(emp);
+        args.put(salaryType.getName(), salary);
+
+        ImmutableEmp newEmp = entityType.newEntity(args);
+
+        assertEquals(Integer.valueOf(99), newEmp.getId());
+        assertNull(newEmp.getName());
+        assertEquals(BigDecimal.ONE, newEmp.getSalary());
+        assertNull(newEmp.getVersion());
     }
 }

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
@@ -175,9 +175,9 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public org.seasar.doma.internal.apt.entity.ImmutableChildEntity newEntity(java.util.Map<String, org.seasar.doma.jdbc.entity.Property<org.seasar.doma.internal.apt.entity.ImmutableChildEntity, ?>> __args) {
         return new org.seasar.doma.internal.apt.entity.ImmutableChildEntity(
-            (java.lang.Integer)__args.get("aaa").get(),
-            (java.lang.Integer)__args.get("bbb").get(),
-            (java.lang.String)__args.get("ccc").get());
+            (java.lang.Integer)(__args.containsKey("aaa") ? __args.get("aaa").get() : null),
+            (java.lang.Integer)(__args.containsKey("bbb") ? __args.get("bbb").get() : null),
+            (java.lang.String)(__args.containsKey("ccc") ? __args.get("ccc").get() : null));
     }
 
     @Override

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
@@ -175,9 +175,9 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public org.seasar.doma.internal.apt.entity.ImmutableEntity newEntity(java.util.Map<String, org.seasar.doma.jdbc.entity.Property<org.seasar.doma.internal.apt.entity.ImmutableEntity, ?>> __args) {
         return new org.seasar.doma.internal.apt.entity.ImmutableEntity(
-            (java.lang.String)__args.get("aaa").get(),
-            (java.lang.Integer)__args.get("bbb").get(),
-            (java.lang.Integer)__args.get("ccc").get());
+            (java.lang.String)(__args.containsKey("aaa") ? __args.get("aaa").get() : null),
+            (java.lang.Integer)(__args.containsKey("bbb") ? __args.get("bbb").get() : null),
+            (java.lang.Integer)(__args.containsKey("ccc") ? __args.get("ccc").get() : null));
     }
 
     @Override


### PR DESCRIPTION
エンティティフィールドに対応するカラムが SELECT 句に存在しない場合に発生していました