### PR TITLE
UnknownColumnHandler の handle() を空実装にすると NullPointerException が発生する問題を修正

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/command/EntityProvider.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/command/EntityProvider.java
@@ -117,9 +117,10 @@ public class EntityProvider<ENTITY> extends AbstractObjectProvider<ENTITY> {
                 }
                 unknownColumnHandler.handle(query, entityType,
                         lowerCaseColumnName);
+            } else {
+                unmappedPropertySet.remove(propertyType);
+                indexMap.put(i, propertyType);
             }
-            unmappedPropertySet.remove(propertyType);
-            indexMap.put(i, propertyType);
         }
         if (resultMappingEnsured && !unmappedPropertySet.isEmpty()) {
             throwResultMappingException(unmappedPropertySet);


### PR DESCRIPTION
fix #101