### PR TITLE
JdbcMappingHint#getDomainClass() がドメインクラスを返さない問題を修正

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/NodePreparedSqlBuilder.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/NodePreparedSqlBuilder.java
@@ -34,7 +34,6 @@ import org.seasar.doma.internal.expr.ExpressionException;
 import org.seasar.doma.internal.expr.ExpressionParser;
 import org.seasar.doma.internal.expr.Value;
 import org.seasar.doma.internal.expr.node.ExpressionNode;
-import org.seasar.doma.internal.jdbc.command.JdbcMappable;
 import org.seasar.doma.internal.jdbc.scalar.Scalar;
 import org.seasar.doma.internal.jdbc.scalar.ScalarException;
 import org.seasar.doma.internal.jdbc.scalar.Scalars;
@@ -606,8 +605,8 @@ public class NodePreparedSqlBuilder implements
             }
 
             @Override
-            public <BASIC> void appendParameter(JdbcMappable<BASIC> parameter) {
-                p.appendParameter(new BasicInParameter<>(parameter::getWrapper));
+            public <BASIC> void appendParameter(InParameter<BASIC> parameter) {
+                p.appendParameter(parameter);
             }
         });
         return null;

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/PreparedSqlBuilder.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/PreparedSqlBuilder.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.seasar.doma.internal.jdbc.command.JdbcMappable;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.SqlKind;
 import org.seasar.doma.jdbc.SqlLogFormattingFunction;
