### PR TITLE
Replace table aliases in the ORDER BY clause.

### DIFF
--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ElseNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ElseNode.java
@@ -14,6 +14,10 @@ public class ElseNode extends AbstractSqlNode implements SpaceStrippingNode {
     this.text = text;
   }
 
+  public String getText() {
+    return text;
+  }
+
   @Override
   public void clearChildren() {
     children.clear();

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ElseifNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ElseifNode.java
@@ -28,6 +28,10 @@ public class ElseifNode extends AbstractSqlNode implements SpaceStrippingNode {
     return expression;
   }
 
+  public String getText() {
+    return text;
+  }
+
   @Override
   public void clearChildren() {
     children.clear();

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/EndNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/EndNode.java
@@ -11,6 +11,10 @@ public class EndNode extends AbstractSqlNode implements SpaceStrippingNode {
     this.text = text;
   }
 
+  public String getText() {
+    return text;
+  }
+
   @Override
   public void clearChildren() {
     children.clear();

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ForNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/ForNode.java
@@ -35,6 +35,10 @@ public class ForNode extends AbstractSqlNode implements SpaceStrippingNode {
     return expression;
   }
 
+  public String getText() {
+    return text;
+  }
+
   @Override
   public void clearChildren() {
     children.clear();

--- a/src/main/java/org/seasar/doma/internal/jdbc/sql/node/IfNode.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/sql/node/IfNode.java
@@ -28,6 +28,10 @@ public class IfNode extends AbstractSqlNode implements SpaceStrippingNode {
     return expression;
   }
 
+  public String getText() {
+    return text;
+  }
+
   @Override
   public void clearChildren() {
     children.clear();

--- a/src/test/java/org/seasar/doma/internal/jdbc/dialect/StandardPagingTransformerTest.java
+++ b/src/test/java/org/seasar/doma/internal/jdbc/dialect/StandardPagingTransformerTest.java
@@ -3,15 +3,16 @@ package org.seasar.doma.internal.jdbc.dialect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import org.seasar.doma.internal.expr.ExpressionEvaluator;
+import org.seasar.doma.internal.expr.Value;
 import org.seasar.doma.internal.jdbc.mock.MockConfig;
 import org.seasar.doma.internal.jdbc.sql.NodePreparedSqlBuilder;
 import org.seasar.doma.internal.jdbc.sql.SqlParser;
-import org.seasar.doma.jdbc.JdbcException;
-import org.seasar.doma.jdbc.PreparedSql;
-import org.seasar.doma.jdbc.SqlKind;
-import org.seasar.doma.jdbc.SqlNode;
+import org.seasar.doma.jdbc.*;
 import org.seasar.doma.message.Message;
 
 public class StandardPagingTransformerTest {
@@ -25,6 +26,38 @@ public class StandardPagingTransformerTest {
     SqlNode sqlNode = transformer.transform(parser.parse());
     NodePreparedSqlBuilder sqlBuilder =
         new NodePreparedSqlBuilder(new MockConfig(), SqlKind.SELECT, "dummyPath");
+    PreparedSql sql = sqlBuilder.build(sqlNode, Function.identity());
+    assertEquals(expected, sql.getRawSql());
+  }
+
+  @Test
+  public void testOffsetLimit_ifNode() throws Exception {
+    String expected =
+        "select * from ( select temp_.*, row_number() over( order by temp_.name desc, temp_.id ) as doma_rownumber_ from ( select emp.id from emp ) as temp_ ) as temp2_ where doma_rownumber_ > 5 and doma_rownumber_ <= 15";
+    StandardPagingTransformer transformer = new StandardPagingTransformer(5, 10);
+    SqlParser parser =
+        new SqlParser("select emp.id from emp order by /*%if true*/emp.name desc,/*%end*/ emp.id");
+    SqlNode sqlNode = transformer.transform(parser.parse());
+    NodePreparedSqlBuilder sqlBuilder =
+        new NodePreparedSqlBuilder(new MockConfig(), SqlKind.SELECT, "dummyPath");
+    PreparedSql sql = sqlBuilder.build(sqlNode, Function.identity());
+    assertEquals(expected, sql.getRawSql());
+  }
+
+  @Test
+  public void testOffsetLimit_forNode() throws Exception {
+    String expected =
+        "select * from ( select temp_.*, row_number() over( order by temp_.name1, temp_.name2, temp_.id ) as doma_rownumber_ from ( select emp.id from emp ) as temp_ ) as temp2_ where doma_rownumber_ > 5 and doma_rownumber_ <= 15";
+    StandardPagingTransformer transformer = new StandardPagingTransformer(5, 10);
+    SqlParser parser =
+        new SqlParser(
+            "select emp.id from emp order by /*%for e: values*/emp.name/*#e*/, /*%end*/emp.id");
+    SqlNode sqlNode = transformer.transform(parser.parse());
+    ExpressionEvaluator evaluator = new ExpressionEvaluator();
+    evaluator.add("values", new Value(List.class, Arrays.asList(1, 2)));
+    NodePreparedSqlBuilder sqlBuilder =
+        new NodePreparedSqlBuilder(
+            new MockConfig(), SqlKind.SELECT, "dummyPath", evaluator, SqlLogType.FORMATTED);
     PreparedSql sql = sqlBuilder.build(sqlNode, Function.identity());
     assertEquals(expected, sql.getRawSql());
   }


### PR DESCRIPTION
We replace the aliases even if they are inside condition or loop directives.
Close #327.