### PR TITLE
組み込み関数の LocalDate, LocalDateTime 対応

### DIFF
--- a/src/main/java/org/seasar/doma/expr/ExpressionFunctions.java
+++ b/src/main/java/org/seasar/doma/expr/ExpressionFunctions.java
@@ -17,6 +17,8 @@ package org.seasar.doma.expr;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 /**
  * 式の中で利用可能な関数群です。
@@ -137,6 +139,15 @@ public interface ExpressionFunctions {
     Timestamp roundDownTimePart(Timestamp timestamp);
 
     /**
+     * LocalDateTime の時刻部分を切り捨てます。
+     * 
+     * @param localDateTime
+     *            LocalDateTime
+     * @return 時刻部分が切り捨てられたタイムスタンプ
+     */
+    LocalDateTime roundDownTimePart(LocalDateTime localDateTime);
+
+    /**
      * 日付の時刻部分を切り上げます。
      * 
      * @param date
@@ -163,6 +174,24 @@ public interface ExpressionFunctions {
      * @return 時刻部分が切り上げられたタイムスタンプ
      */
     Timestamp roundUpTimePart(Timestamp timestamp);
+
+    /**
+     * 翌日の日付を返します。
+     * 
+     * @param localDate
+     *            LocalDate
+     * @return 翌日の日付
+     */
+    LocalDate roundUpTimePart(LocalDate localDate);
+
+    /**
+     * LocalDateTime の時刻部分を切り上げます。
+     * 
+     * @param localDateTime
+     *            LocalDateTime
+     * @return 時刻部分が切り上げられたタイムスタンプ
+     */
+    LocalDateTime roundUpTimePart(LocalDateTime localDateTime);
 
     /**
      * 文字シーケンスが {@code null}、もしくは文字シーケンスの長さが {@code 0} の場合 {@code true} を返します。

--- a/src/main/java/org/seasar/doma/internal/expr/NullExpressionFunctions.java
+++ b/src/main/java/org/seasar/doma/internal/expr/NullExpressionFunctions.java
@@ -17,6 +17,8 @@ package org.seasar.doma.internal.expr;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.seasar.doma.expr.ExpressionFunctions;
 import org.seasar.doma.internal.util.CharSequenceUtil;
@@ -83,6 +85,11 @@ public class NullExpressionFunctions implements ExpressionFunctions {
     }
 
     @Override
+    public LocalDateTime roundDownTimePart(LocalDateTime localDateTime) {
+        return localDateTime;
+    }
+
+    @Override
     public java.util.Date roundUpTimePart(java.util.Date date) {
         return date;
     }
@@ -95,6 +102,16 @@ public class NullExpressionFunctions implements ExpressionFunctions {
     @Override
     public Timestamp roundUpTimePart(Timestamp timestamp) {
         return timestamp;
+    }
+
+    @Override
+    public LocalDate roundUpTimePart(LocalDate localDate) {
+        return localDate;
+    }
+
+    @Override
+    public LocalDateTime roundUpTimePart(LocalDateTime localDateTime) {
+        return localDateTime;
     }
 
     @Override
@@ -116,5 +133,4 @@ public class NullExpressionFunctions implements ExpressionFunctions {
     public boolean isNotBlank(CharSequence charSequence) {
         return CharSequenceUtil.isNotBlank(charSequence);
     }
-
 }

--- a/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
@@ -19,6 +19,9 @@ import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1044,6 +1047,11 @@ public class StandardDialect implements Dialect {
             return new Timestamp(calendar.getTimeInMillis());
         }
 
+        @Override
+        public LocalDateTime roundDownTimePart(LocalDateTime localDateTime) {
+            return localDateTime.truncatedTo(ChronoUnit.DAYS);
+        }
+
         protected Calendar makeRoundedDownClandar(java.util.Date date) {
             Calendar calendar = Calendar.getInstance();
             calendar.setTime(date);
@@ -1079,6 +1087,19 @@ public class StandardDialect implements Dialect {
             }
             Calendar calendar = makeRoundedUpClandar(timestamp);
             return new Timestamp(calendar.getTimeInMillis());
+        }
+
+        @Override
+        public LocalDate roundUpTimePart(LocalDate localDate) {
+            if (localDate == null) {
+                return null;
+            }
+            return localDate.plusDays(1);
+        }
+
+        @Override
+        public LocalDateTime roundUpTimePart(LocalDateTime localDateTime) {
+            return localDateTime.plusDays(1).truncatedTo(ChronoUnit.DAYS);
         }
 
         protected Calendar makeRoundedUpClandar(java.util.Date date) {

--- a/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
@@ -1049,6 +1049,9 @@ public class StandardDialect implements Dialect {
 
         @Override
         public LocalDateTime roundDownTimePart(LocalDateTime localDateTime) {
+            if (localDateTime == null) {
+                return null;
+            }
             return localDateTime.truncatedTo(ChronoUnit.DAYS);
         }
 
@@ -1099,6 +1102,9 @@ public class StandardDialect implements Dialect {
 
         @Override
         public LocalDateTime roundUpTimePart(LocalDateTime localDateTime) {
+            if (localDateTime == null) {
+                return null;
+            }
             return localDateTime.plusDays(1).truncatedTo(ChronoUnit.DAYS);
         }
 

--- a/src/test/java/org/seasar/doma/jdbc/dialect/StandardDialectTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/dialect/StandardDialectTest.java
@@ -17,6 +17,8 @@ package org.seasar.doma.jdbc.dialect;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 
 import junit.framework.TestCase;
@@ -134,6 +136,16 @@ public class StandardDialectTest extends TestCase {
                 functions.roundDownTimePart(timestamp));
     }
 
+    public void testExpressionFunctions_roundDonwTimePart_forLocalDateTime()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDateTime localDateTime = LocalDateTime.of(2009, 1, 23, 12, 34, 56,
+                123456789);
+        assertEquals(LocalDateTime.of(2009, 1, 23, 0, 0, 0, 0),
+                functions.roundDownTimePart(localDateTime));
+    }
+
     public void testExpressionFunctions_roundUpTimePart_forUtilDate()
             throws Exception {
         StandardDialect dialect = new StandardDialect();
@@ -206,6 +218,63 @@ public class StandardDialectTest extends TestCase {
                 .valueOf("2009-12-31 00:00:00.000000000");
         assertEquals(Timestamp.valueOf("2010-01-01 00:00:00.000000000"),
                 functions.roundUpTimePart(timestamp));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDate()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDate localDate = LocalDate.of(2009, 1, 23);
+        assertEquals(LocalDate.of(2009, 1, 24),
+                functions.roundUpTimePart(localDate));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDate_endOfMonth()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDate localDate = LocalDate.of(2009, 3, 31);
+        assertEquals(LocalDate.of(2009, 4, 1),
+                functions.roundUpTimePart(localDate));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDate_endOfYear()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDate localDate = LocalDate.of(2009, 12, 31);
+        assertEquals(LocalDate.of(2010, 1, 1),
+                functions.roundUpTimePart(localDate));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDateTime()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDateTime localDateTime = LocalDateTime.of(2009, 1, 23, 12, 34, 56,
+                123456789);
+        assertEquals(LocalDateTime.of(2009, 1, 24, 0, 0, 0, 0),
+                functions.roundUpTimePart(localDateTime));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDateTime_endOfMonth()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDateTime localDateTime = LocalDateTime.of(2009, 3, 31, 12, 34, 56,
+                123456789);
+        assertEquals(LocalDateTime.of(2009, 4, 1, 0, 0, 0, 0),
+                functions.roundUpTimePart(localDateTime));
+    }
+
+    public void testExpressionFunctions_roundUpTimePart_forLocalDateTime_endOfYear()
+            throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        LocalDateTime localDateTime = LocalDateTime.of(2009, 12, 31, 12, 34, 56,
+                123456789);
+        assertEquals(LocalDateTime.of(2010, 1, 1, 0, 0, 0, 0),
+                functions.roundUpTimePart(localDateTime));
     }
 
     public void testExpressionFunctions_isEmpty() throws Exception {


### PR DESCRIPTION
組み込み関数の LocalDate, LocalDateTime 対応 をしてみました。
次の関数を追加しています。
* java.time.LocalDateTime @roundDownTimePart(java.time.LocalDateTime timestamp)
* java.time.LocalDate @roundUpTimePart(java.time.LocalDate date)
* java.time.LocalDateTime @roundUpTimePart(java.time.LocalDateTime date)

ありそうでなかったので作成してみました。