### PR TITLE
エンティティクラスの継承構造が2段階の場合に無限ループが発生する不具合を修正

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/entity/PropertyField.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/entity/PropertyField.java
@@ -67,8 +67,7 @@ public class PropertyField<ENTITY> {
     }
 
     private Field findField(Class<?> clazz, String name) {
-        for (Class<?> cl = clazz; cl != Object.class; cl = clazz
-                .getSuperclass()) {
+        for (Class<?> cl = clazz; cl != Object.class; cl = cl.getSuperclass()) {
             try {
                 return cl.getDeclaredField(name);
             } catch (NoSuchFieldException ignored) {

--- a/src/test/java/org/seasar/doma/internal/jdbc/entity/Life.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/entity/Life.java
@@ -19,7 +19,7 @@ package org.seasar.doma.internal.jdbc.entity;
  * @author nakamura-to
  *
  */
-public class Animal extends Life {
+public class Life {
 
-    public String kind;
+    int weight;
 }

--- a/src/test/java/org/seasar/doma/internal/jdbc/entity/PropertyFieldTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/entity/PropertyFieldTest.java
@@ -32,6 +32,11 @@ public class PropertyFieldTest extends TestCase {
         assertEquals(1, path.fields.size());
     }
 
+    public void testConstructor_grandParentPath() throws Exception {
+        PropertyField<Person> path = new PropertyField<>("weight", Person.class);
+        assertEquals(1, path.fields.size());
+    }
+
     public void testConstructor_nestedPath() throws Exception {
         PropertyField<Person> path = new PropertyField<>("address.city",
                 Person.class);


### PR DESCRIPTION
2段階とは、親、子、孫のように3つのクラスからなる継承構造を意味します。
close #163