### PR TITLE
EntityListenerの取得はEntityListenerProviderを介するようにしました

### DIFF
--- a/docs/sources/config.rst
+++ b/docs/sources/config.rst
@@ -244,12 +244,15 @@ SELECT時のフェッチサイズをあらわす ``int`` を ``getFetchSize`` �
 エンティティリスナーの取得
 --------------------------
 
-``EntityListener`` を ``getEntityListener`` メソッドで返して下さい。
-``getEntityListener`` メソッドは ``EntityListener`` 実装クラスの ``Class`` と ``EntityListener`` 実装クラスのインスタンスを返す ``Supplier``
-を引数に取り、デフォルトの実装では ``Supplier.get`` メソッドを実行して得たインスタンスを返します。
+``EntityListenerProvider`` を ``getEntityListenerProvider`` メソッドで返して下さい。
+
+``EntityListenerProvider`` の ``get`` メソッドは ``EntityListener`` 実装クラスの ``Class`` と ``EntityListener`` 実装クラスのインスタンスを返す ``Supplier``
+を引数に取り ``EntityListener`` のインスタンスを返します。
+デフォルトの実装では ``Supplier.get`` メソッドを実行して得たインスタンスを返します。
 
 ``EntityListener`` 実装クラスのインスタンスをDIコンテナから取得したいなど、
-インスタンス取得方法をカスタマイズする場合は設定してください。
+インスタンス取得方法をカスタマイズする場合は ``EntityListenerProvider`` を実装したクラスを作成し、
+``getEntityListenerProvider`` メソッドでそのインスタンスを返すよう設定してください。
 
 JDBC ドライバのロード
 =====================

--- a/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
+++ b/src/main/java/org/seasar/doma/internal/RuntimeConfig.java
@@ -17,8 +17,6 @@ package org.seasar.doma.internal;
 
 import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
-import java.util.function.Supplier;
-
 import javax.sql.DataSource;
 
 import org.seasar.doma.jdbc.ClassHelper;
@@ -26,6 +24,7 @@ import org.seasar.doma.jdbc.CommandImplementors;
 import org.seasar.doma.jdbc.Commenter;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.ConfigException;
+import org.seasar.doma.jdbc.EntityListenerProvider;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.MapKeyNaming;
 import org.seasar.doma.jdbc.Naming;
@@ -35,7 +34,6 @@ import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.UnknownColumnHandler;
 import org.seasar.doma.jdbc.dialect.Dialect;
-import org.seasar.doma.jdbc.entity.EntityListener;
 import org.seasar.doma.jdbc.tx.TransactionManager;
 
 /**
@@ -155,15 +153,12 @@ public class RuntimeConfig implements Config {
     }
 
     @Override
-    public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
-            Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
-        LISTENER listener = config.getEntityListener(listenerClass,
-                listenerSupplier);
-        if (listener == null) {
+    public EntityListenerProvider getEntityListenerProvider() {
+        EntityListenerProvider provider = config.getEntityListenerProvider();
+        if (provider == null) {
             throw new ConfigException(config.getClass().getName(),
-                    "getEntityListener");
+                    "getEntityListenerProvider");
         }
-        return listener;
+        return provider;
     }
-
 }

--- a/src/main/java/org/seasar/doma/internal/apt/EntityTypeGenerator.java
+++ b/src/main/java/org/seasar/doma/internal/apt/EntityTypeGenerator.java
@@ -746,7 +746,7 @@ public class EntityTypeGenerator extends AbstractGenerator {
     private void printDeclareListener() {
         iprint("    Class __listenerClass = %1$s.class;%n", entityMeta
                 .getEntityListenerElement().getQualifiedName());
-        iprint("    %1$s __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);%n",
+        iprint("    %1$s __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);%n",
                 entityMeta.getEntityListenerElement().getQualifiedName());
     }
 

--- a/src/main/java/org/seasar/doma/jdbc/Config.java
+++ b/src/main/java/org/seasar/doma/jdbc/Config.java
@@ -17,7 +17,6 @@ package org.seasar.doma.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
-import java.util.function.Supplier;
 
 import javax.sql.DataSource;
 
@@ -241,26 +240,13 @@ public interface Config {
     }
 
     /**
-     * {@link EntityListener} のインスタンスを取得します。
-     * <p>
-     * デフォルトの実装では単純に {@link Supplier#get()} を実行して取得したインスタンスを返します。
+     * {@link EntityListener} のプロバイダを返します。
      * 
-     * {@link EntityListener} をDIコンテナで管理したい場合などはこのメソッドをオーバーライドし、
-     * DIコンテナから取得したインスタンスを返すようにしてください。
-     * 
-     * @param listenerClass
-     *            {@link EntityListener} の実装クラス
-     * @param listenerSupplier
-     *            {@link EntityListener} のインスタンスを返す {@link Supplier}
-     * @param <ENTITY>
-     *            エンティティの型
-     * @param <LISTENER>
-     *            リスナーの型
-     * @return {@link EntityListener} のインスタンス
+     * @return {@link EntityListener} のプロバイダ
+     * @since 2.2.0
      */
