### PR TITLE
Switching remote URLs from SSH to HTTPS

### DIFF
--- a/docs/sources/development.rst
+++ b/docs/sources/development.rst
@@ -14,7 +14,7 @@ Doma の開発
 
 .. code-block:: bash
 
-  $ git clone git@github.com:domaframework/doma.git
+  $ git clone https://github.com/domaframework/doma.git
 
 ビルド
 ======

--- a/docs/sources/getting-started.rst
+++ b/docs/sources/getting-started.rst
@@ -96,7 +96,7 @@ GitHub から simple-boilerplate を clone してください。
 
 .. code-block:: bash
 
-  $ git clone git@github.com:domaframework/simple-boilerplate.git
+  $ git clone https://github.com/domaframework/simple-boilerplate.git
 
 clone されたディレクトリに移動します。
 

--- a/docs/sources/integration-test.rst
+++ b/docs/sources/integration-test.rst
@@ -22,7 +22,7 @@
 
 .. code-block:: bash
 
-  $ git clone git@github.com:domaframework/doma-it.git
+  $ git clone https://github.com/domaframework/doma-it.git
 
 ビルド
 ======


### PR DESCRIPTION
リポジトリのURLをSSHからHTTPSに変更しました.

理由は, HTTPSにした方が利便性が上がると考えたからです.

SSHだとGitHubにアカウントが必要であり, 公開鍵の登録も必要です.
アカウントがない人や, ちょうど手元に秘密鍵がない人は今のURLではcloneできません
(私は後者でした  😅 ).