### PR TITLE
StandardExpressionFunctions#escapeがescapeCharを使用していない

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
+++ b/src/main/java/org/seasar/doma/jdbc/dialect/StandardDialect.java
@@ -915,8 +915,7 @@ public class StandardDialect implements Dialect {
             if (text == null) {
                 return null;
             }
-            return escapeWildcard(defaultWildcardReplacementPattern, text,
-                    defaultReplacement);
+            return escapeWildcard(text, escapeChar);
         }
 
         @Override
@@ -924,7 +923,8 @@ public class StandardDialect implements Dialect {
             if (text == null) {
                 return null;
             }
-            return escapeWildcard(text, escapeChar);
+            return escapeWildcard(defaultWildcardReplacementPattern, text,
+                    defaultReplacement);
         }
 
         @Override

--- a/src/test/java/org/seasar/doma/jdbc/dialect/StandardDialectTest.java
+++ b/src/test/java/org/seasar/doma/jdbc/dialect/StandardDialectTest.java
@@ -47,6 +47,24 @@ public class StandardDialectTest extends TestCase {
         assertEquals("bbb", dialect.removeQuote("bbb"));
     }
 
+    public void testExpressionFunctions_escape() throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        assertEquals("a$$a$%a$_", functions.escape("a$a%a_"));
+    }
+
+    public void testExpressionFunctions_escape_withExclamation() throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        assertEquals("a!!a!%a!_", functions.escape("a!a%a_", '!'));
+    }
+
+    public void testExpressionFunctions_escape_withBackslash() throws Exception {
+        StandardDialect dialect = new StandardDialect();
+        ExpressionFunctions functions = dialect.getExpressionFunctions();
+        assertEquals("a\\\\a\\%a\\_", functions.escape("a\\a%a_", '\\'));
+    }
+
     public void testExpressionFunctions_prefix() throws Exception {
         StandardDialect dialect = new StandardDialect();
         ExpressionFunctions functions = dialect.getExpressionFunctions();


### PR DESCRIPTION
`StandardExpressionFunctions#escape(String text, char escapeChar)` と `StandardExpressionFunctions#escape(String text)` の実装は逆なのではないでしょうか？
