### PR TITLE
PortableObjectTypeをジェネリクスにして、String等をvalueTypeとして指定できるように

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/type/JdbcTypes.java
+++ b/src/main/java/org/seasar/doma/jdbc/type/JdbcTypes.java
@@ -63,8 +63,6 @@ public final class JdbcTypes {
 
     public static final ObjectType OBJECT = new ObjectType();
 
-    public static final PortableObjectType PORTABLE_OBJECT = new PortableObjectType();
-
     public static final ShortType SHORT = new ShortType();
 
     public static final StringType STRING = new StringType();

--- a/src/main/java/org/seasar/doma/jdbc/type/PortableObjectType.java
+++ b/src/main/java/org/seasar/doma/jdbc/type/PortableObjectType.java
@@ -15,21 +15,48 @@
  */
 package org.seasar.doma.jdbc.type;
 
+import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 
 /**
- * {@link Object} 用の {@link JdbcType} の実装です。
+ * DB固有の型用の {@link JdbcType} の実装です。
  * {@link PreparedStatement#setObject(int, Object, int)} を使って値を設定します。
  * 
  * @author nakamura-to
  * @since 2.4.0
  */
-public class PortableObjectType extends ObjectType {
+public class PortableObjectType<T> extends AbstractJdbcType<T> {
+
+    private final JdbcType<T> baseType;
+
+    public PortableObjectType(JdbcType<T> baseType) {
+        super(Types.OTHER);
+        this.baseType = baseType;
+    }
+
+    @Override
+    public T doGetValue(ResultSet resultSet, int index)
+            throws SQLException {
+        return baseType.getValue(resultSet, index);
+    }
 
     @Override
     protected void doSetValue(PreparedStatement preparedStatement, int index,
-            Object value) throws SQLException {
+            T value) throws SQLException {
         preparedStatement.setObject(index, value, this.type);
+    }
+
+    @Override
+    protected T doGetValue(CallableStatement callableStatement, int index)
+            throws SQLException {
+        return baseType.getValue(callableStatement, index);
+    }
+
+    @Override
+    protected String doConvertToLogFormat(T value) {
+        return baseType.convertToLogFormat(value);
     }
 }


### PR DESCRIPTION
`JdbcMappingVisitor#visitStringWrapper`等にて`PortableObjectType`を利用できるよう、`PortableObjectType`をジェネリクス化しました。