-    default <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
-            Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
-        return listenerSupplier.get();
+    default EntityListenerProvider getEntityListenerProvider() {
+        return ConfigSupport.defaultEntityListenerProvider;
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/ConfigSupport.java
+++ b/src/main/java/org/seasar/doma/jdbc/ConfigSupport.java
@@ -56,4 +56,9 @@ public final class ConfigSupport {
     public static Commenter defaultCommenter = new Commenter() {
     };
 
+    /**
+     * @since 2.2.0
+     */
+    public static EntityListenerProvider defaultEntityListenerProvider = new EntityListenerProvider() {
+    };
 }

--- a/src/main/java/org/seasar/doma/jdbc/EntityListenerProvider.java
+++ b/src/main/java/org/seasar/doma/jdbc/EntityListenerProvider.java
@@ -1,0 +1,39 @@
+package org.seasar.doma.jdbc;
+
+import java.util.function.Supplier;
+
+import org.seasar.doma.jdbc.entity.EntityListener;
+
+/**
+ * {@link EntityListener} のプロバイダです。
+ *
+ * @author backpaper0
+ * @since 2.2.0
+ */
+public interface EntityListenerProvider {
+
+    /**
+     * {@link EntityListener} のインスタンスを取得します。
+     * <p>
+     * デフォルトの実装では単純に {@link Supplier#get()} を実行して取得したインスタンスを返します。
+     * 
+     * {@link EntityListener} をDIコンテナで管理したい場合などはこのメソッドをオーバーライドし、
+     * DIコンテナから取得したインスタンスを返すようにしてください。
+     * 
+     * このメソッドは{@code null}を返してはいけません。
+     * 
+     * @param listenerClass
+     *            {@link EntityListener} の実装クラス
+     * @param listenerSupplier
+     *            {@link EntityListener} のインスタンスを返す {@link Supplier}
+     * @param <ENTITY>
+     *            エンティティの型
+     * @param <LISTENER>
+     *            リスナーの型
+     * @return {@link EntityListener} のインスタンス
+     */
+    default <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER get(
+            Class<LISTENER> listenerClass, Supplier<LISTENER> listenerSupplier) {
+        return listenerSupplier.get();
+    }
+}

--- a/src/test/java/org/seasar/doma/internal/RuntimeConfigTest.java
+++ b/src/test/java/org/seasar/doma/internal/RuntimeConfigTest.java
@@ -15,14 +15,13 @@
  */
 package org.seasar.doma.internal;
 
-import java.util.function.Supplier;
-
 import javax.sql.DataSource;
 
 import junit.framework.TestCase;
 
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.ConfigException;
+import org.seasar.doma.jdbc.EntityListenerProvider;
 import org.seasar.doma.jdbc.SimpleDataSource;
 import org.seasar.doma.jdbc.dialect.Dialect;
 import org.seasar.doma.jdbc.dialect.StandardDialect;
@@ -38,17 +37,17 @@ public class RuntimeConfigTest extends TestCase {
         Config originalConfig = new MockConfig() {
 
             @Override
-            public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
-                    Class<LISTENER> listenerClass,
-                    Supplier<LISTENER> listenerSupplier) {
-                return listenerSupplier.get();
+            public EntityListenerProvider getEntityListenerProvider() {
+                return new EntityListenerProvider() {
+                };
             }
         };
 
         RuntimeConfig runtimeConfig = new RuntimeConfig(originalConfig);
 
-        MockEntityListener entityListener = runtimeConfig.getEntityListener(
-                MockEntityListener.class, MockEntityListener::new);
+        MockEntityListener entityListener = runtimeConfig
+                .getEntityListenerProvider().get(MockEntityListener.class,
+                        MockEntityListener::new);
         assertNotNull(entityListener);
     }
 
@@ -56,9 +55,7 @@ public class RuntimeConfigTest extends TestCase {
         Config originalConfig = new MockConfig() {
 
             @Override
-            public <ENTITY, LISTENER extends EntityListener<ENTITY>> LISTENER getEntityListener(
-                    Class<LISTENER> listenerClass,
-                    Supplier<LISTENER> listenerSupplier) {
+            public EntityListenerProvider getEntityListenerProvider() {
                 return null;
             }
         };
@@ -66,12 +63,12 @@ public class RuntimeConfigTest extends TestCase {
         RuntimeConfig runtimeConfig = new RuntimeConfig(originalConfig);
 
         try {
-            runtimeConfig.getEntityListener(MockEntityListener.class,
-                    MockEntityListener::new);
+            runtimeConfig.getEntityListenerProvider().get(
+                    MockEntityListener.class, MockEntityListener::new);
             fail();
         } catch (ConfigException e) {
             assertEquals(originalConfig.getClass().getName(), e.getClassName());
-            assertEquals("getEntityListener", e.getMethodName());
+            assertEquals("getEntityListenerProvider", e.getMethodName());
         }
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Abstract.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Abstract.txt
@@ -101,7 +101,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -109,7 +109,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -117,7 +117,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -125,7 +125,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -133,7 +133,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -141,7 +141,7 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.AbstractEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.AbstractEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_BytesProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_BytesProperty.txt
@@ -100,7 +100,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -108,7 +108,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -116,7 +116,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -124,7 +124,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -132,7 +132,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -140,7 +140,7 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.BytesPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.BytesPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Dept.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Dept.txt
@@ -106,7 +106,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -114,7 +114,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -122,7 +122,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -130,7 +130,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -138,7 +138,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -146,7 +146,7 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Dept entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Dept> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_DomainProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_DomainProperty.txt
@@ -119,7 +119,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -159,7 +159,7 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.DomainPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.DomainPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Emp.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Emp.txt
@@ -131,7 +131,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -139,7 +139,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -147,7 +147,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -155,7 +155,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -163,7 +163,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -171,7 +171,7 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Emp entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Emp> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.EmpListener.class;
-        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.EmpListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_EnumProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_EnumProperty.txt
@@ -106,7 +106,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -114,7 +114,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -122,7 +122,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -130,7 +130,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -138,7 +138,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -146,7 +146,7 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.EnumPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.EnumPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Extends.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Extends.txt
@@ -110,7 +110,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -118,7 +118,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -126,7 +126,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -150,7 +150,7 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerInherited.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerInherited.txt
@@ -110,7 +110,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -118,7 +118,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -126,7 +126,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -150,7 +150,7 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Child2InheritingEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Child2InheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.Parent2EntityListener.class;
-        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.Parent2EntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerNoInherited.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsListenerNoInherited.txt
@@ -105,7 +105,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -113,7 +113,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -121,7 +121,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -129,7 +129,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -137,7 +137,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -145,7 +145,7 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.Child2NoInheritingEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsWithOriginalStates.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ExtendsWithOriginalStates.txt
@@ -112,7 +112,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -120,7 +120,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -128,7 +128,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -136,7 +136,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -144,7 +144,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -152,7 +152,7 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OriginalStatesChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener1.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener1.txt
@@ -95,7 +95,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener1Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener1Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener1.class;
-        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener1 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener3.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener3.txt
@@ -95,7 +95,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener3Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener3Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener3.class;
-        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener3 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener6.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_GenericListener6.txt
@@ -95,7 +95,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.GenericListener6Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.GenericListener6Entity> context) {
         Class __listenerClass = org.seasar.doma.internal.apt.entity.GenericListener6.class;
-        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.internal.apt.entity.GenericListener6 __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableChildEntity.txt
@@ -110,7 +110,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -118,7 +118,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -126,7 +126,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -150,7 +150,7 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ImmutableChildEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableChildEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ImmutableEntity.txt
@@ -110,7 +110,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -118,7 +118,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -126,7 +126,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -150,7 +150,7 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ImmutableEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ImmutableEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType1.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType1.txt
@@ -95,7 +95,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType1Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType1Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType2.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType2.txt
@@ -95,7 +95,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType2Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType2Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType3.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_NamingType3.txt
@@ -95,7 +95,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -103,7 +103,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -111,7 +111,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.NamingType3Entity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.NamingType3Entity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Optional.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Optional.txt
@@ -126,7 +126,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -150,7 +150,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -158,7 +158,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -166,7 +166,7 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalDouble.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalDouble.txt
@@ -111,7 +111,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalDoubleEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalDoubleEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalInt.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalInt.txt
@@ -111,7 +111,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalIntEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalIntEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalLong.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_OptionalLong.txt
@@ -111,7 +111,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.OptionalLongEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.OptionalLongEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ParameterizedProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_ParameterizedProperty.txt
@@ -100,7 +100,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -108,7 +108,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -116,7 +116,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -124,7 +124,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -132,7 +132,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -140,7 +140,7 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.ParameterizedPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrimitiveProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrimitiveProperty.txt
@@ -111,7 +111,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrimitivePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
@@ -102,7 +102,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -110,7 +110,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -118,7 +118,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -126,7 +126,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -134,7 +134,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -142,7 +142,7 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrivateOriginalStatesEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivatePropertyEntity.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_PrivatePropertyEntity.txt
@@ -100,7 +100,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -108,7 +108,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -116,7 +116,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -124,7 +124,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -132,7 +132,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -140,7 +140,7 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.PrivatePropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.PrivatePropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Quote.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_Quote.txt
@@ -111,7 +111,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -119,7 +119,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -127,7 +127,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -135,7 +135,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -143,7 +143,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -151,7 +151,7 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.QuoteEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.QuoteEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 

--- a/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_TransientProperty.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/entity/EntityProcessorTest_TransientProperty.txt
@@ -100,7 +100,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preInsert(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreInsertContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preInsert(entity, context);
     }
 
@@ -108,7 +108,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preUpdate(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreUpdateContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preUpdate(entity, context);
     }
 
@@ -116,7 +116,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void preDelete(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PreDeleteContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.preDelete(entity, context);
     }
 
@@ -124,7 +124,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postInsert(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostInsertContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postInsert(entity, context);
     }
 
@@ -132,7 +132,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postUpdate(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostUpdateContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postUpdate(entity, context);
     }
 
@@ -140,7 +140,7 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
     @Override
     public void postDelete(org.seasar.doma.internal.apt.entity.TransientPropertyEntity entity, org.seasar.doma.jdbc.entity.PostDeleteContext<org.seasar.doma.internal.apt.entity.TransientPropertyEntity> context) {
         Class __listenerClass = org.seasar.doma.jdbc.entity.NullEntityListener.class;
-        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListener(__listenerClass, __listenerSupplier);
+        org.seasar.doma.jdbc.entity.NullEntityListener __listener = context.getConfig().getEntityListenerProvider().get(__listenerClass, __listenerSupplier);
         __listener.postDelete(entity, context);
     }
 


### PR DESCRIPTION
前回PRした #55 では ``Config.getEntityListener`` を導入して ``EntityListener`` のインスタンスを取得するようにしましたが、 ``Config`` の他のメソッドと粒度を合わせるため新たに ``EntityListenerProvider`` を導入して ``Config`` からはプロバイダを取得するだけにしました。