@@ -30,7 +29,7 @@ import org.seasar.doma.wrapper.Wrapper;
 
 public class PreparedSqlBuilder implements SqlContext {
 
-    protected final List<BasicInParameter<?>> parameters = new ArrayList<>();
+    protected final List<InParameter<?>> parameters = new ArrayList<>();
 
     protected final StringBuilder rawSql = new StringBuilder(200);
 
@@ -62,12 +61,12 @@ public class PreparedSqlBuilder implements SqlContext {
         formattedSql.setLength(formattedSql.length() - length);
     }
 
-    public <BASIC> void appendParameter(JdbcMappable<BASIC> parameter) {
+    public <BASIC> void appendParameter(InParameter<BASIC> parameter) {
         rawSql.append("?");
         Wrapper<BASIC> wrapper = parameter.getWrapper();
         formattedSql.append(wrapper.accept(config.getDialect()
                 .getSqlLogFormattingVisitor(), formattingFunction, null));
-        parameters.add(new BasicInParameter<BASIC>(() -> wrapper));
+        parameters.add(parameter);
     }
 
     public PreparedSql build(Function<String, String> commenter) {

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/ScalarInOutParameter.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/ScalarInOutParameter.java
@@ -55,7 +55,7 @@ public class ScalarInOutParameter<BASIC, CONTAINER> implements
 
     @Override
     public Optional<Class<?>> getDomainClass() {
-        return Optional.empty();
+        return scalar.getDomainClass();
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/ScalarInParameter.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/ScalarInParameter.java
@@ -58,7 +58,7 @@ public class ScalarInParameter<BASIC, CONTAINER> implements InParameter<BASIC> {
 
     @Override
     public Optional<Class<?>> getDomainClass() {
-        return Optional.empty();
+        return scalar.getDomainClass();
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlContext.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlContext.java
@@ -15,7 +15,6 @@
  */
 package org.seasar.doma.internal.jdbc.sql;
 
-import org.seasar.doma.internal.jdbc.command.JdbcMappable;
 
 /**
  * @author nakamura-to
@@ -23,7 +22,7 @@ import org.seasar.doma.internal.jdbc.command.JdbcMappable;
  */
 public interface SqlContext {
 
-    <BASIC> void appendParameter(JdbcMappable<BASIC> parameter);
+    <BASIC> void appendParameter(InParameter<BASIC> parameter);
 
     void appendSql(String sql);
 

--- a/src/main/java/org/seasar/doma/jdbc/JdbcMappingHint.java
+++ b/src/main/java/org/seasar/doma/jdbc/JdbcMappingHint.java
@@ -18,10 +18,24 @@ package org.seasar.doma.jdbc;
 import java.util.Optional;
 
 /**
+ * マッピングに関するヒント情報です。
+ * <p>
+ * {@link JdbcMappingVisitor} の実装クラスにおいて、次のマッピングのカスタマイズに利用できます。
+ * 
+ * <ul>
+ * <li>JavaのクラスからSQLの型へのマッピング（JavaからSQLのバインド変数へのマッピング）</li>
+ * <li>SQLの型からJavaのクラスへのマッピング（SQLの結果セットからJavaのマッピング）</li>
+ * </ul>
+ * 
  * @author nakamura-to
  * 
  */
 public interface JdbcMappingHint {
 
+    /**
+     * ドメインクラスにマッピングされている場合、そのドメインクラスを返します。
+     * 
+     * @return ドメインクラス
+     */
     Optional<Class<?>> getDomainClass();
 }

--- a/src/main/java/org/seasar/doma/jdbc/entity/DefaultPropertyType.java
+++ b/src/main/java/org/seasar/doma/jdbc/entity/DefaultPropertyType.java
@@ -35,6 +35,8 @@ import org.seasar.doma.internal.jdbc.scalar.OptionalDoubleScalar;
 import org.seasar.doma.internal.jdbc.scalar.OptionalIntScalar;
 import org.seasar.doma.internal.jdbc.scalar.OptionalLongScalar;
 import org.seasar.doma.internal.jdbc.scalar.Scalar;
+import org.seasar.doma.internal.jdbc.sql.InParameter;
+import org.seasar.doma.internal.jdbc.sql.ScalarInParameter;
 import org.seasar.doma.internal.util.ClassUtil;
 import org.seasar.doma.internal.util.FieldUtil;
 import org.seasar.doma.jdbc.Naming;
@@ -371,6 +373,11 @@ public class DefaultPropertyType<PARENT, ENTITY extends PARENT, BASIC, DOMAIN>
         }
 
         @Override
+        public InParameter<BASIC> asInParameter() {
+            return delegate.asInParameter();
+        }
+
+        @Override
         public Wrapper<BASIC> getWrapper() {
             return delegate.getWrapper();
         }
@@ -420,6 +427,11 @@ public class DefaultPropertyType<PARENT, ENTITY extends PARENT, BASIC, DOMAIN>
                         wrapException.getCause(), entityClass.getName(), name);
             }
             return this;
+        }
+
+        @Override
+        public InParameter<BASIC> asInParameter() {
+            return new ScalarInParameter<>(scalar);
         }
 
         @Override

--- a/src/main/java/org/seasar/doma/jdbc/entity/Property.java
+++ b/src/main/java/org/seasar/doma/jdbc/entity/Property.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.jdbc.entity;
 
 import org.seasar.doma.internal.jdbc.command.JdbcMappable;
+import org.seasar.doma.internal.jdbc.sql.InParameter;
 
 /**
  * プロパティです。
@@ -54,5 +55,13 @@ public interface Property<ENTITY, BASIC> extends JdbcMappable<BASIC> {
      * @return このインスタンス
      */
     Property<ENTITY, BASIC> save(ENTITY entity);
+
+    /**
+     * このプロパティを入力用パラメータとして返します。
+     * 
+     * @return 入力用パラメータ
+     * @since 2.4.0
+     */
+    InParameter<BASIC> asInParameter();
 
 }

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoBatchDeleteQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoBatchDeleteQuery.java
@@ -109,7 +109,7 @@ public class AutoBatchDeleteQuery<ENTITY> extends AutoBatchModifyQuery<ENTITY>
                 builder.appendSql(propertyType.getColumnName(naming::apply,
                         dialect::applyQuote));
                 builder.appendSql(" = ");
-                builder.appendParameter(property);
+                builder.appendParameter(property.asInParameter());
                 builder.appendSql(" and ");
             }
             builder.cutBackSql(5);
@@ -125,7 +125,7 @@ public class AutoBatchDeleteQuery<ENTITY> extends AutoBatchModifyQuery<ENTITY>
             builder.appendSql(versionPropertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             builder.appendSql(" = ");
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
         }
         PreparedSql sql = builder.build(this::comment);
         sqls.add(sql);

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoBatchInsertQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoBatchInsertQuery.java
@@ -180,7 +180,7 @@ public class AutoBatchInsertQuery<ENTITY> extends AutoBatchModifyQuery<ENTITY>
         for (EntityPropertyType<ENTITY, ?> propertyType : targetPropertyTypes) {
             Property<ENTITY, ?> property = propertyType.createProperty();
             property.load(currentEntity);
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
             builder.appendSql(", ");
         }
         builder.cutBackSql(2);

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoBatchUpdateQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoBatchUpdateQuery.java
@@ -126,7 +126,7 @@ public class AutoBatchUpdateQuery<ENTITY> extends AutoBatchModifyQuery<ENTITY>
                 builder.appendSql(propertyType.getColumnName(naming::apply,
                         dialect::applyQuote));
                 builder.appendSql(" = ");
-                builder.appendParameter(property);
+                builder.appendParameter(property.asInParameter());
                 builder.appendSql(" and ");
             }
             builder.cutBackSql(5);
