### PR TITLE
Add the DataType annotation

### DIFF
--- a/docs/domain.rst
+++ b/docs/domain.rst
@@ -59,6 +59,23 @@ The value ``new`` means that the object of annotated class is created with a con
 
 .. _records: https://openjdk.java.net/jeps/359
 
+.. warning::
+
+  To annotate records with ``@Domain`` is a little redundant,
+  because you must specify some properties to ``@Domain`` such as ``valueType``.
+  Instead of ``@Domain``, you can annotate records with ``@DataType``:
+
+  .. code-block:: java
+
+    @DataType
+    public record PhoneNumber(String value) {
+      public String getAreaCode() {
+        ...
+      }
+    }
+
+  But note that ``@DataType`` is an experimental feature.
+
 
 Instantiation with a static factory method
 ------------------------------------------

--- a/src/main/java/org/seasar/doma/experimental/DataType.java
+++ b/src/main/java/org/seasar/doma/experimental/DataType.java
@@ -1,0 +1,24 @@
+package org.seasar.doma.experimental;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates a data type (aka domain class).
+ *
+ * <p>The data type is the user defined type that wraps a basic value. It can be mapped to a
+ * database column.
+ *
+ * <p>This annotation is applied for only record types.
+ *
+ * <pre>
+ * &#064;DataType
+ * public record PhoneNumber(String value) {
+ * }
+ * </pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DataType {}

--- a/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -5,10 +5,26 @@ import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import java.io.Writer;
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.*;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.Parameterizable;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -16,6 +32,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleElementVisitor8;
 import org.seasar.doma.ParameterName;
 import org.seasar.doma.internal.apt.def.TypeParametersDef;
+import org.seasar.doma.internal.apt.util.ElementKindUtil;
 
 public class MoreElements implements Elements {
 
@@ -266,5 +283,17 @@ public class MoreElements implements Elements {
     List<TypeMirror> typeMirrors =
         typeParameterElements.stream().map(TypeParameterElement::asType).collect(toList());
     return ctx.getMoreTypes().getTypeParameterNames(typeMirrors);
+  }
+
+  public VariableElement getSingleParameterOfRecordConstructor(TypeElement record) {
+    if (!ElementKindUtil.isRecord(record.getKind())) {
+      throw new AptIllegalStateException(record.getQualifiedName() + " must be a record type.");
+    }
+    return ElementFilter.constructorsIn(record.getEnclosedElements()).stream()
+        .filter(c -> c.getModifiers().contains(Modifier.PUBLIC))
+        .filter(c -> c.getParameters().size() == 1)
+        .flatMap(c -> c.getParameters().stream())
+        .findFirst()
+        .orElse(null);
   }
 }

--- a/src/main/java/org/seasar/doma/internal/apt/annot/Annotations.java
+++ b/src/main/java/org/seasar/doma/internal/apt/annot/Annotations.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import javax.lang.model.element.*;
 import org.seasar.doma.*;
+import org.seasar.doma.experimental.DataType;
 import org.seasar.doma.experimental.Sql;
 import org.seasar.doma.internal.apt.Context;
 import org.seasar.doma.internal.apt.util.AnnotationValueUtil;
