### PR TITLE
Fix cause position in UniqueConstraintException's constructor

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/UniqueConstraintException.java
+++ b/src/main/java/org/seasar/doma/jdbc/UniqueConstraintException.java
@@ -75,8 +75,8 @@ public class UniqueConstraintException extends JdbcException {
     public UniqueConstraintException(SqlLogType logType, SqlKind kind,
             String rawSql, String formattedSql, String sqlFilePath,
             Throwable cause) {
-        super(Message.DOMA2004, sqlFilePath, choiceSql(logType, rawSql,
-                formattedSql), cause);
+        super(Message.DOMA2004, cause, sqlFilePath, choiceSql(logType, rawSql,
+                formattedSql));
         this.kind = kind;
         this.rawSql = rawSql;
         this.formattedSql = formattedSql;

--- a/src/test/java/org/seasar/doma/jdbc/UniqueConstraintExceptionTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/UniqueConstraintExceptionTest.java
@@ -24,13 +24,15 @@ import junit.framework.TestCase;
 public class UniqueConstraintExceptionTest extends TestCase {
 
     public void test() throws Exception {
+        Exception cause = new Exception();
         UniqueConstraintException e = new UniqueConstraintException(
-                SqlLogType.FORMATTED, SqlKind.INSERT, "aaa", "bbb", "ccc",
-                new Exception());
+                SqlLogType.FORMATTED, SqlKind.INSERT, "aaa", "bbb", "ccc"
+                , cause);
         System.out.println(e.getMessage());
         assertSame(SqlKind.INSERT, e.getKind());
         assertEquals("aaa", e.getRawSql());
         assertEquals("bbb", e.getFormattedSql());
         assertEquals("ccc", e.getSqlFilePath());
+        assertEquals(cause, e.getCause());
     }
 }


### PR DESCRIPTION
`UniqueConstraintException`のコンストラクタで親コンストラクタに渡す`cause`の引数の場所が間違っていて、可変長引数の一つとして扱われていたのを修正しました。