### PR TITLE
Change the default value of the "doma.entity.field.prefix" option.

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -192,7 +192,7 @@ public final class Options {
 
     public static final String DEFAULT_DAO_SUFFIX = "Impl";
 
-    public static final String DEFAULT_ENTITY_FIELD_PREFIX = "$";
+    public static final String DEFAULT_ENTITY_FIELD_PREFIX = "none";
 
     public static final String DEFAULT_CONFIG_PATH = "doma.compile.config";
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest.java
@@ -29,6 +29,7 @@ class EntityProcessorTest extends CompilerSupport {
   void beforeEach() {
     addOption(
         "-Adoma.test=true",
+        "-Adoma.entity.field.prefix=$",
         "-Adoma.domain.converters=org.seasar.doma.internal.apt.processor.entity.DomainConvertersProvider");
   }
 


### PR DESCRIPTION
Now, all field names of the entity types don't have any prefix.
If you want the old prefixed names, set `$` to the "doma.entity.field.prefix" option.