### PR TITLE
Dao の引数ありコンストラクターの引数の型を、Config クラスではなく @Dao の config 値で指定したクラスにする

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/DaoGenerator.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DaoGenerator.java
@@ -395,7 +395,7 @@ public class DaoGenerator extends AbstractGenerator {
                 print("@%1$s(%2$s) ", annotation.getTypeValue(),
                         annotation.getElementsValue());
             }
-            print("%1$s config) {%n", Config.class.getName());
+            print("%1$s config) {%n", daoMeta.getConfigType());
             indent();
             iprint("super(config);%n");
             unindent();


### PR DESCRIPTION
Spring + Doma の環境にて、Dao ごとに接続先データベースを指定するよう、org.seasar.doma.jdbc.Config　の実装を複数作って Dao に DI しています。

    @Dao(config = MyConfig1.class)
    @Annotation(target = AnnotationTarget.CONSTRUCTOR, type = org.springframework.beans.factory.annotation.Autowired.class)
    public interface MyDao1 {}

    @Dao(config = MyConfig2.class)
    @Annotation(target = AnnotationTarget.CONSTRUCTOR, type = org.springframework.beans.factory.annotation.Autowired.class)
    public interface MyDao2 {}

この時、自動生成される Dao の実装クラスには、以下のような引数が Config のコンストラクターができるかと思います。

    @org.springframework.beans.factory.annotation.Autowired()
    public MyDao1Impl(org.seasar.doma.jdbc.Config config) {
        super(config);
    }

ここで Spring に DI させようとすると、Config クラスのサブクラスが複数あるため、どちらの Config を DI すべきかわからず、エラーになります。
DaoGenerator を見ると、このコンストラクターの引数の型には @Dao で指定した config 値ではなく、Config クラスを固定ではめこんでいるようです。
コンストラクターの引数の型を、@Dao で指定した config 値にしないことには、どのような意図があるのでしょうか。

Dao の実装クラスに作られる引数なしのコンストラクターは、内部で @Dao で指定した config 値のクラスをインスタンス化しているので、
引数ありのコンストラクターでも、@Dao の config 値を指定しても良さそうな気がしております。

    /** */
    public MyDao1Impl() {
        super(new com.example.MyConfig1());
    }

浅はかな対応策ではあるかと思いますが、ひとまず pull request させていただきました。
このような用途で、どのように Config クラスを複数実装していけばいいかの助言なども教えていただけますと助かります。
お手すきにてご確認ください。