@@ -142,7 +142,7 @@ public class AutoBatchUpdateQuery<ENTITY> extends AutoBatchModifyQuery<ENTITY>
             builder.appendSql(versionPropertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             builder.appendSql(" = ");
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
         }
         PreparedSql sql = builder.build(this::comment);
         sqls.add(sql);

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoDeleteQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoDeleteQuery.java
@@ -93,7 +93,7 @@ public class AutoDeleteQuery<ENTITY> extends AutoModifyQuery<ENTITY> implements
                 builder.appendSql(propertyType.getColumnName(naming::apply,
                         dialect::applyQuote));
                 builder.appendSql(" = ");
-                builder.appendParameter(property);
+                builder.appendParameter(property.asInParameter());
                 builder.appendSql(" and ");
             }
             builder.cutBackSql(5);
@@ -109,7 +109,7 @@ public class AutoDeleteQuery<ENTITY> extends AutoModifyQuery<ENTITY> implements
             builder.appendSql(versionPropertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             builder.appendSql(" = ");
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
         }
         sql = builder.build(this::comment);
     }

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoInsertQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoInsertQuery.java
@@ -163,7 +163,7 @@ public class AutoInsertQuery<ENTITY> extends AutoModifyQuery<ENTITY> implements
         for (EntityPropertyType<ENTITY, ?> propertyType : targetPropertyTypes) {
             Property<ENTITY, ?> property = propertyType.createProperty();
             property.load(entity);
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
             builder.appendSql(", ");
         }
         builder.cutBackSql(2);

--- a/src/main/java/org/seasar/doma/jdbc/query/AutoUpdateQuery.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/AutoUpdateQuery.java
@@ -123,7 +123,7 @@ public class AutoUpdateQuery<ENTITY> extends AutoModifyQuery<ENTITY> implements
                 builder.appendSql(propertyType.getColumnName(naming::apply,
                         dialect::applyQuote));
                 builder.appendSql(" = ");
-                builder.appendParameter(property);
+                builder.appendParameter(property.asInParameter());
                 builder.appendSql(" and ");
             }
             builder.cutBackSql(5);
@@ -139,7 +139,7 @@ public class AutoUpdateQuery<ENTITY> extends AutoModifyQuery<ENTITY> implements
             builder.appendSql(versionPropertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             builder.appendSql(" = ");
-            builder.appendParameter(property);
+            builder.appendParameter(property.asInParameter());
         }
         sql = builder.build(this::comment);
     }

