### PR TITLE
PostgresDialectでID生成エラーが発生する問題を修正

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/dialect/Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/Dialect.java
@@ -147,15 +147,23 @@ public interface Dialect {
      * <p>
      * {@link #supportsIdentity()} が {@code true} を返す場合にのみ呼び出し可能です。
      * 
-     * @param qualifiedTableName
-     *            テーブルの完全修飾名
+     * @param catalogName
+     *            カタログの名前
+     * @param schemaName
+     *            スキーマの名前
+     * @param tableName
+     *            テーブルの名前
      * @param columnName
      *            IDENTITYカラムの名前
+     * @param isQuoteRequired
+     *            引用符が必要かどうか
      * @return IDENTITYを取得するためのSQL
      * @throws DomaNullPointerException
-     *             引数のいずれかが {@code null} の場合
+     *             {@code tableName} と {@code columnName} のいずれかが {@code null}
+     *             の場合
      */
-    Sql<?> getIdentitySelectSql(String qualifiedTableName, String columnName);
+    Sql<?> getIdentitySelectSql(String catalogName, String schemaName,
+            String tableName, String columnName, boolean isQuoteRequired);
 
     /**
      * シーケンスの次の値を取得するためのSQLを返します。

--- a/src/main/java/org/seasar/doma/jdbc/dialect/H212126Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/H212126Dialect.java
@@ -131,10 +131,11 @@ public class H212126Dialect extends StandardDialect {
     }
 
     @Override
-    public PreparedSql getIdentitySelectSql(String qualifiedTableName,
-            String columnName) {
-        if (qualifiedTableName == null) {
-            throw new DomaNullPointerException("qualifiedTableName");
+    public PreparedSql getIdentitySelectSql(String catalogName,
+            String schemaName, String tableName, String columnName,
+            boolean isQuoteRequired) {
+        if (tableName == null) {
+            throw new DomaNullPointerException("tableName");
         }
         if (columnName == null) {
             throw new DomaNullPointerException("columnName");

--- a/src/main/java/org/seasar/doma/jdbc/dialect/HsqldbDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/HsqldbDialect.java
@@ -130,10 +130,11 @@ public class HsqldbDialect extends StandardDialect {
     }
 
     @Override
-    public PreparedSql getIdentitySelectSql(String qualifiedTableName,
-            String columnName) {
-        if (qualifiedTableName == null) {
-            throw new DomaNullPointerException("qualifiedTableName");
+    public PreparedSql getIdentitySelectSql(String catalogName,
+            String schemaName, String tableName, String columnName,
+            boolean isQuoteRequired) {
+        if (tableName == null) {
+            throw new DomaNullPointerException("tableName");
         }
         if (columnName == null) {
             throw new DomaNullPointerException("columnName");

--- a/src/main/java/org/seasar/doma/jdbc/dialect/SqliteDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/SqliteDialect.java
@@ -127,10 +127,11 @@ public class SqliteDialect extends StandardDialect {
     }
 
     @Override
-    public PreparedSql getIdentitySelectSql(String qualifiedTableName,
-            String columnName) {
-        if (qualifiedTableName == null) {
-            throw new DomaNullPointerException("qualifiedTableName");
+    public PreparedSql getIdentitySelectSql(String catalogName,
+            String schemaName, String tableName, String columnName,
+            boolean isQuoteRequired) {
+        if (tableName == null) {
+            throw new DomaNullPointerException("tableName");
         }
         if (columnName == null) {
             throw new DomaNullPointerException("columnName");

--- a/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
@@ -46,6 +46,7 @@ import org.seasar.doma.jdbc.ScriptBlockContext;
 import org.seasar.doma.jdbc.SelectForUpdateType;
 import org.seasar.doma.jdbc.SelectOptions;
 import org.seasar.doma.jdbc.SelectOptionsAccessor;
+import org.seasar.doma.jdbc.Sql;
 import org.seasar.doma.jdbc.SqlLogFormattingFunction;
 import org.seasar.doma.jdbc.SqlLogFormattingVisitor;
 import org.seasar.doma.jdbc.SqlNode;
@@ -432,8 +433,8 @@ public class StandardDialect implements Dialect {
     }
 
     @Override
-    public PreparedSql getIdentitySelectSql(String qualifiedTableName,
-            String columnName) {
+    public Sql<?> getIdentitySelectSql(String catalogName, String schemaName,
+            String tableName, String columnName, boolean isQuoteRequired) {
         throw new JdbcUnsupportedOperationException(getClass().getName(),
                 "getIdentitySelectSql");
     }

--- a/src/main/java/org/seasar/doma/jdbc/id/BuiltinIdentityIdGenerator.java
+++ b/src/main/java/org/seasar/doma/jdbc/id/BuiltinIdentityIdGenerator.java
@@ -21,7 +21,9 @@ import java.sql.Statement;
 
 import org.seasar.doma.GenerationType;
 import org.seasar.doma.jdbc.JdbcException;
+import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.Sql;
+import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.message.Message;
 
 /**
@@ -94,10 +96,16 @@ public class BuiltinIdentityIdGenerator extends AbstractIdGenerator implements
      *             識別子の取得に失敗した場合
      */
     protected long getGeneratedValue(IdGenerationConfig config) {
-        String qualifiedTableName = config.getQualifiedTableName();
-        String idColumnName = config.getIdColumnName();
-        Sql<?> sql = config.getDialect().getIdentitySelectSql(
-                qualifiedTableName, idColumnName);
+        Naming naming = config.getNaming();
+        EntityType<?> entityType = config.getEntityType();
+        String catalogName = entityType.getCatalogName();
+        String schemaName = entityType.getSchemaName();
+        String tableName = entityType.getTableName(naming::apply);
+        String idColumnName = entityType.getGeneratedIdPropertyType()
+                .getColumnName(naming::apply);
+        Sql<?> sql = config.getDialect().getIdentitySelectSql(catalogName,
+                schemaName, tableName, idColumnName,
+                entityType.isQuoteRequired());
         return getGeneratedValue(config, sql);
     }
 

--- a/src/main/java/org/seasar/doma/jdbc/id/IdGenerationConfig.java
+++ b/src/main/java/org/seasar/doma/jdbc/id/IdGenerationConfig.java
@@ -21,6 +21,7 @@ import javax.sql.DataSource;
 
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.JdbcLogger;
+import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.RequiresNewController;
 import org.seasar.doma.jdbc.dialect.Dialect;
 import org.seasar.doma.jdbc.entity.EntityType;
@@ -39,12 +40,6 @@ public class IdGenerationConfig {
     /** 識別子が属するエンティティ */
     protected final EntityType<?> entityType;
 
-    /** 識別子が属するエンティティに対応するテーブルの完全修飾名 */
-    protected final String qualifiedTableName;
-
-    /** 識別子にマッピングされたカラムの名前 */
-    protected final String idColumnName;
-
     /**
      * インスタンスを構築します。
      * 
@@ -54,32 +49,9 @@ public class IdGenerationConfig {
      *            識別子が属するエンティティ
      */
     public IdGenerationConfig(Config config, EntityType<?> entityType) {
-        this(config, entityType, entityType.getQualifiedTableName(
-                config.getNaming()::apply, config.getDialect()::applyQuote),
-                entityType.getGeneratedIdPropertyType().getColumnName(
-                        config.getNaming()::apply,
-                        config.getDialect()::applyQuote));
-    }
-
-    /**
-     * インスタンスを構築します。
-     * 
-     * @param config
-     *            JDBCの設定
-     * @param entityType
-     *            識別子が属するエンティティ
-     * @param qualifiedTableName
-     *            識別子が属するエンティティに対応するテーブルの完全修飾名
-     * @param idColumnName
-     *            識別子にマッピングされたカラムの名前
-     */
-    protected IdGenerationConfig(Config config, EntityType<?> entityType,
-            String qualifiedTableName, String idColumnName) {
-        assertNotNull(config, entityType, qualifiedTableName, idColumnName);
+        assertNotNull(config, entityType);
         this.config = config;
         this.entityType = entityType;
-        this.qualifiedTableName = qualifiedTableName;
-        this.idColumnName = idColumnName;
     }
 
     public DataSource getDataSource() {
@@ -102,6 +74,10 @@ public class IdGenerationConfig {
         return config.getRequiresNewController();
     }
 
+    public Naming getNaming() {
+        return config.getNaming();
+    }
+
     public int getFetchSize() {
         return config.getFetchSize();
     }
@@ -116,14 +92,6 @@ public class IdGenerationConfig {
 
     public EntityType<?> getEntityType() {
         return entityType;
-    }
-
-    public String getQualifiedTableName() {
-        return qualifiedTableName;
-    }
-
-    public String getIdColumnName() {
-        return idColumnName;
     }
 
 }

--- a/src/test/java/example/entity/IdGeneratedEmp.java
+++ b/src/test/java/example/entity/IdGeneratedEmp.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package example.entity;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+import org.seasar.doma.Entity;
+import org.seasar.doma.GeneratedValue;
+import org.seasar.doma.GenerationType;
+import org.seasar.doma.Id;
+import org.seasar.doma.OriginalStates;
+import org.seasar.doma.Table;
+import org.seasar.doma.Version;
+import org.seasar.doma.jdbc.entity.NamingType;
+
+@Entity(naming = NamingType.SNAKE_UPPER_CASE)
+@Table(catalog = "CATA", quote = true)
+public class IdGeneratedEmp implements Serializable {
+
+    private static final long serialVersionUID = -6511179565163144602L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer id;
+
+    String name;
+
+    BigDecimal salary;
+
+    @Version
+    Integer version;
+
+    @OriginalStates
+    public IdGeneratedEmp originalStates;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BigDecimal getSalary() {
+        return salary;
+    }
+
+    public void setSalary(BigDecimal salary) {
+        this.salary = salary;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+}

--- a/src/test/java/example/entity/_IdGeneratedEmp.java
+++ b/src/test/java/example/entity/_IdGeneratedEmp.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package example.entity;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.annotation.Generated;
+
+import org.seasar.doma.jdbc.entity.AbstractEntityType;
+import org.seasar.doma.jdbc.entity.DefaultPropertyType;
+import org.seasar.doma.jdbc.entity.EntityPropertyType;
+import org.seasar.doma.jdbc.entity.GeneratedIdPropertyType;
+import org.seasar.doma.jdbc.entity.NamingType;
+import org.seasar.doma.jdbc.entity.PostDeleteContext;
+import org.seasar.doma.jdbc.entity.PostInsertContext;
+import org.seasar.doma.jdbc.entity.PostUpdateContext;
+import org.seasar.doma.jdbc.entity.PreDeleteContext;
+import org.seasar.doma.jdbc.entity.PreInsertContext;
+import org.seasar.doma.jdbc.entity.PreUpdateContext;
+import org.seasar.doma.jdbc.entity.Property;
+import org.seasar.doma.jdbc.entity.VersionPropertyType;
+import org.seasar.doma.jdbc.id.BuiltinIdentityIdGenerator;
+
+@Generated("")
+public class _IdGeneratedEmp extends AbstractEntityType<IdGeneratedEmp> {
+
+    private static _IdGeneratedEmp singleton = new _IdGeneratedEmp();
+
+    private static final org.seasar.doma.jdbc.entity.OriginalStatesAccessor<IdGeneratedEmp> __originalStatesAccessor = new org.seasar.doma.jdbc.entity.OriginalStatesAccessor<>(
+            IdGeneratedEmp.class, "originalStates");
+
+    private final NamingType __namingType = NamingType.UPPER_CASE;
+
+    public final GeneratedIdPropertyType<Object, IdGeneratedEmp, Integer, Object> id = new GeneratedIdPropertyType<>(
+            IdGeneratedEmp.class, Integer.class, Integer.class,
+            () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null,
+            "id", "ID", __namingType, false, new BuiltinIdentityIdGenerator());
+
+    public final DefaultPropertyType<Object, IdGeneratedEmp, String, Object> name = new DefaultPropertyType<>(
+            IdGeneratedEmp.class, String.class, String.class,
+            () -> new org.seasar.doma.wrapper.StringWrapper(), null, null,
+            "name", "NAME", __namingType, true, true, false);
+
+    public final DefaultPropertyType<Object, IdGeneratedEmp, BigDecimal, BigDecimal> salary = new DefaultPropertyType<>(
+            IdGeneratedEmp.class, BigDecimal.class, BigDecimal.class,
+            () -> new org.seasar.doma.wrapper.BigDecimalWrapper(), null, null,
+            "salary", "SALARY", __namingType, true, true, false);
+
+    public final VersionPropertyType<Object, IdGeneratedEmp, Integer, Integer> version = new VersionPropertyType<>(
+            IdGeneratedEmp.class, Integer.class, Integer.class,
+            () -> new org.seasar.doma.wrapper.IntegerWrapper(), null, null,
+            "version", "VERSION", __namingType, false);
+
+    private final String __name = "Emp";
+
+    private final String __catalogName = "CATA";
+
+    private final String __schemaName = null;
+
+    private final String __tableName = "";
+
+    private final List<EntityPropertyType<IdGeneratedEmp, ?>> __idPropertyTypes;
+
+    private final List<EntityPropertyType<IdGeneratedEmp, ?>> __entityPropertyTypes;
+
+    private final Map<String, EntityPropertyType<IdGeneratedEmp, ?>> __entityPropertyTypeMap;
+
+    private _IdGeneratedEmp() {
+        List<EntityPropertyType<IdGeneratedEmp, ?>> __idList = new ArrayList<>();
+        __idList.add(id);
+        __idPropertyTypes = Collections.unmodifiableList(__idList);
+        List<EntityPropertyType<IdGeneratedEmp, ?>> __list = new ArrayList<>();
+        __list.add(id);
+        __list.add(name);
+        __list.add(salary);
+        __list.add(version);
+        __entityPropertyTypes = Collections.unmodifiableList(__list);
+        Map<String, EntityPropertyType<IdGeneratedEmp, ?>> __map = new HashMap<>();
+        __map.put("id", id);
+        __map.put("name", name);
+        __map.put("salary", salary);
+        __map.put("version", version);
+        __entityPropertyTypeMap = Collections.unmodifiableMap(__map);
+    }
+
+    @Override
+    public boolean isImmutable() {
+        return false;
+    }
+
+    @Override
+    public IdGeneratedEmp newEntity(
+            Map<String, Property<IdGeneratedEmp, ?>> args) {
+        IdGeneratedEmp entity = new IdGeneratedEmp();
+        args.values().forEach(v -> v.save(entity));
+        return entity;
+    }
+
+    @Override
+    public Class<IdGeneratedEmp> getEntityClass() {
+        return IdGeneratedEmp.class;
+    }
+
+    @Override
+    public String getName() {
+        return __name;
+    }
+
+    @Override
+    public List<EntityPropertyType<IdGeneratedEmp, ?>> getEntityPropertyTypes() {
+        return __entityPropertyTypes;
+    }
+
+    @Override
+    public EntityPropertyType<IdGeneratedEmp, ?> getEntityPropertyType(
+            String propertyName) {
+        return __entityPropertyTypeMap.get(propertyName);
+    }
+
+    @Override
+    public void saveCurrentStates(IdGeneratedEmp __entity) {
+        IdGeneratedEmp __currentStates = new IdGeneratedEmp();
+        id.copy(__currentStates, __entity);
+        name.copy(__currentStates, __entity);
+        salary.copy(__currentStates, __entity);
+        version.copy(__currentStates, __entity);
+        __originalStatesAccessor.set(__entity, __currentStates);
+    }
+
+    @Override
+    public IdGeneratedEmp getOriginalStates(IdGeneratedEmp entity) {
+        if (entity.originalStates instanceof IdGeneratedEmp) {
+            IdGeneratedEmp originalStates = (IdGeneratedEmp) entity.originalStates;
+            return originalStates;
+        }
+        return null;
+    }
+
+    @Override
+    public GeneratedIdPropertyType<Object, IdGeneratedEmp, ?, ?> getGeneratedIdPropertyType() {
+        return id;
+    }
+
+    @Override
+    public VersionPropertyType<Object, IdGeneratedEmp, ?, ?> getVersionPropertyType() {
+        return version;
+    }
+
+    @Override
+    public List<EntityPropertyType<IdGeneratedEmp, ?>> getIdPropertyTypes() {
+        return __idPropertyTypes;
+    }
+
+    @Override
+    public void preInsert(IdGeneratedEmp entity,
+            PreInsertContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public void preUpdate(IdGeneratedEmp entity,
+            PreUpdateContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public void preDelete(IdGeneratedEmp entity,
+            PreDeleteContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public void postInsert(IdGeneratedEmp entity,
+            PostInsertContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public void postUpdate(IdGeneratedEmp entity,
+            PostUpdateContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public void postDelete(IdGeneratedEmp entity,
+            PostDeleteContext<IdGeneratedEmp> context) {
+    }
+
+    @Override
+    public String getCatalogName() {
+        return __catalogName;
+    }
+
+    @Override
+    public String getSchemaName() {
+        return __schemaName;
+    }
+
+    @Override
+    public String getTableName() {
+        return getTableName((namingType, text) -> namingType.apply(text));
+    }
+
+    @Override
+    public String getTableName(
+            BiFunction<NamingType, String, String> namingFunction) {
+        if (__tableName.isEmpty()) {
+            return namingFunction.apply(getNamingType(), getName());
+        }
+        return __tableName;
+    }
+
+    @Override
+    public NamingType getNamingType() {
+        return __namingType;
+    }
+
+    @Override
+    public boolean isQuoteRequired() {
+        return true;
+    }
+
+    public static _IdGeneratedEmp getSingletonInternal() {
+        return singleton;
+    }
+}

--- a/src/test/java/org/seasar/doma/jdbc/dialect/PostgresDialectTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/dialect/PostgresDialectTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.jdbc.dialect;
+
+import junit.framework.TestCase;
+
+import org.seasar.doma.internal.jdbc.sql.PreparedSql;
+
+/**
+ * 
+ * @author nakamura-to
+ *
+ */
+public class PostgresDialectTest extends TestCase {
+
+    public void testGetIdentitySelectSql_quoteNotRequired() throws Exception {
+        PostgresDialect dialect = new PostgresDialect();
+        PreparedSql sql = dialect.getIdentitySelectSql("aaa", "bbb", "ccc",
+                "ddd", false);
+        assertEquals("select currval('aaa.bbb.ccc_ddd_seq')", sql.getRawSql());
+    }
+
+    public void testGetIdentitySelectSql_quoteRequired() throws Exception {
+        PostgresDialect dialect = new PostgresDialect();
+        PreparedSql sql = dialect.getIdentitySelectSql("aaa", "bbb", "ccc",
+                "ddd", true);
+        assertEquals("select currval('\"aaa\".\"bbb\".\"ccc_ddd_seq\"')",
+                sql.getRawSql());
+    }
+
+}

--- a/src/test/java/org/seasar/doma/jdbc/id/BuiltinIdentityIdGeneratorTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/id/BuiltinIdentityIdGeneratorTest.java
@@ -22,7 +22,7 @@ import org.seasar.doma.internal.jdbc.mock.MockResultSet;
 import org.seasar.doma.internal.jdbc.mock.RowData;
 import org.seasar.doma.jdbc.dialect.PostgresDialect;
 
-import example.entity._Emp;
+import example.entity._IdGeneratedEmp;
 
 /**
  * @author taedium
@@ -38,11 +38,11 @@ public class BuiltinIdentityIdGeneratorTest extends TestCase {
 
         BuiltinIdentityIdGenerator identityIdGenerator = new BuiltinIdentityIdGenerator();
         IdGenerationConfig idGenerationConfig = new IdGenerationConfig(config,
-                _Emp.getSingletonInternal(), "EMP", "ID");
+                _IdGeneratedEmp.getSingletonInternal());
         Long value = identityIdGenerator.generatePostInsert(idGenerationConfig,
                 config.dataSource.connection.preparedStatement);
         assertEquals(new Long(11), value);
-        assertEquals("select currval('EMP_ID_seq')",
+        assertEquals("select currval('\"CATA\".\"EMP_ID_seq\"')",
                 config.dataSource.connection.preparedStatement.sql);
     }
 

--- a/src/test/java/org/seasar/doma/jdbc/id/BuiltinSequenceIdGeneratorTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/id/BuiltinSequenceIdGeneratorTest.java
@@ -22,7 +22,7 @@ import org.seasar.doma.internal.jdbc.mock.MockResultSet;
 import org.seasar.doma.internal.jdbc.mock.RowData;
 import org.seasar.doma.jdbc.dialect.PostgresDialect;
 
-import example.entity._Emp;
+import example.entity._IdGeneratedEmp;
 
 /**
  * @author taedium
@@ -41,7 +41,7 @@ public class BuiltinSequenceIdGeneratorTest extends TestCase {
         idGenerator.setInitialValue(1);
         idGenerator.setAllocationSize(1);
         IdGenerationConfig idGenerationConfig = new IdGenerationConfig(config,
-                _Emp.getSingletonInternal(), "EMP", "ID");
+                _IdGeneratedEmp.getSingletonInternal());
         Long value = idGenerator.generatePreInsert(idGenerationConfig);
         assertEquals(new Long(11), value);
         assertEquals("select nextval('aaa')",

--- a/src/test/java/org/seasar/doma/jdbc/id/BuiltinTableIdGeneratorTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/id/BuiltinTableIdGeneratorTest.java
@@ -28,7 +28,7 @@ import org.seasar.doma.internal.jdbc.mock.MockResultSet;
 import org.seasar.doma.internal.jdbc.mock.RowData;
 import org.seasar.doma.jdbc.dialect.PostgresDialect;
 
-import example.entity._Emp;
+import example.entity._IdGeneratedEmp;
 
 /**
  * @author taedium
@@ -63,7 +63,7 @@ public class BuiltinTableIdGeneratorTest extends TestCase {
         idGenerator.setAllocationSize(1);
         idGenerator.initialize();
         IdGenerationConfig idGenerationConfig = new IdGenerationConfig(config,
-                _Emp.getSingletonInternal(), "EMP", "ID");
+                _IdGeneratedEmp.getSingletonInternal());
         Long value = idGenerator.generatePreInsert(idGenerationConfig);
         assertEquals(new Long(10), value);
         assertEquals("update aaa set VALUE = VALUE + ? where PK = ?",


### PR DESCRIPTION
`Dialect#getIdentitySelectSql` のシグニチャを変更し、引用符で囲む前の名前を受け取るようにしました。
`PostgresDialect` の実装では、 `@Table(quote = true)` の場合、シーケンス名を作成した後で、カタログ名、スキーマ名、シーケンス名をそれぞれ引用符で囲み連結します。

```java
@Table(catalog = "catalog_name", schema = "schema_name",  name = "table_name", quote = true)
public class TableName {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id")
    Long id;
}
```

上記のエンティティクラスに対応するID取得のSQLは次のようになります。

```sql
select currval('"catalog_name"."schema_name"."table_name_id_seq"');
```

fixed #73