### PR TITLE
Support ApplicationScoped and Dependent annotations for Quarkus.

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -46,6 +46,10 @@ public final class Options {
 
   public static final String LOMBOK_VALUE = "doma.lombok.Value";
 
+  public static final String CDI_APPLICATION_SCOPED = "doma.cdi.ApplicationScoped";
+
+  public static final String CDI_DEPENDENT = "doma.cdi.Dependent";
+
   private final Context ctx;
 
   private final Map<String, String> options;
@@ -134,6 +138,16 @@ public final class Options {
     return name != null ? name : Constants.DEFAULT_LOMBOK_VALUE;
   }
 
+  public String getCdiApplicationScoped() {
+    String name = getOption(CDI_APPLICATION_SCOPED);
+    return name != null ? name : Constants.DEFAULT_CDI_APPLICATION_SCOPED;
+  }
+
+  public String getCdiDependent() {
+    String name = getOption(CDI_DEPENDENT);
+    return name != null ? name : Constants.DEFAULT_CDI_DEPENDENT;
+  }
+
   private String getOption(String key) {
     String v = options.get(key);
     if (v != null) {
@@ -190,5 +204,10 @@ public final class Options {
     public static final String DEFAULT_LOMBOK_ALL_ARGS_CONSTRUCTOR = "lombok.AllArgsConstructor";
 
     public static final String DEFAULT_LOMBOK_VALUE = "lombok.Value";
+
+    public static final String DEFAULT_CDI_APPLICATION_SCOPED =
+        "javax.enterprise.context.ApplicationScoped";
+
+    public static final String DEFAULT_CDI_DEPENDENT = "javax.enterprise.context.Dependent";
   }
 }

--- a/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
@@ -32,7 +32,9 @@ import org.seasar.doma.internal.util.ClassUtil;
   Options.SQL_VALIDATION,
   Options.VERSION_VALIDATION,
   Options.RESOURCES_DIR,
-  Options.CONFIG_PATH
+  Options.CONFIG_PATH,
+  Options.CDI_APPLICATION_SCOPED,
+  Options.CDI_DEPENDENT
 })
 public class DaoProcessor extends AbstractGeneratingProcessor<DaoMeta> {
 

--- a/src/main/java/org/seasar/doma/internal/jdbc/dao/AbstractDao.java
+++ b/src/main/java/org/seasar/doma/internal/jdbc/dao/AbstractDao.java
@@ -17,7 +17,7 @@ import org.seasar.doma.jdbc.QueryImplementors;
 
 public abstract class AbstractDao implements ConfigProvider {
 
-  protected final Config __config;
+  protected Config __config;
 
   protected AbstractDao() {
     __config = null;

--- a/src/test/java/org/seasar/doma/internal/apt/cdi/ApplicationScoped.java
+++ b/src/test/java/org/seasar/doma/internal/apt/cdi/ApplicationScoped.java
@@ -1,0 +1,8 @@
+package org.seasar.doma.internal.apt.cdi;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Target;
+
+@Target(value = {TYPE})
+public @interface ApplicationScoped {}

--- a/src/test/java/org/seasar/doma/internal/apt/cdi/Dependent.java
+++ b/src/test/java/org/seasar/doma/internal/apt/cdi/Dependent.java
@@ -1,0 +1,8 @@
+package org.seasar.doma.internal.apt.cdi;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Target;
+
+@Target(value = {TYPE})
+public @interface Dependent {}

--- a/src/test/java/org/seasar/doma/internal/apt/processor/dao/ApplicationScopedDao.java
+++ b/src/test/java/org/seasar/doma/internal/apt/processor/dao/ApplicationScopedDao.java
@@ -1,0 +1,12 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+import org.seasar.doma.AnnotateWith;
+import org.seasar.doma.Annotation;
+import org.seasar.doma.AnnotationTarget;
+import org.seasar.doma.Dao;
+import org.seasar.doma.internal.apt.cdi.ApplicationScoped;
+
+@Dao
+@AnnotateWith(
+    annotations = {@Annotation(target = AnnotationTarget.CLASS, type = ApplicationScoped.class)})
+public interface ApplicationScopedDao {}

--- a/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
+++ b/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
@@ -18,6 +18,8 @@ import org.seasar.doma.internal.apt.CompilerSupport;
 import org.seasar.doma.internal.apt.GeneratedClassNameParameterResolver;
 import org.seasar.doma.internal.apt.ResourceParameterResolver;
 import org.seasar.doma.internal.apt.SimpleParameterResolver;
+import org.seasar.doma.internal.apt.cdi.ApplicationScoped;
+import org.seasar.doma.internal.apt.cdi.Dependent;
 import org.seasar.doma.internal.apt.processor.DaoProcessor;
 import org.seasar.doma.message.Message;
 
@@ -124,7 +126,12 @@ class DaoProcessorTest extends CompilerSupport {
           invocationContext(ResultStreamDao.class),
           invocationContext(PlainSingletonConfigDao.class),
           invocationContext(SqlProcessorDao.class),
-          invocationContext(OnlyDefaultMethodsExtendsDao.class));
+          invocationContext(OnlyDefaultMethodsExtendsDao.class),
+          invocationContext(
+              ApplicationScopedDao.class,
+              "-Adoma.cdi.ApplicationScoped=" + ApplicationScoped.class.getCanonicalName()),
+          invocationContext(
+              DependentDao.class, "-Adoma.cdi.Dependent=" + Dependent.class.getName()));
     }
 
     private TestTemplateInvocationContext invocationContext(Class<?> clazz, String... options) {

--- a/src/test/java/org/seasar/doma/internal/apt/processor/dao/DependentDao.java
+++ b/src/test/java/org/seasar/doma/internal/apt/processor/dao/DependentDao.java
@@ -1,0 +1,11 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+import org.seasar.doma.AnnotateWith;
+import org.seasar.doma.Annotation;
+import org.seasar.doma.AnnotationTarget;
+import org.seasar.doma.Dao;
+import org.seasar.doma.internal.apt.cdi.Dependent;
+
+@Dao
+@AnnotateWith(annotations = {@Annotation(target = AnnotationTarget.CLASS, type = Dependent.class)})
+public interface DependentDao {}

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_ApplicationScopedDao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_ApplicationScopedDao.txt
@@ -1,0 +1,23 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+/** */
+@org.seasar.doma.internal.apt.cdi.ApplicationScoped()
+@javax.annotation.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+public class ApplicationScopedDaoImpl extends org.seasar.doma.internal.jdbc.dao.AbstractDao implements org.seasar.doma.internal.apt.processor.dao.ApplicationScopedDao {
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    /** */
+    ApplicationScopedDaoImpl() {
+    }
+
+    /**
+     * @param config the config
+     */
+    public ApplicationScopedDaoImpl(org.seasar.doma.jdbc.Config config) {
+        super(config);
+    }
+
+}

--- a/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_DependentDao.txt
+++ b/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_DependentDao.txt
@@ -1,0 +1,23 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+/** */
+@org.seasar.doma.internal.apt.cdi.Dependent()
+@javax.annotation.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+public class DependentDaoImpl extends org.seasar.doma.internal.jdbc.dao.AbstractDao implements org.seasar.doma.internal.apt.processor.dao.DependentDao {
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    /** */
+    DependentDaoImpl() {
+    }
+
+    /**
+     * @param config the config
+     */
+    public DependentDaoImpl(org.seasar.doma.jdbc.Config config) {
+        super(config);
+    }
+
+}


### PR DESCRIPTION
Quarkus needs a no-args constructor. See https://quarkus.io/blog/quarkus-dependency-injection/