### PR TITLE
リンクに関連したJavadoc生成オプションを追加しました

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ javadoc {
     options.encoding = encoding
     options.charSet = encoding
     options.docEncoding = encoding
+    options.links 'http://docs.oracle.com/javase/jp/8/docs/api/'
     exclude '**/internal/**'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ javadoc {
     options.charSet = encoding
     options.docEncoding = encoding
     options.links 'http://docs.oracle.com/javase/jp/8/docs/api/'
+    options.use = true
     exclude '**/internal/**'
 }
 


### PR DESCRIPTION
次の2点についてJavadoc生成オプションを追加しました。

* `String`などのクラス名からJava SE 8のJavadocへリンクする
* クラスとパッケージの使用ページを生成する

これらがあった方がJavadocを便利に使えると思っています。