### PR TITLE
Kotlin 1.1.2 を実験的にサポート

### DIFF
--- a/docs/sources/annotation-processing.rst
+++ b/docs/sources/annotation-processing.rst
@@ -55,6 +55,11 @@ doma.expr.functions
   ``org.seasar.doma.expr.ExpressionFunctions`` のサブタイプでなければいけない。
   デフォルトの値は、 ``org.seasar.doma.expr.ExpressionFunctions`` 。
 
+doma.resources.dir
+  SQLファイルなどリソースファイルの出力先ディレクトリ。
+  絶対パスで指定する。
+  指定しない場合はクラスファイルの出力先ディレクトリが使われる。
+
 doma.sql.validation
   SQLファイルの存在チェックとSQLコメントの文法チェックを行う場合は ``true`` 。
   行わない場合は ``false`` 。
@@ -95,7 +100,7 @@ Gradle
   compileJava.options.compilerArgs = ['-Adoma.dao.subpackage=impl', '-Adoma.dao.suffix=Impl']
 
 設定ファイル
-==========
+==================
 
 デフォルトでは ``main/resources/doma.compile.config`` ファイルにオプションを記述しておくことで、
 ビルドツールごとのオプションの設定を利用する必要がなくなります。

--- a/docs/sources/kotlin-support.rst
+++ b/docs/sources/kotlin-support.rst
@@ -5,7 +5,7 @@ Kotlin サポート
 .. contents:: 目次
    :depth: 3
 
-Doma は `Kotlin <https://kotlinlang.org/>`_ 1.0.6を実験的にサポートしています。
+Doma は `Kotlin <https://kotlinlang.org/>`_ 1.1.2を実験的にサポートしています。
 
 Kotlin利用のベストプラクティス
 ================================
@@ -60,16 +60,17 @@ Kotlin利用のベストプラクティス
 Daoインタフェース
 -------------------
 
+* KotlinではなくJavaで定義する
 * 更新処理の戻り値の型は `org.seasar.doma.jdbc.Result` や `org.seasar.doma.jdbc.BatchResult` を使う
 
 .. code-block:: java
 
