### PR TITLE
Fix broken link in document

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -89,7 +89,7 @@ Visit the webpage served at http://127.0.0.1:8000.
 
 
 .. _google-java-format: https://github.com/google/google-java-format
-.. _google-java-format IntelliJ plugin: https://github.com/google/google-java-format#intellij
+.. _google-java-format IntelliJ plugin: https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides
 .. _google-java-format Eclipse plugin: https://github.com/google/google-java-format#eclipse
 .. _Spotless: https://github.com/diffplug/spotless
 .. _Travis CI: http://docs.travis-ci.com/


### PR DESCRIPTION
Fixed broken link in document.
Cause was this commit: https://github.com/google/google-java-format/commit/dc8f413b1154c7c984942294ce3ddfaaf40099b3