### PR TITLE
SQLファイルを使った更新がスキップされる問題を修正 fix #78

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/query/SqlFileDeleteQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/SqlFileDeleteQuery.java
@@ -47,10 +47,10 @@ public class SqlFileDeleteQuery extends SqlFileModifyQuery implements
     public void prepare() {
         super.prepare();
         assertNotNull(method, sqlFilePath);
-        executable = true;
         preDelete();
         prepareOptions();
         prepareOptimisticLock();
+        prepareExecutable();
         prepareSql();
         assertNotNull(sql);
     }
@@ -65,6 +65,11 @@ public class SqlFileDeleteQuery extends SqlFileModifyQuery implements
         if (entityHandler != null) {
             entityHandler.prepareOptimisticLock();
         }
+    }
+
+    protected void prepareExecutable() {
+        executable = true;
+        sqlExecutionSkipCause = null;
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/jdbc/query/SqlFileInsertQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/SqlFileInsertQuery.java
@@ -45,9 +45,9 @@ public class SqlFileInsertQuery extends SqlFileModifyQuery implements
     public void prepare() {
         super.prepare();
         assertNotNull(method, sqlFilePath);
-        executable = true;
         preInsert();
         prepareOptions();
+        prepareExecutable();
         prepareSql();
         assertNotNull(sql);
     }
@@ -56,6 +56,11 @@ public class SqlFileInsertQuery extends SqlFileModifyQuery implements
         if (entityHandler != null) {
             entityHandler.preInsert();
         }
+    }
+
+    protected void prepareExecutable() {
+        executable = true;
+        sqlExecutionSkipCause = null;
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/jdbc/query/SqlFileUpdateQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/SqlFileUpdateQuery.java
@@ -60,6 +60,7 @@ public class SqlFileUpdateQuery extends SqlFileModifyQuery implements
         prepareOptimisticLock();
         prepareOptions();
         prepareTargetPropertyTypes();
+        prepareExecutable();
         prepareSql();
         assertNotNull(sql);
     }
@@ -79,6 +80,13 @@ public class SqlFileUpdateQuery extends SqlFileModifyQuery implements
     protected void prepareTargetPropertyTypes() {
         if (entityHandler != null) {
             entityHandler.prepareTargetPropertyTypes();
+        }
+    }
+
+    protected void prepareExecutable() {
+        if (entityHandler == null || entityHandler.hasTargetPropertyTypes()) {
+            executable = true;
+            sqlExecutionSkipCause = null;
         }
     }
 
@@ -183,10 +191,11 @@ public class SqlFileUpdateQuery extends SqlFileModifyQuery implements
 
         protected void prepareTargetPropertyTypes() {
             targetPropertyTypes = helper.getTargetPropertyTypes(entity);
-            if (!targetPropertyTypes.isEmpty()) {
-                executable = true;
-                sqlExecutionSkipCause = null;
-            }
+        }
+
+        protected boolean hasTargetPropertyTypes() {
+            return targetPropertyTypes != null
+                    && !targetPropertyTypes.isEmpty();
         }
 
         protected void postUpdate() {

--- a/src/test/java/org/seasar/doma/jdbc/query/SqlFileUpdateQueryTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/query/SqlFileUpdateQueryTest.java
@@ -82,6 +82,7 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals(null, parameters.get(1).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(2).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(3).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_states() throws Exception {
@@ -111,11 +112,13 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals("aaa", parameters.get(0).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_excludeNull() throws Exception {
         Emp emp = new Emp();
         emp.setId(10);
+        emp.setName("hoge");
         emp.setVersion(100);
 
         SqlFileUpdateQuery query = new SqlFileUpdateQuery();
@@ -131,12 +134,14 @@ public class SqlFileUpdateQueryTest extends TestCase {
         query.prepare();
 
         PreparedSql sql = query.getSql();
-        assertEquals("update aaa set VERSION = ? + 1 where id = ?",
+        assertEquals("update aaa set NAME = ?, VERSION = ? + 1 where id = ?",
                 sql.getRawSql());
         List<InParameter<?>> parameters = sql.getParameters();
-        assertEquals(2, parameters.size());
-        assertEquals(new Integer(100), parameters.get(0).getWrapper().get());
-        assertEquals(new Integer(10), parameters.get(1).getWrapper().get());
+        assertEquals(3, parameters.size());
+        assertEquals("hoge", parameters.get(0).getWrapper().get());
+        assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
+        assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_excludeNull_updateNullableInPreUpdate()
@@ -166,6 +171,7 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals("hoge", parameters.get(0).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_ignoreVersion() throws Exception {
@@ -195,6 +201,7 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals("aaa", parameters.get(0).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_include() throws Exception {
@@ -224,6 +231,7 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals("aaa", parameters.get(0).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_exclude() throws Exception {
@@ -254,6 +262,7 @@ public class SqlFileUpdateQueryTest extends TestCase {
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
         assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
         assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public void testPopulate_IsExecutable() throws Exception {
@@ -272,6 +281,34 @@ public class SqlFileUpdateQueryTest extends TestCase {
         query.prepare();
 
         assertFalse(query.isExecutable());
+    }
+
+    public void testNonEntity() throws Exception {
+        SqlFileUpdateQuery query = new SqlFileUpdateQuery();
+        query.setMethod(getClass().getDeclaredMethod(getName()));
+        query.setSqlFilePath("META-INF/org/seasar/doma/jdbc/query/SqlFileUpdateQueryTest/testNonEntity.sql");
+        query.setConfig(runtimeConfig);
+        query.setCallerClassName("aaa");
+        query.setCallerMethodName("bbb");
+        query.setSqlLogType(SqlLogType.FORMATTED);
+        query.addParameter("id", Integer.class, Integer.valueOf(10));
+        query.addParameter("name", String.class, "aaa");
+        query.addParameter("version", Integer.class, Integer.valueOf(100));
+        query.prepare();
+
+        UpdateQuery updateQuery = query;
+        PreparedSql sql = updateQuery.getSql();
+        assertEquals("update aaa set NAME = ?, VERSION = ? + 1 where id = ?",
+                sql.getRawSql());
+        assertEquals(
+                "update aaa set NAME = 'aaa', VERSION = 100 + 1 where id = 10",
+                sql.getFormattedSql());
+        List<? extends InParameter<?>> parameters = sql.getParameters();
+        assertEquals(3, parameters.size());
+        assertEquals("aaa", parameters.get(0).getWrapper().get());
+        assertEquals(new Integer(100), parameters.get(1).getWrapper().get());
+        assertEquals(new Integer(10), parameters.get(2).getWrapper().get());
+        assertTrue(query.isExecutable());
     }
 
     public static class PreUpdate implements EntityType<Emp> {

--- a/src/test/resources/META-INF/org/seasar/doma/jdbc/query/SqlFileUpdateQueryTest/testNonEntity.sql
+++ b/src/test/resources/META-INF/org/seasar/doma/jdbc/query/SqlFileUpdateQueryTest/testNonEntity.sql
@@ -1,0 +1,1 @@
+update aaa set NAME = /* name */'hoge', VERSION = /* version */0 + 1 where id = /* id */0


### PR DESCRIPTION
以下のような、Daoメソッドの一番目のパラメータが非エンティティクラスの場合にのみ発生する不具合でした。

```java
@Update(sqlFile = true)
int update(String name);
```