### PR TITLE
ポータビリティの高い `PreparedStatement#setObject` を選択可能にする

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/type/JdbcTypes.java
+++ b/src/main/java/org/seasar/doma/jdbc/type/JdbcTypes.java
@@ -63,6 +63,8 @@ public final class JdbcTypes {
 
     public static final ObjectType OBJECT = new ObjectType();
 
+    public static final PortableObjectType PORTABLE_OBJECT = new PortableObjectType();
+
     public static final ShortType SHORT = new ShortType();
 
     public static final StringType STRING = new StringType();

--- a/src/main/java/org/seasar/doma/jdbc/type/PortableObjectType.java
+++ b/src/main/java/org/seasar/doma/jdbc/type/PortableObjectType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.jdbc.type;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * {@link Object} 用の {@link JdbcType} の実装です。
+ * {@link PreparedStatement#setObject(int, Object, int)} を使って値を設定します。
+ * 
+ * @author nakamura-to
+ * @since 2.4.0
+ */
+public class PortableObjectType extends ObjectType {
+
+    @Override
+    protected void doSetValue(PreparedStatement preparedStatement, int index,
+            Object value) throws SQLException {
+        preparedStatement.setObject(index, value, this.type);
+    }
+}


### PR DESCRIPTION
最大限のポータビリティを得るには `setObject(int parameterIndex, Object x)` よりも `setObject(int parameterIndex, Object x, int sqlType)` を使うべきという記述が `java.sql. PreparedStatement ` のJavaDocコメントにあります。実際に、PostgreSQLにおいては、 `setObject(int parameterIndex, Object x, int sqlType)` を使うことでPostgreSQL独自のjson型やdaterange型を標準JDBC APIで扱えます。

この修正では、Dialectの生成時に定型的なコードを記述することで、ポータビリティの高い `PreparedStatement#setObject` を利用可能にします。

利用例は以下の通りです。

```java
PostgresDialect dialect = new PostgresDialect(new PostgresJdbcMappingVisitor() {

    @Override
    public Void visitObjectWrapper(ObjectWrapper wrapper,
            JdbcMappingFunction p, JdbcMappingHint q)
            throws SQLException {
        return p.apply(wrapper, JdbcTypes.PORTABLE_OBJECT);
    }
});
```

`visitObjectWrapper` メソッドの第3パラメータ `JdbcMappingHint ` が提供するメソッドを使うことで、ドメインクラスへの対応付けの有無やドメインクラスの型で条件分岐して適用することも可能です。