### PR TITLE
SelectBuilder のデフォルトの FetchType を Lazy に設定

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/builder/SelectBuilder.java
+++ b/src/main/java/org/seasar/doma/jdbc/builder/SelectBuilder.java
@@ -114,6 +114,7 @@ public class SelectBuilder {
         this.query = new SqlSelectQuery();
         this.query.setConfig(config);
         this.query.setCallerClassName(getClass().getName());
+        this.query.setFetchType(FetchType.LAZY);
         this.query.setSqlLogType(SqlLogType.FORMATTED);
         this.paramIndex = new ParamIndex();
     }


### PR DESCRIPTION
Stream を使った際に遅延で処理しかつクローズできるようにするため。