### PR TITLE
StandardExpressionFunctionsの実装クラスにpublicなコンストラクタを追加

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/dialect/Db2Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/Db2Dialect.java
@@ -228,6 +228,14 @@ public class Db2Dialect extends StandardDialect {
             super(DEFAULT_WILDCARDS);
         }
 
+        public Db2ExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected Db2ExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/H212126Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/H212126Dialect.java
@@ -230,6 +230,19 @@ public class H212126Dialect extends StandardDialect {
      */
     public static class H212126ExpressionFunctions extends
             StandardExpressionFunctions {
+
+        public H212126ExpressionFunctions() {
+            super();
+        }
+
+        public H212126ExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected H212126ExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/dialect/H2Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/H2Dialect.java
@@ -165,6 +165,19 @@ public class H2Dialect extends H212126Dialect {
      */
     public static class H2ExpressionFunctions extends
             H212126ExpressionFunctions {
+
+        public H2ExpressionFunctions() {
+            super();
+        }
+
+        public H2ExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected H2ExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/dialect/HsqldbDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/HsqldbDialect.java
@@ -218,6 +218,19 @@ public class HsqldbDialect extends StandardDialect {
      */
     public static class HsqldbExpressionFunctions extends
             StandardExpressionFunctions {
+
+        public HsqldbExpressionFunctions() {
+            super();
+        }
+
+        public HsqldbExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected HsqldbExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/dialect/Mssql2008Dialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/Mssql2008Dialect.java
@@ -219,6 +219,15 @@ public class Mssql2008Dialect extends StandardDialect {
         public Mssql2008ExpressionFunctions() {
             super(DEFAULT_WILDCARDS);
         }
+
+        public Mssql2008ExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected Mssql2008ExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/MssqlDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/MssqlDialect.java
@@ -41,6 +41,7 @@ import org.seasar.doma.wrapper.Wrapper;
 public class MssqlDialect extends Mssql2008Dialect {
 
     private boolean pagingForceOffsetFetch;
+
     /**
      * インスタンスを構築します。
      */
@@ -114,9 +115,10 @@ public class MssqlDialect extends Mssql2008Dialect {
     public MssqlDialect(JdbcMappingVisitor jdbcMappingVisitor,
             SqlLogFormattingVisitor sqlLogFormattingVisitor,
             ExpressionFunctions expressionFunctions) {
-        this(jdbcMappingVisitor, sqlLogFormattingVisitor, expressionFunctions, false);
+        this(jdbcMappingVisitor, sqlLogFormattingVisitor, expressionFunctions,
+                false);
     }
-    
+
     /**
      * {@link JdbcMappingVisitor} と {@link SqlLogFormattingVisitor} と
      * {@link ExpressionFunctions} を指定してインスタンスを構築します。
@@ -133,7 +135,7 @@ public class MssqlDialect extends Mssql2008Dialect {
      */
     public MssqlDialect(JdbcMappingVisitor jdbcMappingVisitor,
             SqlLogFormattingVisitor sqlLogFormattingVisitor,
-            ExpressionFunctions expressionFunctions, 
+            ExpressionFunctions expressionFunctions,
             boolean pagingForceOffsetFetch) {
         super(jdbcMappingVisitor, sqlLogFormattingVisitor, expressionFunctions);
         this.pagingForceOffsetFetch = pagingForceOffsetFetch;
@@ -209,6 +211,19 @@ public class MssqlDialect extends Mssql2008Dialect {
      */
     public static class MssqlExpressionFunctions extends
             Mssql2008ExpressionFunctions {
+
+        public MssqlExpressionFunctions() {
+            super();
+        }
+
+        public MssqlExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected MssqlExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/MysqlDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/MysqlDialect.java
@@ -228,6 +228,19 @@ public class MysqlDialect extends StandardDialect {
      */
     public static class MysqlExpressionFunctions extends
             StandardExpressionFunctions {
+
+        public MysqlExpressionFunctions() {
+            super();
+        }
+
+        public MysqlExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected MysqlExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/OracleDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/OracleDialect.java
@@ -508,6 +508,14 @@ public class OracleDialect extends StandardDialect {
             super(DEFAULT_WILDCARDS);
         }
 
+        public OracleExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected OracleExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/PostgresDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/PostgresDialect.java
@@ -266,6 +266,19 @@ public class PostgresDialect extends StandardDialect {
      */
     public static class PostgresExpressionFunctions extends
             StandardExpressionFunctions {
+
+        public PostgresExpressionFunctions() {
+            super();
+        }
+
+        public PostgresExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected PostgresExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
     /**

--- a/src/main/java/org/seasar/doma/jdbc/dialect/SqliteDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/SqliteDialect.java
@@ -199,6 +199,19 @@ public class SqliteDialect extends StandardDialect {
      */
     public static class SqliteExpressionFunctions extends
             StandardExpressionFunctions {
+
+        public SqliteExpressionFunctions() {
+            super();
+        }
+
+        public SqliteExpressionFunctions(char[] wildcards) {
+            super(wildcards);
+        }
+
+        protected SqliteExpressionFunctions(char escapeChar, char[] wildcards) {
+            super(escapeChar, wildcards);
+        }
+
     }
 
 }


### PR DESCRIPTION
ワイルドカード文字やエスケープ文字をカスタマイズしやすくしました。