@@ -98,6 +99,11 @@ public class Annotations {
   public DaoAnnot newDaoAnnot(TypeElement typeElement) {
     assertNotNull(typeElement);
     return newInstance(typeElement, Dao.class, DaoAnnot::new);
+  }
+
+  public DataTypeAnnot newDataTypeAnnot(TypeElement typeElement) {
+    assertNotNull(typeElement);
+    return newInstance(typeElement, DataType.class, DataTypeAnnot::new);
   }
 
   public DomainAnnot newDomainAnnot(TypeElement typeElement) {

--- a/src/main/java/org/seasar/doma/internal/apt/annot/DataTypeAnnot.java
+++ b/src/main/java/org/seasar/doma/internal/apt/annot/DataTypeAnnot.java
@@ -1,0 +1,12 @@
+package org.seasar.doma.internal.apt.annot;
+
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+
+public class DataTypeAnnot extends AbstractAnnot {
+
+  DataTypeAnnot(AnnotationMirror annotationMirror, Map<String, AnnotationValue> values) {
+    super(annotationMirror);
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
@@ -45,6 +46,7 @@ import javax.lang.model.util.SimpleTypeVisitor8;
 import org.seasar.doma.Domain;
 import org.seasar.doma.Embeddable;
 import org.seasar.doma.Entity;
+import org.seasar.doma.experimental.DataType;
 import org.seasar.doma.internal.ClassName;
 import org.seasar.doma.internal.ClassNames;
 import org.seasar.doma.internal.apt.AptException;
@@ -229,6 +231,10 @@ public class CtTypes {
     if (domain != null) {
       return getDomainInfo(domain);
     }
+    DataType dataType = typeElement.getAnnotation(DataType.class);
+    if (dataType != null) {
+      return getDomainInfo(typeElement, dataType);
+    }
     return getExternalDomainInfo(typeElement.asType());
   }
 
@@ -239,6 +245,15 @@ public class CtTypes {
       return new DomainInfo(e.getTypeMirror(), false);
     }
     throw new AptIllegalStateException("unreachable.");
+  }
+
+  private DomainInfo getDomainInfo(TypeElement typeElement, DataType dataType) {
+    VariableElement param =
+        ctx.getMoreElements().getSingleParameterOfRecordConstructor(typeElement);
+    if (param == null) {
+      throw new AptIllegalStateException(typeElement.getQualifiedName().toString());
+    }
+    return new DomainInfo(param.asType(), false);
   }
 
   private DomainInfo getExternalDomainInfo(TypeMirror domainType) {

--- a/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMeta.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMeta.java
@@ -1,0 +1,108 @@
+package org.seasar.doma.internal.apt.meta.domain;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.util.List;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import org.seasar.doma.internal.apt.annot.DataTypeAnnot;
+import org.seasar.doma.internal.apt.cttype.BasicCtType;
+import org.seasar.doma.internal.apt.def.TypeParametersDef;
+
+public class DataTypeMeta implements DomainMeta {
+
+  private final TypeElement typeElement;
+
+  private final TypeMirror type;
+
+  private final DataTypeAnnot dataTypeAnnot;
+
+  private TypeParametersDef typeParametersDef;
+
+  private BasicCtType basicCtType;
+
+  private String accessorMethod;
+
+  public DataTypeMeta(TypeElement typeElement, TypeMirror type, DataTypeAnnot dataTypeAnnot) {
+    assertNotNull(typeElement, type);
+    this.typeElement = typeElement;
+    this.type = type;
+    this.dataTypeAnnot = dataTypeAnnot;
+  }
+
+  @Override
+  public TypeMirror getType() {
+    return type;
+  }
+
+  @Override
+  public TypeElement getTypeElement() {
+    return typeElement;
+  }
+
+  public DataTypeAnnot getDataTypeAnnot() {
+    return dataTypeAnnot;
+  }
+
+  @Override
+  public String getFactoryMethod() {
+    return "new";
+  }
+
+  @Override
+  public String getAccessorMethod() {
+    return accessorMethod;
+  }
+
+  public void setAccessorMethod(String accessorMethod) {
+    this.accessorMethod = accessorMethod;
+  }
+
+  @Override
+  public boolean getAcceptNull() {
+    return false;
+  }
+
+  @Override
+  public boolean providesConstructor() {
+    return true;
+  }
+
+  @Override
+  public List<String> getTypeParameters() {
+    return typeParametersDef.getTypeParameters();
+  }
+
+  public void setTypeParametersDef(TypeParametersDef typeParametersDef) {
+    this.typeParametersDef = typeParametersDef;
+  }
+
+  @Override
+  public List<String> getTypeVariables() {
+    return typeParametersDef.getTypeVariables();
+  }
+
+  @Override
+  public BasicCtType getBasicCtType() {
+    return basicCtType;
+  }
+
+  public void setBasicCtType(BasicCtType basicCtType) {
+    this.basicCtType = basicCtType;
+  }
+
+  @Override
+  public TypeMirror getValueType() {
+    return basicCtType.getType();
+  }
+
+  @Override
+  public boolean isParameterized() {
+    return !typeElement.getTypeParameters().isEmpty();
+  }
+
+  @Override
+  public boolean isError() {
+    return false;
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMetaFactory.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMetaFactory.java
@@ -1,0 +1,103 @@
+package org.seasar.doma.internal.apt.meta.domain;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import org.seasar.doma.internal.Constants;
+import org.seasar.doma.internal.apt.AptException;
+import org.seasar.doma.internal.apt.AptIllegalStateException;
+import org.seasar.doma.internal.apt.Context;
+import org.seasar.doma.internal.apt.annot.DataTypeAnnot;
+import org.seasar.doma.internal.apt.cttype.BasicCtType;
+import org.seasar.doma.internal.apt.def.TypeParametersDef;
+import org.seasar.doma.internal.apt.meta.TypeElementMetaFactory;
+import org.seasar.doma.internal.apt.util.ElementKindUtil;
+import org.seasar.doma.message.Message;
+
+public class DataTypeMetaFactory implements TypeElementMetaFactory<DataTypeMeta> {
+
+  private final Context ctx;
+
+  public DataTypeMetaFactory(Context ctx) {
+    assertNotNull(ctx);
+    this.ctx = ctx;
+  }
+
+  @Override
+  public DataTypeMeta createTypeElementMeta(TypeElement typeElement) {
+    assertNotNull(typeElement);
+    DataTypeAnnot dataTypeAnnot = ctx.getAnnotations().newDataTypeAnnot(typeElement);
+    if (dataTypeAnnot == null) {
+      throw new AptIllegalStateException("dataTypeAnnot");
+    }
+    DataTypeMeta dataTypeMeta = new DataTypeMeta(typeElement, typeElement.asType(), dataTypeAnnot);
+    validateTypeElement(typeElement, dataTypeMeta);
+    doTypeParameters(typeElement, dataTypeMeta);
+    doValueType(typeElement, dataTypeMeta);
+    return dataTypeMeta;
+  }
+
+  private void validateTypeElement(TypeElement typeElement, DataTypeMeta dataTypeMeta) {
+    if (!ElementKindUtil.isRecord(typeElement.getKind())) {
+      throw new AptException(Message.DOMA4449, typeElement, new Object[] {});
+    }
+    if (typeElement.getNestingKind().isNested()) {
+      validateEnclosingElement(typeElement);
+    }
+  }
+
+  void validateEnclosingElement(Element element) {
+    TypeElement typeElement = ctx.getMoreElements().toTypeElement(element);
+    if (typeElement == null) {
+      return;
+    }
+    String simpleName = typeElement.getSimpleName().toString();
+    if (simpleName.contains(Constants.BINARY_NAME_DELIMITER)
+        || simpleName.contains(Constants.DESC_NAME_DELIMITER)) {
+      throw new AptException(
+          Message.DOMA4450, typeElement, new Object[] {typeElement.getQualifiedName()});
+    }
+    NestingKind nestingKind = typeElement.getNestingKind();
+    if (nestingKind == NestingKind.TOP_LEVEL) {
+      return;
+    } else if (nestingKind == NestingKind.MEMBER) {
+      Set<Modifier> modifiers = typeElement.getModifiers();
+      if (modifiers.containsAll(Arrays.asList(Modifier.STATIC, Modifier.PUBLIC))) {
+        validateEnclosingElement(typeElement.getEnclosingElement());
+      } else {
+        throw new AptException(
+            Message.DOMA4451, typeElement, new Object[] {typeElement.getQualifiedName()});
+      }
+    } else {
+      throw new AptException(
+          Message.DOMA4452, typeElement, new Object[] {typeElement.getQualifiedName()});
+    }
+  }
+
+  public void doTypeParameters(TypeElement typeElement, DataTypeMeta dataTypeMeta) {
+    TypeParametersDef typeParametersDef = ctx.getMoreElements().getTypeParametersDef(typeElement);
+    dataTypeMeta.setTypeParametersDef(typeParametersDef);
+  }
+
+  private void doValueType(TypeElement typeElement, DataTypeMeta dataTypeMeta) {
+    VariableElement param =
+        ctx.getMoreElements().getSingleParameterOfRecordConstructor(typeElement);
+    if (param == null) {
+      throw new AptException(Message.DOMA4453, typeElement, new Object[] {});
+    }
+    TypeMirror type = param.asType();
+    BasicCtType basicCtType = ctx.getCtTypes().newBasicCtType(type);
+    if (basicCtType == null) {
+      throw new AptException(Message.DOMA4454, param, new Object[] {type});
+    }
+    dataTypeMeta.setBasicCtType(basicCtType);
+    dataTypeMeta.setAccessorMethod(param.getSimpleName().toString());
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/meta/domain/DomainMeta.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/domain/DomainMeta.java
@@ -1,95 +1,31 @@
 package org.seasar.doma.internal.apt.meta.domain;
 
-import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
-
 import java.util.List;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import org.seasar.doma.internal.apt.annot.DomainAnnot;
 import org.seasar.doma.internal.apt.cttype.BasicCtType;
-import org.seasar.doma.internal.apt.def.TypeParametersDef;
 import org.seasar.doma.internal.apt.meta.TypeElementMeta;
 
-public class DomainMeta implements TypeElementMeta {
+public interface DomainMeta extends TypeElementMeta {
+  TypeMirror getType();
 
-  private final TypeElement typeElement;
+  TypeElement getTypeElement();
 
-  private final TypeMirror type;
+  List<String> getTypeVariables();
 
-  private TypeParametersDef typeParametersDef;
+  List<String> getTypeParameters();
 
-  private BasicCtType basicCtType;
+  BasicCtType getBasicCtType();
 
-  private DomainAnnot domainAnnot;
+  TypeMirror getValueType();
 
-  public DomainMeta(TypeElement typeElement, TypeMirror type) {
-    assertNotNull(typeElement, type);
-    this.typeElement = typeElement;
-    this.type = type;
-  }
+  String getFactoryMethod();
 
-  public TypeMirror getType() {
-    return type;
-  }
+  String getAccessorMethod();
 
-  public TypeElement getTypeElement() {
-    return typeElement;
-  }
+  boolean getAcceptNull();
 
-  public void setTypeParametersDef(TypeParametersDef typeParametersDef) {
-    this.typeParametersDef = typeParametersDef;
-  }
+  boolean providesConstructor();
 
-  public List<String> getTypeVariables() {
-    return typeParametersDef.getTypeVariables();
-  }
-
-  public List<String> getTypeParameters() {
-    return typeParametersDef.getTypeParameters();
-  }
-
-  public BasicCtType getBasicCtType() {
-    return basicCtType;
-  }
-
-  public void setBasicCtType(BasicCtType basicCtType) {
-    this.basicCtType = basicCtType;
-  }
-
-  public TypeMirror getValueType() {
-    return domainAnnot.getValueTypeValue();
-  }
-
-  public String getFactoryMethod() {
-    return domainAnnot.getFactoryMethodValue();
-  }
-
-  public String getAccessorMethod() {
-    return domainAnnot.getAccessorMethodValue();
-  }
-
-  public boolean getAcceptNull() {
-    return domainAnnot.getAcceptNullValue();
-  }
-
-  DomainAnnot getDomainAnnot() {
-    return domainAnnot;
-  }
-
-  void setDomainAnnot(DomainAnnot domainAnnot) {
-    this.domainAnnot = domainAnnot;
-  }
-
-  public boolean providesConstructor() {
-    return "new".equals(domainAnnot.getFactoryMethodValue());
-  }
-
-  public boolean isParameterized() {
-    return !typeElement.getTypeParameters().isEmpty();
-  }
-
-  @Override
-  public boolean isError() {
-    return false;
-  }
+  boolean isParameterized();
 }

--- a/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMeta.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMeta.java
@@ -1,0 +1,106 @@
+package org.seasar.doma.internal.apt.meta.domain;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.util.List;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import org.seasar.doma.internal.apt.annot.DomainAnnot;
+import org.seasar.doma.internal.apt.cttype.BasicCtType;
+import org.seasar.doma.internal.apt.def.TypeParametersDef;
+import org.seasar.doma.internal.apt.meta.TypeElementMeta;
+
+public class InternalDomainMeta implements TypeElementMeta, DomainMeta {
+
+  private final TypeElement typeElement;
+
+  private final TypeMirror type;
+
+  private TypeParametersDef typeParametersDef;
+
+  private BasicCtType basicCtType;
+
+  private DomainAnnot domainAnnot;
+
+  public InternalDomainMeta(TypeElement typeElement, TypeMirror type) {
+    assertNotNull(typeElement, type);
+    this.typeElement = typeElement;
+    this.type = type;
+  }
+
+  @Override
+  public TypeMirror getType() {
+    return type;
+  }
+
+  @Override
+  public TypeElement getTypeElement() {
+    return typeElement;
+  }
+
+  public void setTypeParametersDef(TypeParametersDef typeParametersDef) {
+    this.typeParametersDef = typeParametersDef;
+  }
+
+  @Override
+  public List<String> getTypeVariables() {
+    return typeParametersDef.getTypeVariables();
+  }
+
+  @Override
+  public List<String> getTypeParameters() {
+    return typeParametersDef.getTypeParameters();
+  }
+
+  @Override
+  public BasicCtType getBasicCtType() {
+    return basicCtType;
+  }
+
+  public void setBasicCtType(BasicCtType basicCtType) {
+    this.basicCtType = basicCtType;
+  }
+
+  @Override
+  public TypeMirror getValueType() {
+    return domainAnnot.getValueTypeValue();
+  }
+
+  @Override
+  public String getFactoryMethod() {
+    return domainAnnot.getFactoryMethodValue();
+  }
+
+  @Override
+  public String getAccessorMethod() {
+    return domainAnnot.getAccessorMethodValue();
+  }
+
+  @Override
+  public boolean getAcceptNull() {
+    return domainAnnot.getAcceptNullValue();
+  }
+
+  DomainAnnot getDomainAnnot() {
+    return domainAnnot;
+  }
+
+  void setDomainAnnot(DomainAnnot domainAnnot) {
+    this.domainAnnot = domainAnnot;
+  }
+
+  @Override
+  public boolean providesConstructor() {
+    return "new".equals(domainAnnot.getFactoryMethodValue());
+  }
+
+  @Override
+  public boolean isParameterized() {
+    return !typeElement.getTypeParameters().isEmpty();
+  }
+
+  @Override
+  public boolean isError() {
+    return false;
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMetaFactory.java
+++ b/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMetaFactory.java
@@ -33,23 +33,23 @@ import org.seasar.doma.internal.apt.util.ElementKindUtil;
 import org.seasar.doma.internal.util.StringUtil;
 import org.seasar.doma.message.Message;
 
-public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
+public class InternalDomainMetaFactory implements TypeElementMetaFactory<InternalDomainMeta> {
 
   private final Context ctx;
 
-  public DomainMetaFactory(Context ctx) {
+  public InternalDomainMetaFactory(Context ctx) {
     assertNotNull(ctx);
     this.ctx = ctx;
   }
 
   @Override
-  public DomainMeta createTypeElementMeta(TypeElement classElement) {
+  public InternalDomainMeta createTypeElementMeta(TypeElement classElement) {
     assertNotNull(classElement);
     DomainAnnot domainAnnot = ctx.getAnnotations().newDomainAnnot(classElement);
     if (domainAnnot == null) {
       throw new AptIllegalStateException("domainAnnot");
     }
-    DomainMeta domainMeta = new DomainMeta(classElement, classElement.asType());
+    InternalDomainMeta domainMeta = new InternalDomainMeta(classElement, classElement.asType());
     domainMeta.setDomainAnnot(domainAnnot);
     Strategy strategy = createStrategy(classElement, domainMeta);
     strategy.doTypeParameters(classElement, domainMeta);
@@ -71,17 +71,17 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
 
   interface Strategy {
 
-    void doTypeParameters(TypeElement classElement, DomainMeta domainMeta);
+    void doTypeParameters(TypeElement classElement, InternalDomainMeta domainMeta);
 
-    void doWrapperCtType(TypeElement classElement, DomainMeta domainMeta);
+    void doWrapperCtType(TypeElement classElement, InternalDomainMeta domainMeta);
 
-    void validateAcceptNull(TypeElement classElement, DomainMeta domainMeta);
+    void validateAcceptNull(TypeElement classElement, InternalDomainMeta domainMeta);
 
-    void validateClass(TypeElement classElement, DomainMeta domainMeta);
+    void validateClass(TypeElement classElement, InternalDomainMeta domainMeta);
 
     void validateInitializer(TypeElement classElement, DomainMeta domainMeta);
 
-    void validateAccessorMethod(TypeElement classElement, DomainMeta domainMeta);
+    void validateAccessorMethod(TypeElement classElement, InternalDomainMeta domainMeta);
   }
 
   protected static class DefaultStrategy implements Strategy {
@@ -94,14 +94,14 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
     }
 
     @Override
-    public void doTypeParameters(TypeElement classElement, DomainMeta domainMeta) {
+    public void doTypeParameters(TypeElement classElement, InternalDomainMeta domainMeta) {
       TypeParametersDef typeParametersDef =
           ctx.getMoreElements().getTypeParametersDef(classElement);
       domainMeta.setTypeParametersDef(typeParametersDef);
     }
 
     @Override
-    public void doWrapperCtType(TypeElement classElement, DomainMeta domainMeta) {
+    public void doWrapperCtType(TypeElement classElement, InternalDomainMeta domainMeta) {
       BasicCtType basicCtType = ctx.getCtTypes().newBasicCtType(domainMeta.getValueType());
       if (basicCtType == null) {
         DomainAnnot domainAnnot = domainMeta.getDomainAnnot();
@@ -116,7 +116,7 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
     }
 
     @Override
-    public void validateAcceptNull(TypeElement classElement, DomainMeta domainMeta) {
+    public void validateAcceptNull(TypeElement classElement, InternalDomainMeta domainMeta) {
       if (domainMeta.getBasicCtType().isPrimitive() && domainMeta.getAcceptNull()) {
         DomainAnnot domainAnnot = domainMeta.getDomainAnnot();
         throw new AptException(
@@ -129,7 +129,7 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
     }
 
     @Override
-    public void validateClass(TypeElement classElement, DomainMeta domainMeta) {
+    public void validateClass(TypeElement classElement, InternalDomainMeta domainMeta) {
       ElementKind kind = classElement.getKind();
       if (kind == ElementKind.CLASS || ElementKindUtil.isRecord(kind)) {
         if (domainMeta.providesConstructor()
@@ -271,7 +271,7 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
     }
 
     @Override
-    public void validateAccessorMethod(TypeElement classElement, DomainMeta domainMeta) {
+    public void validateAccessorMethod(TypeElement classElement, InternalDomainMeta domainMeta) {
       TypeElement typeElement = classElement;
       TypeMirror typeMirror = classElement.asType();
       for (; typeElement != null && typeMirror.getKind() != TypeKind.NONE; ) {
@@ -360,7 +360,7 @@ public class DomainMetaFactory implements TypeElementMetaFactory<DomainMeta> {
     }
 
     @Override
-    public void validateAccessorMethod(TypeElement classElement, DomainMeta domainMeta) {
+    public void validateAccessorMethod(TypeElement classElement, InternalDomainMeta domainMeta) {
       VariableElement field = findSingleField(classElement, domainMeta);
       String accessorMethod = inferAccessorMethod(field);
       if (!accessorMethod.equals(domainMeta.getAccessorMethod())) {

--- a/src/main/java/org/seasar/doma/internal/apt/processor/AbstractDomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/processor/AbstractDomainProcessor.java
@@ -1,0 +1,34 @@
+package org.seasar.doma.internal.apt.processor;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.lang.annotation.Annotation;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import org.seasar.doma.internal.ClassName;
+import org.seasar.doma.internal.ClassNames;
+import org.seasar.doma.internal.apt.generator.DomainDescGenerator;
+import org.seasar.doma.internal.apt.generator.Generator;
+import org.seasar.doma.internal.apt.generator.Printer;
+import org.seasar.doma.internal.apt.meta.domain.DomainMeta;
+
+public abstract class AbstractDomainProcessor<M extends DomainMeta>
+    extends AbstractGeneratingProcessor<M> {
+
+  public AbstractDomainProcessor(Class<? extends Annotation> supportedAnnotationType) {
+    super(supportedAnnotationType);
+  }
+
+  @Override
+  protected ClassName createClassName(TypeElement typeElement, DomainMeta meta) {
+    assertNotNull(typeElement, meta);
+    Name binaryName = ctx.getMoreElements().getBinaryName(typeElement);
+    return ClassNames.newDomainDescClassName(binaryName);
+  }
+
+  @Override
+  protected Generator createGenerator(ClassName className, Printer printer, DomainMeta meta) {
+    assertNotNull(className, meta, printer);
+    return new DomainDescGenerator(ctx, className, printer, meta);
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/processor/DataTypeProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/processor/DataTypeProcessor.java
@@ -1,0 +1,28 @@
+package org.seasar.doma.internal.apt.processor;
+
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import org.seasar.doma.experimental.DataType;
+import org.seasar.doma.internal.apt.Options;
+import org.seasar.doma.internal.apt.meta.domain.DataTypeMeta;
+import org.seasar.doma.internal.apt.meta.domain.DataTypeMetaFactory;
+
+@SupportedAnnotationTypes({"org.seasar.doma.experimental.DataType"})
+@SupportedOptions({
+  Options.VERSION_VALIDATION,
+  Options.RESOURCES_DIR,
+  Options.TEST,
+  Options.DEBUG,
+  Options.CONFIG_PATH
+})
+public class DataTypeProcessor extends AbstractDomainProcessor<DataTypeMeta> {
+
+  public DataTypeProcessor() {
+    super(DataType.class);
+  }
+
+  @Override
+  protected DataTypeMetaFactory createTypeElementMetaFactory() {
+    return new DataTypeMetaFactory(ctx);
+  }
+}

--- a/src/main/java/org/seasar/doma/internal/apt/processor/DomainProcessor.java
+++ b/src/main/java/org/seasar/doma/internal/apt/processor/DomainProcessor.java
@@ -1,20 +1,11 @@
 package org.seasar.doma.internal.apt.processor;
 
-import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
-
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
-import javax.lang.model.element.Name;
-import javax.lang.model.element.TypeElement;
 import org.seasar.doma.Domain;
-import org.seasar.doma.internal.ClassName;
-import org.seasar.doma.internal.ClassNames;
 import org.seasar.doma.internal.apt.Options;
-import org.seasar.doma.internal.apt.generator.DomainDescGenerator;
-import org.seasar.doma.internal.apt.generator.Generator;
-import org.seasar.doma.internal.apt.generator.Printer;
-import org.seasar.doma.internal.apt.meta.domain.DomainMeta;
-import org.seasar.doma.internal.apt.meta.domain.DomainMetaFactory;
+import org.seasar.doma.internal.apt.meta.domain.InternalDomainMeta;
+import org.seasar.doma.internal.apt.meta.domain.InternalDomainMetaFactory;
 
 @SupportedAnnotationTypes({"org.seasar.doma.Domain"})
 @SupportedOptions({
@@ -25,27 +16,14 @@ import org.seasar.doma.internal.apt.meta.domain.DomainMetaFactory;
   Options.DEBUG,
   Options.CONFIG_PATH
 })
-public class DomainProcessor extends AbstractGeneratingProcessor<DomainMeta> {
+public class DomainProcessor extends AbstractDomainProcessor<InternalDomainMeta> {
 
   public DomainProcessor() {
     super(Domain.class);
   }
 
   @Override
-  protected DomainMetaFactory createTypeElementMetaFactory() {
-    return new DomainMetaFactory(ctx);
-  }
-
-  @Override
-  protected ClassName createClassName(TypeElement typeElement, DomainMeta meta) {
-    assertNotNull(typeElement, meta);
-    Name binaryName = ctx.getMoreElements().getBinaryName(typeElement);
-    return ClassNames.newDomainDescClassName(binaryName);
-  }
-
-  @Override
-  protected Generator createGenerator(ClassName className, Printer printer, DomainMeta meta) {
-    assertNotNull(className, meta, printer);
-    return new DomainDescGenerator(ctx, className, printer, meta);
+  protected InternalDomainMetaFactory createTypeElementMetaFactory() {
+    return new InternalDomainMetaFactory(ctx);
   }
 }

--- a/src/main/java/org/seasar/doma/jdbc/domain/DomainTypeFactory.java
+++ b/src/main/java/org/seasar/doma/jdbc/domain/DomainTypeFactory.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import org.seasar.doma.DomaIllegalArgumentException;
 import org.seasar.doma.DomaNullPointerException;
 import org.seasar.doma.Domain;
+import org.seasar.doma.experimental.DataType;
 import org.seasar.doma.internal.ClassNames;
 import org.seasar.doma.internal.WrapException;
 import org.seasar.doma.internal.util.ClassUtil;
@@ -51,7 +52,8 @@ public final class DomainTypeFactory {
     if (classHelper == null) {
       throw new DomaNullPointerException("classHelper");
     }
-    if (!domainClass.isAnnotationPresent(Domain.class)) {
+    if (!domainClass.isAnnotationPresent(Domain.class)
+        && !domainClass.isAnnotationPresent(DataType.class)) {
       throw new DomaIllegalArgumentException(
           "domainClass", Message.DOMA2205.getMessage(domainClass.getName()));
     }

--- a/src/main/java/org/seasar/doma/message/Message.java
+++ b/src/main/java/org/seasar/doma/message/Message.java
@@ -904,6 +904,18 @@ public enum Message implements MessageResource {
   DOMA4446("cannot annotate the default method."),
   DOMA4447("The multidimensional array is not supported as a domain class."),
   DOMA4448("The component type of the array must not have any type parameter."),
+  DOMA4449("You can annotate only records with @DateType."),
+  DOMA4450(
+      "The simple name of the type \"{0}\" contains \"$\" or \"__\". "
+          + "The simple name of the data type and its enclosing type must not contain them."),
+  DOMA4451(
+      "The type \"{0}\" is not public and static. "
+          + "The data type and its enclosing type must be public and static."),
+  DOMA4452(
+      "The type \"{0}\" is a local or anonymous class. "
+          + "The data type and its enclosing type must be a top level or member class."),
+  DOMA4453("The public constructor whose parameter size is one is not found."),
+  DOMA4454("The parameter type \"{0}\" is not supported as a persistent type."),
 
   // other
   DOMA5001(

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,4 +1,5 @@
 org.seasar.doma.internal.apt.processor.DomainProcessor
+org.seasar.doma.internal.apt.processor.DataTypeProcessor
 org.seasar.doma.internal.apt.processor.ExternalDomainProcessor
 org.seasar.doma.internal.apt.processor.DomainConvertersProcessor
 org.seasar.doma.internal.apt.processor.EmbeddableProcessor


### PR DESCRIPTION
The DataType annotation is an experimental feature.
You can annotate only records with this annotation.

```java
@DataType
public record Job(String value) {}
```

is equivalent to:

```java
@Domain(valueType = String.class, accessorMethod = "value")
public record Job(String value) {}
```