### PR TITLE
Allow the innerJoin and the leftJoin methods to have no condition.

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/AssociationKind.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/AssociationKind.java
@@ -1,0 +1,6 @@
+package org.seasar.doma.jdbc.criteria;
+
+public enum AssociationKind {
+  MANDATORY,
+  OPTIONAL
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlSelectStatement.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlSelectStatement.java
@@ -9,6 +9,7 @@ import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.command.Command;
+import org.seasar.doma.jdbc.criteria.AssociationKind;
 import org.seasar.doma.jdbc.criteria.command.AssociateCommand;
 import org.seasar.doma.jdbc.criteria.context.SelectContext;
 import org.seasar.doma.jdbc.criteria.declaration.JoinDeclaration;
@@ -45,7 +46,16 @@ public class EntityqlSelectStatement<ENTITY> extends AbstractStatement<List<ENTI
       EntityDef<ENTITY1> first,
       EntityDef<ENTITY2> second,
       BiConsumer<ENTITY1, ENTITY2> associator) {
-    declaration.associate(first, second, associator);
+    declaration.associate(first, second, associator, AssociationKind.MANDATORY);
+    return this;
+  }
+
+  public <ENTITY1, ENTITY2> EntityqlSelectStatement<ENTITY> associate(
+      EntityDef<ENTITY1> first,
+      EntityDef<ENTITY2> second,
+      BiConsumer<ENTITY1, ENTITY2> associator,
+      AssociationKind kind) {
+    declaration.associate(first, second, associator, kind);
     return this;
   }
 

--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -926,9 +926,11 @@ public enum Message implements MessageResource {
 
   // criteria
   DOMA6001(
-      "The parameter \"{0}\" is unknown. Ensure that you have passed it to the \"from\" method or the \"join\" method."),
+      "The parameter \"{0}\" is unknown. "
+          + "Ensure that you have passed it to the from, the innerJoin, or the leftJoin method before invoking the associate method. "
+          + "If the innerJoin or leftJoin method call is optional, pass the AssociationKind.OPTIONAL value to the associate method."),
   DOMA6002(
-      "The propertyDef \"{0}\" is unknown. Ensure that you have passed it to the \"select\" method."),
+      "The propertyDef \"{0}\" is unknown. Ensure that you have passed it to the select method."),
   DOMA6003("The table alias is not found for the entityDef \"{0}\"."),
   DOMA6004("The column alias is not found for the propertyDef \"{0}\"."),
   ;

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlSelectTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlSelectTest.java
@@ -1,8 +1,10 @@
 package org.seasar.doma.jdbc.criteria;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
+import org.seasar.doma.DomaException;
 import org.seasar.doma.internal.jdbc.mock.MockConfig;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.Sql;
@@ -10,6 +12,7 @@ import org.seasar.doma.jdbc.criteria.entity.Dept_;
 import org.seasar.doma.jdbc.criteria.entity.Emp;
 import org.seasar.doma.jdbc.criteria.entity.Emp_;
 import org.seasar.doma.jdbc.criteria.statement.SelectStatement;
+import org.seasar.doma.message.Message;
 
 class EntityqlSelectTest {
 
@@ -19,6 +22,56 @@ class EntityqlSelectTest {
   void from() {
     Emp_ e = new Emp_();
     SelectStatement<Emp> stmt = Entityql.from(e);
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals(
+        "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION from EMP t0_", sql.getFormattedSql());
+  }
+
+  @Test
+  void innerJoin() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    SelectStatement<Emp> stmt = Entityql.from(e).innerJoin(d, on -> on.eq(e.id, d.id));
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals(
+        "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION from EMP t0_ inner join CATA.DEPT t1_ on (t0_.ID = t1_.ID)",
+        sql.getFormattedSql());
+  }
+
+  @Test
+  void innerJoin_empty() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    SelectStatement<Emp> stmt = Entityql.from(e).innerJoin(d, on -> {});
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals(
+        "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION from EMP t0_", sql.getFormattedSql());
+  }
+
+  @Test
+  void leftJoin() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    SelectStatement<Emp> stmt = Entityql.from(e).leftJoin(d, on -> on.eq(e.id, d.id));
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals(
+        "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION from EMP t0_ left outer join CATA.DEPT t1_ on (t0_.ID = t1_.ID)",
+        sql.getFormattedSql());
+  }
+
+  @Test
+  void leftJoin_empty() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    SelectStatement<Emp> stmt = Entityql.from(e).leftJoin(d, on -> {});
 
     Sql<?> sql = stmt.asSql(config);
     assertEquals(
@@ -37,6 +90,35 @@ class EntityqlSelectTest {
     assertEquals(
         "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION, t1_.ID, t1_.NAME from EMP t0_ inner join CATA.DEPT t1_ on (t0_.ID = t1_.ID)",
         sql.getFormattedSql());
+  }
+
+  @Test
+  void associate_mandatory() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    try {
+      Entityql.from(e).innerJoin(d, on -> {}).associate(e, d, (emp, dept) -> {});
+      fail();
+    } catch (DomaException ex) {
+      assertEquals(Message.DOMA6001, ex.getMessageResource());
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  void associate_optional() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+
+    SelectStatement<Emp> stmt =
+        Entityql.from(e)
+            .innerJoin(d, on -> {})
+            .associate(e, d, (emp, dept) -> {}, AssociationKind.OPTIONAL);
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals(
+        "select t0_.ID, t0_.NAME, t0_.SALARY, t0_.VERSION from EMP t0_", sql.getFormattedSql());
   }
 
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/NativeSqlSelectTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/NativeSqlSelectTest.java
@@ -483,6 +483,16 @@ class NativeSqlSelectTest {
   }
 
   @Test
+  void innerJoin_empty() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+    SelectIntermediate<Emp> stmt = NativeSql.from(e).innerJoin(d, on -> {}).select(e.id);
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals("select t0_.ID from EMP t0_", sql.getFormattedSql());
+  }
+
+  @Test
   void leftJoin() {
     Emp_ e = new Emp_();
     Dept_ d = new Dept_();
@@ -493,6 +503,16 @@ class NativeSqlSelectTest {
     assertEquals(
         "select t0_.ID from EMP t0_ left outer join CATA.DEPT t1_ on (t0_.ID = t1_.ID)",
         sql.getFormattedSql());
+  }
+
+  @Test
+  void leftJoin_empty() {
+    Emp_ e = new Emp_();
+    Dept_ d = new Dept_();
+    SelectIntermediate<Emp> stmt = NativeSql.from(e).leftJoin(d, on -> {}).select(e.id);
+
+    Sql<?> sql = stmt.asSql(config);
+    assertEquals("select t0_.ID from EMP t0_", sql.getFormattedSql());
   }
 
   @Test


### PR DESCRIPTION
It is useful to build dynamic queries easily.