### PR TITLE
Fixed that schema name was not used.

### DIFF
--- a/src/main/java/org/seasar/doma/internal/apt/meta/id/SequenceIdGeneratorMeta.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/id/SequenceIdGeneratorMeta.java
@@ -20,7 +20,7 @@ public class SequenceIdGeneratorMeta implements IdGeneratorMeta {
       buf.append(catalogName);
       buf.append(".");
     }
-    String schemaName = sequenceGeneratorAnnot.getCatalogValue();
+    String schemaName = sequenceGeneratorAnnot.getSchemaValue();
     if (!schemaName.isEmpty()) {
       buf.append(schemaName);
       buf.append(".");


### PR DESCRIPTION
The schema parameter of @SequenceGenerator annotation is not used.
Catalog names are used instead of schema names.

Expect:
```sql
select nextval('catalog.schema.my_sequence');
```

Actual:
```sql
select nextval('catalog.catalog.my_sequence');
```
