### PR TITLE
Reload a typeElement with its canonical name to avoid the eclipse bug.

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
@@ -160,7 +160,12 @@ public class MoreTypes implements Types {
     if (element == null) {
       return null;
     }
-    return ctx.getMoreElements().toTypeElement(element);
+    TypeElement typeElement = ctx.getMoreElements().toTypeElement(element);
+    if (typeElement == null) {
+      return null;
+    }
+    // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288
+    return ctx.getMoreElements().getTypeElement(typeElement.getQualifiedName());
   }
 
   public DeclaredType toDeclaredType(TypeMirror typeMirror) {


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288

Close #421 