### PR TITLE
設定ファイルから注釈処理のオプションを読み込めるように

### DIFF
--- a/docs/sources/annotation-processing.rst
+++ b/docs/sources/annotation-processing.rst
@@ -70,6 +70,10 @@ doma.version.validation
   （Domaのバージョンに互換性がある限りにおいて）。
   デフォルトの値は、 ``true`` 。
 
+doma.config.path
+  オプションの設定ファイルを置く場所の指定。
+  デフォルトの値は、 ``doma.compile.config``。
+
 Eclipse
 =======
 
@@ -90,3 +94,10 @@ Gradle
 
   compileJava.options.compilerArgs = ['-Adoma.dao.subpackage=impl', '-Adoma.dao.suffix=Impl']
 
+設定ファイル
+==========
+
+デフォルトでは ``main/resources/doma.compile.config`` ファイルにオプションを記述しておくことで、
+ビルドツールごとのオプションの設定を利用する必要がなくなります。
+記述形式はプロパティファイルと同様です。
+なお、設定がバッティングした場合、ビルドツールごとのオプションの設定が優先されます。

--- a/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -15,9 +15,19 @@
  */
 package org.seasar.doma.internal.apt;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
+import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 
 import org.seasar.doma.internal.Artifact;
 
@@ -47,12 +57,14 @@ public final class Options {
 
     public static final String VERSION_VALIDATION = "doma.version.validation";
 
+    public static final String CONFIG_PATH = "doma.config.path";
+
     public static final String LOMBOK_ALL_ARGS_CONSTRUCTOR = "doma.lombok.AllArgsConstructor";
 
     public static final String LOMBOK_VALUE = "doma.lombok.Value";
 
     public static boolean isTestEnabled(ProcessingEnvironment env) {
-        String test = env.getOptions().get(Options.TEST);
+        String test = getOption(env, Options.TEST);
         return Boolean.valueOf(test).booleanValue();
     }
 
@@ -71,27 +83,27 @@ public final class Options {
     }
 
     public static boolean isDebugEnabled(ProcessingEnvironment env) {
-        String debug = env.getOptions().get(Options.DEBUG);
+        String debug = getOption(env, Options.DEBUG);
         return Boolean.valueOf(debug).booleanValue();
     }
 
     public static String getDaoPackage(ProcessingEnvironment env) {
-        String pkg = env.getOptions().get(Options.DAO_PACKAGE);
+        String pkg = getOption(env, Options.DAO_PACKAGE);
         return pkg != null ? pkg : null;
     }
 
     public static String getDaoSubpackage(ProcessingEnvironment env) {
-        String subpackage = env.getOptions().get(Options.DAO_SUBPACKAGE);
+        String subpackage = getOption(env, Options.DAO_SUBPACKAGE);
         return subpackage != null ? subpackage : null;
     }
 
     public static String getDaoSuffix(ProcessingEnvironment env) {
-        String suffix = env.getOptions().get(Options.DAO_SUFFIX);
+        String suffix = getOption(env, Options.DAO_SUFFIX);
         return suffix != null ? suffix : Constants.DEFAULT_DAO_SUFFIX;
     }
 
     public static String getEntityFieldPrefix(ProcessingEnvironment env) {
-        String prefix = env.getOptions().get(Options.ENTITY_FIELD_PREFIX);
+        String prefix = getOption(env, Options.ENTITY_FIELD_PREFIX);
         if ("none".equalsIgnoreCase(prefix)) {
             return "";
         }
@@ -99,33 +111,82 @@ public final class Options {
     }
 
     public static String getExprFunctions(ProcessingEnvironment env) {
-        String name = env.getOptions().get(Options.EXPR_FUNCTIONS);
+        String name = getOption(env, Options.EXPR_FUNCTIONS);
         return name != null ? name : null;
     }
 
     public static String getDomainConverters(ProcessingEnvironment env) {
-        String converters = env.getOptions().get(Options.DOMAIN_CONVERTERS);
+        String converters = getOption(env, Options.DOMAIN_CONVERTERS);
         return converters != null ? converters : null;
     }
 
     public static boolean getSqlValidation(ProcessingEnvironment env) {
-        String v = env.getOptions().get(Options.SQL_VALIDATION);
+        String v = getOption(env, Options.SQL_VALIDATION);
         return v != null ? Boolean.valueOf(v).booleanValue() : true;
     }
 
     public static boolean getVersionValidation(ProcessingEnvironment env) {
-        String v = env.getOptions().get(Options.VERSION_VALIDATION);
+        String v = getOption(env, Options.VERSION_VALIDATION);
         return v != null ? Boolean.valueOf(v).booleanValue() : true;
     }
 
+    public static String getConfigPath(ProcessingEnvironment env) {
+        String configPath = env.getOptions().get(Options.CONFIG_PATH);
+        return configPath != null ? configPath : Constants.DEFAULT_CONFIG_PATH;
+    }
+
     public static String getLombokAllArgsConstructor(ProcessingEnvironment env) {
-        String name = env.getOptions().get(Options.LOMBOK_ALL_ARGS_CONSTRUCTOR);
+        String name = getOption(env, Options.LOMBOK_ALL_ARGS_CONSTRUCTOR);
         return name != null ? name : Constants.DEFAULT_LOMBOK_ALL_ARGS_CONSTRUCTOR;
     }
 
     public static String getLombokValue(ProcessingEnvironment env) {
-        String name = env.getOptions().get(Options.LOMBOK_VALUE);
+        String name = getOption(env, Options.LOMBOK_VALUE);
         return name != null ? name : Constants.DEFAULT_LOMBOK_VALUE;
+    }
+
+    private static String getOption(ProcessingEnvironment env, String key) {
+        String v = env.getOptions().get(key);
+        if (v != null) {
+            return v;
+        }
+
+        return getConfig(env).get(key);
+    }
+
+    private static Map<String, Map<String, String>> configCache = new HashMap<>();
+    private static Map<String, String> getConfig(ProcessingEnvironment env) {
+        FileObject config = getFileObject(env, "", getConfigPath(env));
+        if (config == null) {
+            return Collections.emptyMap();
+        }
+        return configCache.computeIfAbsent(config.toUri().getPath(), configPath -> {
+            try {
+                return loadProperties(config);
+            } catch (IOException e) {
+                return Collections.emptyMap();
+            }
+        });
+    }
+
+    public static FileObject getFileObject(ProcessingEnvironment env, String pkg, String relativeName) {
+        Filer filer = env.getFiler();
+
+        try {
+            return filer.getResource(StandardLocation.CLASS_OUTPUT, pkg, relativeName);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> loadProperties(FileObject config) throws IOException {
+        try (InputStream is = config.openInputStream();
+             InputStreamReader isr = new InputStreamReader(is, "UTF-8")){
+            Properties props = new Properties();
+            props.load(isr);
+            return (Map<String, String>) new HashMap(props);
+        }
     }
 
     protected static class Constants {
@@ -133,6 +194,8 @@ public final class Options {
         public static final String DEFAULT_DAO_SUFFIX = "Impl";
 
         public static final String DEFAULT_ENTITY_FIELD_PREFIX = "$";
+
+        public static final String DEFAULT_CONFIG_PATH = "doma.config";
 
         public static final String DEFAULT_LOMBOK_ALL_ARGS_CONSTRUCTOR = "lombok.AllArgsConstructor";
 

--- a/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -154,7 +155,7 @@ public final class Options {
         return getConfig(env).get(key);
     }
 
-    private static Map<String, Map<String, String>> configCache = new HashMap<>();
+    private static Map<String, Map<String, String>> configCache = new ConcurrentHashMap<>();
     private static Map<String, String> getConfig(ProcessingEnvironment env) {
         FileObject config = getFileObject(env, "", getConfigPath(env));
         if (config == null) {
@@ -169,7 +170,7 @@ public final class Options {
         });
     }
 
-    public static FileObject getFileObject(ProcessingEnvironment env, String pkg, String relativeName) {
+    private static FileObject getFileObject(ProcessingEnvironment env, String pkg, String relativeName) {
         Filer filer = env.getFiler();
 
         try {
@@ -195,7 +196,7 @@ public final class Options {
 
         public static final String DEFAULT_ENTITY_FIELD_PREFIX = "$";
 
-        public static final String DEFAULT_CONFIG_PATH = "doma.config";
+        public static final String DEFAULT_CONFIG_PATH = "doma.compile.config";
 
         public static final String DEFAULT_LOMBOK_ALL_ARGS_CONSTRUCTOR = "lombok.AllArgsConstructor";
 

--- a/src/test/java/org/seasar/doma/internal/apt/dao/DaoProcessorTest.java
+++ b/src/test/java/org/seasar/doma/internal/apt/dao/DaoProcessorTest.java
@@ -588,6 +588,17 @@ public class DaoProcessorTest extends AptTestCase {
         assertTrue(getCompiledResult());
     }
 
+    public void testSqlValidationSkipWhenOptionSpecifiedByConfigFile() throws Exception {
+        addOption("-Adoma.config.path=sql.validation.skip.config");
+        Class<?> target = SqlValidationSkipDao.class;
+        DaoProcessor processor = new DaoProcessor();
+        addProcessor(processor);
+        addCompilationUnit(target);
+        compile();
+        assertGeneratedSource(target);
+        assertTrue(getCompiledResult());
+    }
+
     public void testParameterizedParam() throws Exception {
         Class<?> target = ParameterizedParamDao.class;
         DaoProcessor processor = new DaoProcessor();

--- a/src/test/resources/org/seasar/doma/internal/apt/dao/DaoProcessorTest_SqlValidationSkipWhenOptionSpecifiedByConfigFile.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/dao/DaoProcessorTest_SqlValidationSkipWhenOptionSpecifiedByConfigFile.txt
@@ -1,0 +1,85 @@
+package org.seasar.doma.internal.apt.dao;
+
+/** */
+@javax.annotation.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+public class SqlValidationSkipDaoImpl extends org.seasar.doma.internal.jdbc.dao.AbstractDao implements org.seasar.doma.internal.apt.dao.SqlValidationSkipDao {
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.AbstractDao.getDeclaredMethod(org.seasar.doma.internal.apt.dao.SqlValidationSkipDao.class, "selectById", java.lang.String.class);
+
+    /** */
+    public SqlValidationSkipDaoImpl() {
+        super(new org.seasar.doma.internal.apt.dao.MyConfig());
+    }
+
+    /**
+     * @param connection the connection
+     */
+    public SqlValidationSkipDaoImpl(java.sql.Connection connection) {
+        super(new org.seasar.doma.internal.apt.dao.MyConfig(), connection);
+    }
+
+    /**
+     * @param dataSource the dataSource
+     */
+    public SqlValidationSkipDaoImpl(javax.sql.DataSource dataSource) {
+        super(new org.seasar.doma.internal.apt.dao.MyConfig(), dataSource);
+    }
+
+    /**
+     * @param config the configuration
+     */
+    protected SqlValidationSkipDaoImpl(org.seasar.doma.jdbc.Config config) {
+        super(config);
+    }
+
+    /**
+     * @param config the configuration
+     * @param connection the connection
+     */
+    protected SqlValidationSkipDaoImpl(org.seasar.doma.jdbc.Config config, java.sql.Connection connection) {
+        super(config, connection);
+    }
+
+    /**
+     * @param config the configuration
+     * @param dataSource the dataSource
+     */
+    protected SqlValidationSkipDaoImpl(org.seasar.doma.jdbc.Config config, javax.sql.DataSource dataSource) {
+        super(config, dataSource);
+    }
+
+    @Override
+    public java.lang.String selectById(java.lang.String name) {
+        entering("org.seasar.doma.internal.apt.dao.SqlValidationSkipDaoImpl", "selectById", name);
+        try {
+            org.seasar.doma.jdbc.query.SqlFileSelectQuery __query = getQueryImplementors().createSqlFileSelectQuery(__method0);
+            __query.setMethod(__method0);
+            __query.setConfig(__config);
+            __query.setSqlFilePath("META-INF/org/seasar/doma/internal/apt/dao/SqlValidationSkipDao/selectById.sql");
+            __query.addParameter("name", java.lang.String.class, name);
+            __query.setCallerClassName("org.seasar.doma.internal.apt.dao.SqlValidationSkipDaoImpl");
+            __query.setCallerMethodName("selectById");
+            __query.setResultEnsured(false);
+            __query.setResultMappingEnsured(false);
+            __query.setFetchType(org.seasar.doma.FetchType.LAZY);
+            __query.setQueryTimeout(-1);
+            __query.setMaxRows(-1);
+            __query.setFetchSize(-1);
+            __query.setSqlLogType(org.seasar.doma.jdbc.SqlLogType.FORMATTED);
+            __query.prepare();
+            org.seasar.doma.jdbc.command.SelectCommand<java.lang.String> __command = getCommandImplementors().createSelectCommand(__method0, __query, new org.seasar.doma.internal.jdbc.command.BasicSingleResultHandler<java.lang.String>(org.seasar.doma.wrapper.StringWrapper::new, false));
+            java.lang.String __result = __command.execute();
+            __query.complete();
+            exiting("org.seasar.doma.internal.apt.dao.SqlValidationSkipDaoImpl", "selectById", __result);
+            return __result;
+        } catch (java.lang.RuntimeException __e) {
+            throwing("org.seasar.doma.internal.apt.dao.SqlValidationSkipDaoImpl", "selectById", __e);
+            throw __e;
+        }
+    }
+
+}

--- a/src/test/resources/sql.validation.skip.config
+++ b/src/test/resources/sql.validation.skip.config
@@ -1,0 +1,1 @@
+doma.sql.validation=false


### PR DESCRIPTION
#190 の対応案です。

以下のように動くよう実装したつもりです。

* 注釈オプションに`doma.config.path`オプションを追加 (デフォルトは`doma.config`)
* デフォルトでは`main/resources/doma.config`に置かれた設定ファイルを読み込む

ひとまず実装だけしてみました。方向性はあっているでしょうか。
ご検討のほどよろしくお願いします。