### PR TITLE
ContextClassLoaderからだとClassが取得できなことがある問題を修正

### DIFF
--- a/src/main/java/org/seasar/doma/jdbc/ClassHelper.java
+++ b/src/main/java/org/seasar/doma/jdbc/ClassHelper.java
@@ -46,7 +46,11 @@ public interface ClassHelper {
             if (classLoader == null) {
                 return (Class<T>) Class.forName(className);
             } else {
-                return (Class<T>) classLoader.loadClass(className);
+                try {
+                    return (Class<T>) classLoader.loadClass(className);
+                } catch (ClassNotFoundException e) {
+                    return (Class<T>) Class.forName(className);
+                }
             }
         } catch (ClassNotFoundException e) {
             throw new WrapException(e);


### PR DESCRIPTION
#246 に対する修正

`classLoader.loadClass`だとClassが取得できない場合があるので、その場合は以前と同じように`Class.forName`でClassを取得するように修正しました。