--- a/src/main/java/org/seasar/doma/jdbc/query/BatchUpdateQueryHelper.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/BatchUpdateQueryHelper.java
@@ -113,7 +113,7 @@ public class BatchUpdateQueryHelper<E> {
             context.appendSql(propertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             context.appendSql(" = ");
-            context.appendParameter(property);
+            context.appendParameter(property.asInParameter());
             if (propertyType.isVersion() && !versionIgnored) {
                 context.appendSql(" + 1");
             }

--- a/src/main/java/org/seasar/doma/jdbc/query/UpdateQueryHelper.java
+++ b/src/main/java/org/seasar/doma/jdbc/query/UpdateQueryHelper.java
@@ -145,7 +145,7 @@ public class UpdateQueryHelper<E> {
             context.appendSql(propertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             context.appendSql(" = ");
-            context.appendParameter(property);
+            context.appendParameter(property.asInParameter());
             context.appendSql(", ");
         }
         if (!versionIgnored && versionPropertyType != null) {
@@ -154,7 +154,7 @@ public class UpdateQueryHelper<E> {
             context.appendSql(versionPropertyType.getColumnName(naming::apply,
                     dialect::applyQuote));
             context.appendSql(" = ");
-            context.appendParameter(property);
+            context.appendParameter(property.asInParameter());
             context.appendSql(" + 1");
         } else {
             context.cutBackSql(2);

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/PreparedSqlBuilderTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/PreparedSqlBuilderTest.java
@@ -21,12 +21,16 @@ import java.util.function.Function;
 import junit.framework.TestCase;
 
 import org.seasar.doma.internal.jdbc.mock.MockConfig;
-import org.seasar.doma.internal.jdbc.scalar.BasicScalar;
+import org.seasar.doma.jdbc.ClassHelper;
 import org.seasar.doma.jdbc.SqlKind;
 import org.seasar.doma.jdbc.SqlLogType;
+import org.seasar.doma.jdbc.domain.DomainType;
+import org.seasar.doma.jdbc.domain.DomainTypeFactory;
 import org.seasar.doma.wrapper.BigDecimalWrapper;
 import org.seasar.doma.wrapper.StringWrapper;
 import org.seasar.doma.wrapper.Wrapper;
+
+import example.domain.PhoneNumber;
 
 /**
  * @author taedium
@@ -41,17 +45,31 @@ public class PreparedSqlBuilderTest extends TestCase {
                 SqlKind.SELECT, SqlLogType.FORMATTED);
         builder.appendSql("select * from aaa where name = ");
         Wrapper<String> stringWrapper = new StringWrapper("hoge");
-        builder.appendParameter(new BasicScalar<String>(() -> stringWrapper,
-                false));
+        builder.appendParameter(new BasicInParameter<String>(
+                () -> stringWrapper));
 
         builder.appendSql(" and salary = ");
         Wrapper<BigDecimal> bigDecimalWrapper = new BigDecimalWrapper(
                 new BigDecimal(100));
-        builder.appendParameter(new BasicScalar<BigDecimal>(
-                () -> bigDecimalWrapper, false));
+        builder.appendParameter(new BasicInParameter<BigDecimal>(
+                () -> bigDecimalWrapper));
         PreparedSql sql = builder.build(Function.identity());
         assertEquals("select * from aaa where name = ? and salary = ?",
                 sql.toString());
+    }
+
+    public void testAppendParameter_domain() throws Exception {
+        PreparedSqlBuilder builder = new PreparedSqlBuilder(config,
+                SqlKind.SELECT, SqlLogType.FORMATTED);
+        builder.appendSql("select * from aaa where phoneNumber = ");
+        DomainType<String, PhoneNumber> phoneNumberType = DomainTypeFactory
+                .getDomainType(PhoneNumber.class, new ClassHelper() {
+                });
+        PhoneNumber phoneNumber = new PhoneNumber("03-1234-5678");
+        builder.appendParameter(new DomainInParameter<String, PhoneNumber>(
+                phoneNumberType, phoneNumber));
+        PreparedSql sql = builder.build(Function.identity());
+        assertEquals("select * from aaa where phoneNumber = ?", sql.toString());
     }
 
     public void testCutBackSql() {

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/ScalarInOutParameterTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/ScalarInOutParameterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal.jdbc.sql;
+
+import java.util.Optional;
+
+import junit.framework.TestCase;
+
+import org.seasar.doma.internal.jdbc.scalar.Scalar;
+import org.seasar.doma.jdbc.ClassHelper;
+import org.seasar.doma.jdbc.Reference;
+import org.seasar.doma.jdbc.domain.DomainType;
+import org.seasar.doma.jdbc.domain.DomainTypeFactory;
+
+import example.domain.PhoneNumber;
+
+/**
+ * @author nakamura-to
+ *
+ */
+public class ScalarInOutParameterTest extends TestCase {
+
+    public void testGetDomainClass() throws Exception {
+        DomainType<String, PhoneNumber> domainType = DomainTypeFactory
+                .getDomainType(PhoneNumber.class, new ClassHelper() {
+                });
+        Scalar<String, PhoneNumber> scalar = domainType.createScalar();
+        Reference<PhoneNumber> ref = new Reference<>();
+        ScalarInOutParameter<String, PhoneNumber> parameter = new ScalarInOutParameter<>(
+                scalar, ref);
+        Optional<Class<?>> optional = parameter.getDomainClass();
+        assertEquals(PhoneNumber.class, optional.get());
+    }
+
+    public void testGetDomainClass_optional() throws Exception {
+        DomainType<String, PhoneNumber> domainType = DomainTypeFactory
+                .getDomainType(PhoneNumber.class, new ClassHelper() {
+                });
+        Scalar<String, Optional<PhoneNumber>> scalar = domainType
+                .createOptionalScalar();
+        Reference<Optional<PhoneNumber>> ref = new Reference<>();
+        ScalarInOutParameter<String, Optional<PhoneNumber>> parameter = new ScalarInOutParameter<>(
+                scalar, ref);
+        Optional<Class<?>> optional = parameter.getDomainClass();
+        assertEquals(PhoneNumber.class, optional.get());
+    }
+}

--- a/src/test/java/org/seasar/doma/internal/jdbc/sql/ScalarInParameterTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/sql/ScalarInParameterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal.jdbc.sql;
+
+import java.util.Optional;
+
+import junit.framework.TestCase;
+
+import org.seasar.doma.internal.jdbc.scalar.Scalar;
+import org.seasar.doma.jdbc.ClassHelper;
+import org.seasar.doma.jdbc.domain.DomainType;
+import org.seasar.doma.jdbc.domain.DomainTypeFactory;
+
+import example.domain.PhoneNumber;
+
+/**
+ * @author nakamura-to
+ *
+ */
+public class ScalarInParameterTest extends TestCase {
+
+    public void testGetDomainClass() throws Exception {
+        DomainType<String, PhoneNumber> domainType = DomainTypeFactory
+                .getDomainType(PhoneNumber.class, new ClassHelper() {
+                });
+        Scalar<String, PhoneNumber> scalar = domainType.createScalar();
+        ScalarInParameter<String, PhoneNumber> parameter = new ScalarInParameter<>(
+                scalar);
+        Optional<Class<?>> optional = parameter.getDomainClass();
+        assertEquals(PhoneNumber.class, optional.get());
+    }
+
+    public void testGetDomainClass_optional() throws Exception {
+        DomainType<String, PhoneNumber> domainType = DomainTypeFactory
+                .getDomainType(PhoneNumber.class, new ClassHelper() {
+                });
+        Scalar<String, Optional<PhoneNumber>> scalar = domainType
+                .createOptionalScalar();
+        ScalarInParameter<String, Optional<PhoneNumber>> parameter = new ScalarInParameter<>(
+                scalar);
+        Optional<Class<?>> optional = parameter.getDomainClass();
+        assertEquals(PhoneNumber.class, optional.get());
+    }
+
+}


### PR DESCRIPTION
ドメインクラスがエンティティクラスのプロパティであり、かつSQLのバインド変数にマッピングされる場合に問題が発生していました