-  @Dao(config = AppConfig::class)
-  interface PersonDao {
+  @Dao(config = AppConfig.class)
+  public interface PersonDao {
     @Select
-    fun selectById(id: Int): Person
+    Person selectById(Integer id);
     @Insert
-    fun insert(person: Person): Result<Person>
+    Result<Person> insert(Person person);
   }
 
 * 更新処理の戻り値を扱う際は `Destructuring Declarations <https://kotlinlang.org/docs/reference/multi-declarations.html>`_ を使う
@@ -94,10 +95,25 @@ Gradleでビルドする際は、確実な注釈処理が行われるように�
 
 Eclispeを利用する場合設定を適切に行えばJavaの注釈処理は自動で行われますが、kapt（Kotlinの注釈処理）はGradleを実行しない限り行われないことに注意してください。
 
+下記はbuild.gradleの抜粋です。コンパイル時にSQLファイルを参照するために下記の設定に特に注意してください。
+
+.. code-block:: groovy
+
+  // コンパイルより前にSQLファイルを出力先ディレクトリにコピーするために依存関係を逆転する
+  compileJava.dependsOn processResources
+  
+  // SQLファイルなどリソースファイルの出力先ディレクトリをkaptに伝える
+  kapt {
+      arguments {
+          arg("doma.resources.dir", processResources.destinationDir)
+      }
+  }
+
+
 JavaとKotlinの混在
 -------------------------
 
-kaptの不確実な挙動を避けるため、Domaに関するコードの全てもしくは一部をJavaで書くことは検討に値します。
+kaptの不確実な挙動を避けるため、Domaに関するコードの全てをJavaで書くことは検討に値します。
 Domaの利用において、JavaとKotlinの混在は問題ありません。
 
 サンプルプロジェクト

--- a/src/main/java/org/seasar/doma/internal/apt/DaoProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DaoProcessor.java
@@ -53,7 +53,8 @@ import org.seasar.doma.internal.apt.meta.TypeElementMetaFactory;
 @SupportedAnnotationTypes({ "org.seasar.doma.Dao" })
 @SupportedOptions({ Options.TEST, Options.DEBUG, Options.DAO_PACKAGE,
         Options.DAO_SUBPACKAGE, Options.DAO_SUFFIX, Options.EXPR_FUNCTIONS,
-        Options.SQL_VALIDATION, Options.VERSION_VALIDATION })
+        Options.SQL_VALIDATION, Options.VERSION_VALIDATION,
+        Options.RESOURCES_DIR })
 public class DaoProcessor extends AbstractGeneratingProcessor<DaoMeta> {
 
     public DaoProcessor() {

--- a/src/main/java/org/seasar/doma/internal/apt/DomainConvertersProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DomainConvertersProcessor.java
@@ -35,7 +35,7 @@ import org.seasar.doma.message.Message;
  * @since 1.25.0
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.DomainConverters" })
-@SupportedOptions({ Options.TEST, Options.DEBUG })
+@SupportedOptions({ Options.RESOURCES_DIR, Options.TEST, Options.DEBUG })
 public class DomainConvertersProcessor extends AbstractProcessor {
 
     public DomainConvertersProcessor() {

--- a/src/main/java/org/seasar/doma/internal/apt/DomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/DomainProcessor.java
@@ -32,7 +32,8 @@ import org.seasar.doma.internal.apt.meta.DomainMetaFactory;
  * 
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.Domain" })
-@SupportedOptions({ Options.VERSION_VALIDATION, Options.LOMBOK_VALUE,
+@SupportedOptions({ Options.VERSION_VALIDATION, Options.RESOURCES_DIR,
+        Options.LOMBOK_VALUE,
         Options.TEST, Options.DEBUG })
 public class DomainProcessor extends AbstractGeneratingProcessor<DomainMeta> {
 

--- a/src/main/java/org/seasar/doma/internal/apt/EmbeddableProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/EmbeddableProcessor.java
@@ -33,7 +33,8 @@ import org.seasar.doma.internal.apt.meta.EmbeddablePropertyMetaFactory;
  *
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.Embeddable" })
-@SupportedOptions({ Options.VERSION_VALIDATION, Options.LOMBOK_VALUE,
+@SupportedOptions({ Options.VERSION_VALIDATION, Options.RESOURCES_DIR,
+        Options.LOMBOK_VALUE,
         Options.LOMBOK_ALL_ARGS_CONSTRUCTOR, Options.TEST, Options.DEBUG })
 public class EmbeddableProcessor extends
         AbstractGeneratingProcessor<EmbeddableMeta> {

--- a/src/main/java/org/seasar/doma/internal/apt/EntityProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/EntityProcessor.java
@@ -34,7 +34,7 @@ import org.seasar.doma.internal.apt.meta.EntityPropertyMetaFactory;
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.Entity" })
 @SupportedOptions({ Options.ENTITY_FIELD_PREFIX, Options.DOMAIN_CONVERTERS,
-        Options.VERSION_VALIDATION, Options.LOMBOK_VALUE,
+        Options.VERSION_VALIDATION, Options.RESOURCES_DIR, Options.LOMBOK_VALUE,
         Options.LOMBOK_ALL_ARGS_CONSTRUCTOR, Options.TEST, Options.DEBUG })
 public class EntityProcessor extends AbstractGeneratingProcessor<EntityMeta> {
 

--- a/src/main/java/org/seasar/doma/internal/apt/ExternalDomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/ExternalDomainProcessor.java
@@ -32,7 +32,8 @@ import org.seasar.doma.internal.apt.meta.ExternalDomainMetaFactory;
  * 
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.ExternalDomain" })
-@SupportedOptions({ Options.VERSION_VALIDATION, Options.TEST, Options.DEBUG })
+@SupportedOptions({ Options.VERSION_VALIDATION, Options.RESOURCES_DIR,
+        Options.TEST, Options.DEBUG })
 public class ExternalDomainProcessor extends
         AbstractGeneratingProcessor<ExternalDomainMeta> {
 

--- a/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -25,12 +25,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.tools.FileObject;
-import javax.tools.StandardLocation;
 
 import org.seasar.doma.internal.Artifact;
+import org.seasar.doma.internal.apt.util.ResourceUtil;
 
 /**
  * @author taedium
@@ -59,6 +58,8 @@ public final class Options {
     public static final String VERSION_VALIDATION = "doma.version.validation";
 
     public static final String CONFIG_PATH = "doma.config.path";
+
+    public static final String RESOURCES_DIR = "doma.resources.dir";
 
     public static final String LOMBOK_ALL_ARGS_CONSTRUCTOR = "doma.lombok.AllArgsConstructor";
 
@@ -157,7 +158,7 @@ public final class Options {
 
     private static Map<String, Map<String, String>> configCache = new ConcurrentHashMap<>();
     private static Map<String, String> getConfig(ProcessingEnvironment env) {
-        FileObject config = getFileObject(env, "", getConfigPath(env));
+        FileObject config = getFileObject(env, getConfigPath(env));
         if (config == null) {
             return Collections.emptyMap();
         }
@@ -170,11 +171,10 @@ public final class Options {
         });
     }
 
-    private static FileObject getFileObject(ProcessingEnvironment env, String pkg, String relativeName) {
-        Filer filer = env.getFiler();
-
+    private static FileObject getFileObject(ProcessingEnvironment env,
+            String path) {
         try {
-            return filer.getResource(StandardLocation.CLASS_OUTPUT, pkg, relativeName);
+            return ResourceUtil.getResource(path, env);
         } catch (IOException e) {
             return null;
         }

--- a/src/main/java/org/seasar/doma/internal/apt/SingletonConfigProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/SingletonConfigProcessor.java
@@ -38,7 +38,7 @@ import org.seasar.doma.message.Message;
  * 
  */
 @SupportedAnnotationTypes({ "org.seasar.doma.SingletonConfig" })
-@SupportedOptions({ Options.TEST, Options.DEBUG })
+@SupportedOptions({ Options.RESOURCES_DIR, Options.TEST, Options.DEBUG })
 public class SingletonConfigProcessor extends AbstractProcessor {
 
     public SingletonConfigProcessor() {

--- a/src/main/java/org/seasar/doma/internal/apt/meta/AbstractSqlFileQueryMetaFactory.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/AbstractSqlFileQueryMetaFactory.java
@@ -23,17 +23,16 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.LinkedHashMap;
 
-import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.FileObject;
-import javax.tools.StandardLocation;
 
 import org.seasar.doma.internal.WrapException;
 import org.seasar.doma.internal.apt.AptException;
 import org.seasar.doma.internal.apt.Options;
 import org.seasar.doma.internal.apt.SqlValidator;
+import org.seasar.doma.internal.apt.util.ResourceUtil;
 import org.seasar.doma.internal.jdbc.sql.SqlParser;
 import org.seasar.doma.internal.jdbc.util.SqlFileUtil;
 import org.seasar.doma.internal.util.IOUtil;
@@ -136,9 +135,8 @@ public abstract class AbstractSqlFileQueryMetaFactory<M extends AbstractSqlFileQ
     }
 
     protected FileObject getFileObject(String path, ExecutableElement method) {
-        Filer filer = env.getFiler();
         try {
-            return filer.getResource(StandardLocation.CLASS_OUTPUT, "", path);
+            return ResourceUtil.getResource(path, env);
         } catch (IOException e) {
             throw new AptException(Message.DOMA4143, env, method, e,
                     new Object[] { path, e });

--- a/src/main/java/org/seasar/doma/internal/apt/meta/DaoMetaFactory.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/DaoMetaFactory.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
@@ -42,7 +41,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
-import javax.tools.StandardLocation;
 
 import org.seasar.doma.DaoMethod;
 import org.seasar.doma.SingletonConfig;
@@ -55,6 +53,7 @@ import org.seasar.doma.internal.apt.Options;
 import org.seasar.doma.internal.apt.mirror.AnnotateWithMirror;
 import org.seasar.doma.internal.apt.mirror.DaoMirror;
 import org.seasar.doma.internal.apt.util.ElementUtil;
+import org.seasar.doma.internal.apt.util.ResourceUtil;
 import org.seasar.doma.internal.apt.util.TypeMirrorUtil;
 import org.seasar.doma.internal.jdbc.util.SqlFileUtil;
 import org.seasar.doma.jdbc.Config;
@@ -391,9 +390,8 @@ public class DaoMetaFactory implements TypeElementMetaFactory<DaoMeta> {
     }
 
     protected FileObject getFileObject(String path) {
-        Filer filer = env.getFiler();
         try {
-            return filer.getResource(StandardLocation.CLASS_OUTPUT, "", path);
+            return ResourceUtil.getResource(path, env);
         } catch (Exception ignored) {
             // Ignore, in case the Filer implementation doesn't support
             // directory path.

--- a/src/main/java/org/seasar/doma/internal/apt/util/ResourceUtil.java
+++ b/src/main/java/org/seasar/doma/internal/apt/util/ResourceUtil.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal.apt.util;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import org.seasar.doma.internal.apt.Options;
+
+/**
+ * @author nakamura
+ *
+ */
+public class ResourceUtil {
+
+    public static FileObject getResource(String relativePath,
+            ProcessingEnvironment env) throws IOException {
+        assertNotNull(relativePath, env);
+        Map<String, String> options = env.getOptions();
+        String resourcesDir = options.get(Options.RESOURCES_DIR);
+        if (resourcesDir != null) {
+            Path path = Paths.get(resourcesDir, relativePath);
+            return new FileObjectImpl(path);
+        }
+        Filer filer = env.getFiler();
+        return filer.getResource(StandardLocation.CLASS_OUTPUT, "",
+                relativePath);
+    }
+
+    protected static class FileObjectImpl implements FileObject {
+
+        private final Path path;
+
+        public FileObjectImpl(Path path) {
+            this.path = path;
+        }
+
+        @Override
+        public URI toUri() {
+            return path.toUri();
+        }
+
+        @Override
+        public String getName() {
+            return path.toString();
+        }
+
+        @Override
+        public InputStream openInputStream() throws IOException {
+            return Files.newInputStream(path);
+        }
+
+        @Override
+        public OutputStream openOutputStream() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Reader openReader(boolean ignoreEncodingErrors)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Writer openWriter() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getLastModified() {
+            return 0L;
+        }
+
+        @Override
+        public boolean delete() {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/seasar/doma/internal/apt/util/ResourceUtilTest.java
+++ b/src/test/java/org/seasar/doma/internal/apt/util/ResourceUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-2010 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.doma.internal.apt.util;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.tools.FileObject;
+
+import junit.framework.TestCase;
+
+/**
+ * @author nakamura
+ *
+ */
+public class ResourceUtilTest extends TestCase {
+
+    public void testFileObjectImpl_toUri() throws Exception {
+        Path path = Paths.get("aaa", "bbb");
+        FileObject fileObject = new ResourceUtil.FileObjectImpl(path);
+        assertNotNull(fileObject.toUri());
+    }
+
+    public void testFileObjectImpl_getName() throws Exception {
+        Path path = Paths.get("aaa", "bbb");
+        FileObject fileObject = new ResourceUtil.FileObjectImpl(path);
+        assertNotNull(fileObject.getName());
+    }
+
+    public void testFileObjectImpl_openInputStream() throws Exception {
+        File file = File.createTempFile("aaa", null);
+        try {
+            FileObject fileObject = new ResourceUtil.FileObjectImpl(file.toPath());
+            try (InputStream is = fileObject.openInputStream()) {
+                is.read();
+            }
+        } finally {
+            file.delete();
+        }
+    }
+
+}


### PR DESCRIPTION
#177 以降Kotlin 1.0.6 で動作したが、1.1.2では次の問題が起き動作しなくなっていた。
- リソースファイルをクラスファイルの出力先にコピーしても削除されてしまい、注釈処理でSQLファイルが見つからない
- Kotlinで書いたDaoメソッドのパラメータ名が利用されずにJavaのスタブコードが生成されてしまうため、注釈処理でSQLファイルでのバインド変数チェックができない

上記の問題に対し次のように対処する。
- kaptでリソースファイルの出力先を明示的に渡せるようにする
- DaoはKotlinではなくJavaで定義したもののみをサポートする