### PR TITLE
Remove descriptions of Doma 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,19 @@ Major versions
 | -------------------------------------- | ----------------- | -------------------------------------- | ------ |
 | [Doma 1](http://doma.seasar.org/)      | stable            | https://github.com/seasarorg/doma/     | master |
 | [Doma 2](http://doma.readthedocs.org/) | stable            | https://github.com/domaframework/doma/ | master |
-| Doma 3                                 | under development | https://github.com/domaframework/doma/ | doma-3 |
 
 
 Compatibility matrix
 -------------------------
 
-|         | Doma 1 | Doma 2 | Doma 3 |
-| ------- | ------ | ------ | ------ |
-| Java 6  |   v    |        |        |
-| Java 7  |   v    |        |        |
-| Java 8  |   v    |   v    |        |
-| Java 9  |        |   v    |        |
-| Java 10 |        |   v    |        |
-| Java 11 |        |   v    |        |
+|         | Doma 1 | Doma 2 |
+| ------- | ------ | ------ |
+| Java 6  |   v    |        |
+| Java 7  |   v    |        |
+| Java 8  |   v    |   v    |
+| Java 9  |        |   v    |
+| Java 10 |        |   v    |
+| Java 11 |        |   v    |
 
 License
 -------


### PR DESCRIPTION
We will develop Doma 3 again if [JEP 326: Raw String Literals](https://openjdk.java.net/jeps/326) will be included in JDK.