### PR TITLE
Add default constructor to AbstractDao for CDI

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplGenerator.java
+++ b/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplGenerator.java
@@ -121,6 +121,7 @@ public class DaoImplGenerator extends AbstractGenerator {
         printAnnotatedConstructor();
       }
     } else {
+      printNoArgDummyConstructor();
       printAnnotatedConstructor();
     }
   }
@@ -146,6 +147,14 @@ public class DaoImplGenerator extends AbstractGenerator {
             p.print("%1$s.%2$s()", type, method);
           }
         });
+  }
+
+  private void printNoArgDummyConstructor() {
+    iprint("/** Dummy constructor for CDI */%n");
+    iprint("public %1$s() {%n", simpleName);
+    iprint("    super();%n");
+    iprint("}%n");
+    print("%n");
   }
 
   private void printNoArgConstructor(Code configCode) {

--- a/src/main/java/org/seasar/doma/internal/jdbc/dao/AbstractDao.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/dao/AbstractDao.java
@@ -19,6 +19,11 @@ public abstract class AbstractDao implements ConfigProvider {
 
   protected final Config __config;
 
+  // Dummy constructor for CDI
+  protected AbstractDao() {
+    this.__config = null;
+  }
+
   protected AbstractDao(Config config) {
     if (config == null) {
       throw new DomaNullPointerException("config");

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AnnotateWithDao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AnnotateWithDao.txt
@@ -12,6 +12,11 @@ public class AnnotateWithDaoImpl extends org.seasar.doma.internal.jdbc.dao.Abstr
 
     private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.AbstractDao.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AnnotateWithDao.class, "insert", org.seasar.doma.internal.apt.processor.entity.Emp.class);
 
+    /** Dummy constructor for CDI */
+    public AnnotateWithDaoImpl() {
+        super();
+    }
+
     /**
      * @param config the config
      */

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AnnotationConfigDao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AnnotationConfigDao.txt
@@ -12,6 +12,11 @@ public class AnnotationConfigDaoImpl extends org.seasar.doma.internal.jdbc.dao.A
 
     private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.AbstractDao.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AnnotationConfigDao.class, "insert", org.seasar.doma.internal.apt.processor.entity.Emp.class);
 
+    /** Dummy constructor for CDI */
+    public AnnotationConfigDaoImpl() {
+        super();
+    }
+
     /**
      * @param config the config
      */

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_Issue214Dao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_Issue214Dao.txt
@@ -10,6 +10,11 @@ public class Issue214DaoImpl extends org.seasar.doma.internal.jdbc.dao.AbstractD
 
     private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.AbstractDao.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.Issue214Dao.class, "select", org.seasar.doma.internal.apt.processor.dao.Issue214Entity.class);
 
+    /** Dummy constructor for CDI */
+    public Issue214DaoImpl() {
+        super();
+    }
+
     /**
      * @param config the config
      */

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_NoConfigDao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_NoConfigDao.txt
@@ -10,6 +10,11 @@ public class NoConfigDaoImpl extends org.seasar.doma.internal.jdbc.dao.AbstractD
 
     private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.AbstractDao.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.NoConfigDao.class, "insert", org.seasar.doma.internal.apt.processor.entity.Emp.class);
 
+    /** Dummy constructor for CDI */
+    public NoConfigDaoImpl() {
+        super();
+    }
+
     /**
      * @param config the config
      */


### PR DESCRIPTION
This is the necessary change for CDI that I am thinking of. However, it doesn't work. Use it if you can.

Reading the jar that I built myself didn't work, so I don't think a compilation environment has been created.