### PR TITLE
kapt 1.0.1-2の実験的なサポート

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/AbstractGeneratingProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/AbstractGeneratingProcessor.java
@@ -16,6 +16,7 @@
 package org.seasar.doma.internal.apt;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -34,7 +35,9 @@ import org.seasar.doma.message.Message;
 public abstract class AbstractGeneratingProcessor<M extends TypeElementMeta>
         extends AbstractProcessor {
 
-    protected AbstractGeneratingProcessor() {
+    protected AbstractGeneratingProcessor(
+            Class<? extends Annotation> supportedAnnotationType) {
+        super(supportedAnnotationType);
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/internal/apt/AbstractProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/AbstractProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.seasar.doma.internal.apt;
 
+import java.lang.annotation.Annotation;
 import java.util.function.Consumer;
 
 import javax.lang.model.SourceVersion;
@@ -30,7 +31,11 @@ import org.seasar.doma.message.Message;
 public abstract class AbstractProcessor extends
         javax.annotation.processing.AbstractProcessor {
 
-    protected AbstractProcessor() {
+    protected Class<? extends Annotation> supportedAnnotationType;
+
+    protected AbstractProcessor(
+            Class<? extends Annotation> supportedAnnotationType) {
+        this.supportedAnnotationType = supportedAnnotationType;
     }
 
     @Override
@@ -40,6 +45,11 @@ public abstract class AbstractProcessor extends
 
     protected void handleTypeElement(TypeElement typeElement,
             Consumer<TypeElement> handler) {
+        Annotation annotation = typeElement
+                .getAnnotation(supportedAnnotationType);
+        if (annotation == null) {
+            return;
+        }
         if (Options.isDebugEnabled(processingEnv)) {
             Notifier.debug(processingEnv, Message.DOMA4090, getClass()
                     .getName(), typeElement.getQualifiedName());
@@ -66,5 +76,4 @@ public abstract class AbstractProcessor extends
                     .getName(), typeElement.getQualifiedName());
         }
     }
-
 }

--- a/src/main/java/org/seasar/doma/internal/apt/DaoProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DaoProcessor.java
@@ -25,6 +25,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.TypeElement;
 
+import org.seasar.doma.Dao;
 import org.seasar.doma.internal.apt.meta.ArrayCreateQueryMetaFactory;
 import org.seasar.doma.internal.apt.meta.AutoBatchModifyQueryMetaFactory;
 import org.seasar.doma.internal.apt.meta.AutoFunctionQueryMetaFactory;
@@ -53,6 +54,10 @@ import org.seasar.doma.internal.apt.meta.TypeElementMetaFactory;
         Options.DAO_SUBPACKAGE, Options.DAO_SUFFIX, Options.EXPR_FUNCTIONS,
         Options.SQL_VALIDATION, Options.VERSION_VALIDATION })
 public class DaoProcessor extends AbstractGeneratingProcessor<DaoMeta> {
+
+    public DaoProcessor() {
+        super(Dao.class);
+    }
 
     @Override
     protected TypeElementMetaFactory<DaoMeta> createTypeElementMetaFactory() {

--- a/src/main/java/org/seasar/doma/internal/apt/DomainConvertersProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DomainConvertersProcessor.java
@@ -24,6 +24,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 
+import org.seasar.doma.DomainConverters;
 import org.seasar.doma.ExternalDomain;
 import org.seasar.doma.internal.apt.mirror.DomainConvertersMirror;
 import org.seasar.doma.internal.apt.util.TypeMirrorUtil;
@@ -38,6 +39,7 @@ import org.seasar.doma.message.Message;
 public class DomainConvertersProcessor extends AbstractProcessor {
 
     public DomainConvertersProcessor() {
+        super(DomainConverters.class);
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/internal/apt/DomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DomainProcessor.java
@@ -15,7 +15,7 @@
  */
 package org.seasar.doma.internal.apt;
 
-import static org.seasar.doma.internal.util.AssertionUtil.*;
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import java.io.IOException;
 
@@ -23,6 +23,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.TypeElement;
 
+import org.seasar.doma.Domain;
 import org.seasar.doma.internal.apt.meta.DomainMeta;
 import org.seasar.doma.internal.apt.meta.DomainMetaFactory;
 
@@ -33,6 +34,10 @@ import org.seasar.doma.internal.apt.meta.DomainMetaFactory;
 @SupportedAnnotationTypes({ "org.seasar.doma.Domain" })
 @SupportedOptions({ Options.VERSION_VALIDATION, Options.TEST, Options.DEBUG })
 public class DomainProcessor extends AbstractGeneratingProcessor<DomainMeta> {
+
+    public DomainProcessor() {
+        super(Domain.class);
+    }
 
     @Override
     protected DomainMetaFactory createTypeElementMetaFactory() {

--- a/src/main/java/org/seasar/doma/internal/apt/EntityProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/EntityProcessor.java
@@ -15,7 +15,7 @@
  */
 package org.seasar.doma.internal.apt;
 
-import static org.seasar.doma.internal.util.AssertionUtil.*;
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import java.io.IOException;
 
@@ -23,6 +23,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.TypeElement;
 
+import org.seasar.doma.Entity;
 import org.seasar.doma.internal.apt.meta.EntityMeta;
 import org.seasar.doma.internal.apt.meta.EntityMetaFactory;
 import org.seasar.doma.internal.apt.meta.EntityPropertyMetaFactory;
@@ -35,6 +36,10 @@ import org.seasar.doma.internal.apt.meta.EntityPropertyMetaFactory;
 @SupportedOptions({ Options.ENTITY_FIELD_PREFIX, Options.DOMAIN_CONVERTERS,
         Options.VERSION_VALIDATION, Options.TEST, Options.DEBUG })
 public class EntityProcessor extends AbstractGeneratingProcessor<EntityMeta> {
+
+    public EntityProcessor() {
+        super(Entity.class);
+    }
 
     @Override
     protected EntityMetaFactory createTypeElementMetaFactory() {

--- a/src/main/java/org/seasar/doma/internal/apt/ExternalDomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/ExternalDomainProcessor.java
@@ -15,7 +15,7 @@
  */
 package org.seasar.doma.internal.apt;
 
-import static org.seasar.doma.internal.util.AssertionUtil.*;
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import java.io.IOException;
 
@@ -23,6 +23,7 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.element.TypeElement;
 
+import org.seasar.doma.ExternalDomain;
 import org.seasar.doma.internal.apt.meta.ExternalDomainMeta;
 import org.seasar.doma.internal.apt.meta.ExternalDomainMetaFactory;
 
@@ -34,6 +35,10 @@ import org.seasar.doma.internal.apt.meta.ExternalDomainMetaFactory;
 @SupportedOptions({ Options.VERSION_VALIDATION, Options.TEST, Options.DEBUG })
 public class ExternalDomainProcessor extends
         AbstractGeneratingProcessor<ExternalDomainMeta> {
+
+    public ExternalDomainProcessor() {
+        super(ExternalDomain.class);
+    }
 
     @Override
     protected ExternalDomainMetaFactory createTypeElementMetaFactory() {

--- a/src/main/java/org/seasar/doma/internal/apt/SingletonConfigProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/SingletonConfigProcessor.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
 
+import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.internal.apt.mirror.SingletonConfigMirror;
 import org.seasar.doma.internal.apt.util.TypeMirrorUtil;
 import org.seasar.doma.jdbc.Config;
@@ -41,6 +42,7 @@ import org.seasar.doma.message.Message;
 public class SingletonConfigProcessor extends AbstractProcessor {
 
     public SingletonConfigProcessor() {
+        super(SingletonConfig.class);
     }
 
     @Override

--- a/src/main/java/org/seasar/doma/internal/apt/meta/EntityMeta.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/EntityMeta.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
+import org.seasar.doma.ParameterName;
 import org.seasar.doma.internal.apt.mirror.EntityMirror;
 import org.seasar.doma.internal.apt.mirror.TableMirror;
 import org.seasar.doma.jdbc.entity.NamingType;
@@ -141,8 +142,13 @@ public class EntityMeta implements TypeElementMeta {
         }
         List<EntityPropertyMeta> results = new ArrayList<EntityPropertyMeta>();
         for (VariableElement param : constructor.getParameters()) {
-            results.add(allPropertyMetaMap
-                    .get(param.getSimpleName().toString()));
+            String name = param.getSimpleName().toString();
+            ParameterName parameterName = param
+                    .getAnnotation(ParameterName.class);
+            if (parameterName != null) {
+                name = parameterName.value();
+            }
+            results.add(allPropertyMetaMap.get(name));
         }
         return results;
     }

--- a/src/main/java/org/seasar/doma/internal/apt/meta/EntityMetaFactory.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/EntityMetaFactory.java
@@ -43,6 +43,7 @@ import javax.lang.model.util.ElementFilter;
 import org.seasar.doma.Entity;
 import org.seasar.doma.EntityField;
 import org.seasar.doma.OriginalStates;
+import org.seasar.doma.ParameterName;
 import org.seasar.doma.Transient;
 import org.seasar.doma.internal.apt.AptException;
 import org.seasar.doma.internal.apt.AptIllegalStateException;
@@ -591,6 +592,11 @@ public class EntityMetaFactory implements TypeElementMetaFactory<EntityMeta> {
             int validCount = 0;
             for (VariableElement param : constructor.getParameters()) {
                 String name = param.getSimpleName().toString();
+                ParameterName parameterName = param
+                        .getAnnotation(ParameterName.class);
+                if (parameterName != null) {
+                    name = parameterName.value();
+                }
                 TypeMirror paramType = param.asType();
                 TypeMirror propertyType = types.get(name);
                 if (propertyType == null) {


### PR DESCRIPTION
kapt 1.0.1-2は以下の問題がある。

- 無関係な注釈プロセッサを起動する
- コンストラクトのパラメータ名を保持しない

それぞれ次のように回避した。

- Domaの注釈プロセッサでアノテーションをチェックし必要なときにのみ動作するようにした
- `@ParameterName` で指定された名前を利用するようにした