### PR TITLE
Change the semantics of condition operators.

### DIFF
--- a/docs/criteria-api.rst
+++ b/docs/criteria-api.rst
@@ -494,9 +494,16 @@ We support the following operators and predicates:
 
 .. note::
 
-    The ``eq`` operator generates the ``is null`` predicate if the second operand is ``null``.
-    Also, the ``ne`` operator generates the ``is not null`` predicate if the second operand is ``null``.
+    If the right hand operand is ``null``, the WHERE or the HAVING clause doesn't include the operator.
+    See WhereDeclaration_ and HavingDeclaration_ javadoc for more details.
 
+.. _WhereDeclaration: https://www.javadoc.io/doc/org.seasar.doma/doma-core/latest/org/seasar/doma/jdbc/criteria/declaration/WhereDeclaration.html
+.. _HavingDeclaration: https://www.javadoc.io/doc/org.seasar.doma/doma-core/latest/org/seasar/doma/jdbc/criteria/declaration/HavingDeclaration.html
+
+We also support the following utility operators:
+
+* eqOrIsNull - ("=" or "is null")
+* neOrIsNotNull - ("<>" or "is not null")
 
 We also support the following logical operators:
 
@@ -579,13 +586,13 @@ For example, suppose that a where expression contains a conditional expression a
             .where(
                 c -> {
                   c.eq(e.departmentId, 1);
-                  if (name != null) {
+                  if (enableNameCondition) {
                     c.like(e.employeeName, name);
                   }
                 })
             .fetch();
 
-In the case that the ``name`` variable is ``null``, the ``like`` expression is ignored.
+In the case that the ``enableNameCondition`` variable is ``false``, the ``like`` expression is ignored.
 The above query issues the following SQL statement:
 
 .. code-block:: sql

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/Criterion.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/Criterion.java
@@ -132,7 +132,7 @@ public interface Criterion {
 
     public Like(Operand.Prop left, CharSequence right, LikeOption option) {
       this.left = Objects.requireNonNull(left);
-      this.right = right;
+      this.right = Objects.requireNonNull(right);
       this.option = Objects.requireNonNull(option);
     }
 
@@ -149,7 +149,7 @@ public interface Criterion {
 
     public NotLike(Operand.Prop left, CharSequence right, LikeOption option) {
       this.left = Objects.requireNonNull(left);
-      this.right = right;
+      this.right = Objects.requireNonNull(right);
       this.option = Objects.requireNonNull(option);
     }
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
@@ -21,82 +21,274 @@ public abstract class ComparisonDeclaration {
     this.setter = Objects.requireNonNull(setter);
   }
 
+  /**
+   * Adds a {@code =} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void eq(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Eq(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Eq(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code =} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void eq(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Eq(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code <>} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void ne(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Ne(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Ne(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code <>} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void ne(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Ne(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code >} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void gt(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Gt(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Gt(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code >} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void gt(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Gt(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code >=} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void ge(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Ge(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Ge(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code >=} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void ge(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Ge(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code <} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void lt(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Lt(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Lt(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code <} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void lt(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Lt(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code <=} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operand.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void le(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Le(new Operand.Prop(left), new Operand.Param(left, right)));
+    if (right != null) {
+      add(new Criterion.Le(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
   }
 
+  /**
+   * Adds a {@code <=} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void le(PropertyMetamodel<PROPERTY> left, PropertyMetamodel<PROPERTY> right) {
     Objects.requireNonNull(left);
     Objects.requireNonNull(right);
     add(new Criterion.Le(new Operand.Prop(left), new Operand.Prop(right)));
   }
 
+  /**
+   * Adds a {@code IS NULL} operator.
+   *
+   * @param propertyMetamodel the left hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code propertyMetamodel} is null
+   */
+  public <PROPERTY> void isNull(PropertyMetamodel<PROPERTY> propertyMetamodel) {
+    Objects.requireNonNull(propertyMetamodel);
+    add(new Criterion.IsNull(new Operand.Prop(propertyMetamodel)));
+  }
+
+  /**
+   * Adds a {@code IS NOT NULL} operator.
+   *
+   * @param propertyMetamodel the left hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code propertyMetamodel} is null
+   */
+  public <PROPERTY> void isNotNull(PropertyMetamodel<PROPERTY> propertyMetamodel) {
+    Objects.requireNonNull(propertyMetamodel);
+    add(new Criterion.IsNotNull(new Operand.Prop(propertyMetamodel)));
+  }
+
+  /**
+   * Adds a {@code =} operator or a {@code IS NULL} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition includes the
+   *     {@code IS NULL} operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY> void eqOrIsNull(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
+    Objects.requireNonNull(left);
+    if (right == null) {
+      add(new Criterion.IsNull(new Operand.Prop(left)));
+    } else {
+      add(new Criterion.Eq(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
+  }
+
+  /**
+   * Adds a {@code <>} operator or a {@code IS NOT NULL} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition includes the
+   *     {@code IS NOT NULL} operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY> void neOrIsNotNull(PropertyMetamodel<PROPERTY> left, PROPERTY right) {
+    Objects.requireNonNull(left);
+    if (right == null) {
+      add(new Criterion.IsNotNull(new Operand.Prop(left)));
+    } else {
+      add(new Criterion.Ne(new Operand.Prop(left), new Operand.Param(left, right)));
+    }
+  }
+
+  /**
+   * Add a {@code AND} operator.
+   *
+   * @param block the right hand operand
+   * @throws NullPointerException if {@code block} is null
+   */
   public void and(Runnable block) {
     Objects.requireNonNull(block);
     runBlock(block, Criterion.And::new);
   }
 
+  /**
+   * Add a {@code OR} operator.
+   *
+   * @param block the right hand operand
+   * @throws NullPointerException if {@code block} is null
+   */
   public void or(Runnable block) {
     Objects.requireNonNull(block);
     runBlock(block, Criterion.Or::new);
   }
 
+  /**
+   * Add a {@code NOT} operator.
+   *
+   * @param block the right hand operand
+   * @throws NullPointerException if {@code block} is null
+   */
   public void not(Runnable block) {
     Objects.requireNonNull(block);
     runBlock(block, Criterion.Not::new);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/HavingDeclaration.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/HavingDeclaration.java
@@ -3,6 +3,7 @@ package org.seasar.doma.jdbc.criteria.declaration;
 import java.util.Objects;
 import org.seasar.doma.jdbc.criteria.context.SelectContext;
 
+/** The having declaration. */
 public class HavingDeclaration extends ComparisonDeclaration {
 
   public HavingDeclaration(SelectContext context) {

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/WhereDeclaration.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/WhereDeclaration.java
@@ -15,6 +15,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.criteria.option.LikeOption;
 import org.seasar.doma.jdbc.criteria.tuple.Tuple2;
 
+/** The where declaration. */
 public class WhereDeclaration extends ComparisonDeclaration {
 
   public WhereDeclaration(SelectContext context) {
@@ -32,64 +33,138 @@ public class WhereDeclaration extends ComparisonDeclaration {
     Objects.requireNonNull(context);
   }
 
-  public <PROPERTY> void isNull(PropertyMetamodel<PROPERTY> propertyMetamodel) {
-    Objects.requireNonNull(propertyMetamodel);
-    add(new Criterion.IsNull(new Operand.Prop(propertyMetamodel)));
-  }
-
-  public <PROPERTY> void isNotNull(PropertyMetamodel<PROPERTY> propertyMetamodel) {
-    Objects.requireNonNull(propertyMetamodel);
-    add(new Criterion.IsNotNull(new Operand.Prop(propertyMetamodel)));
-  }
-
+  /**
+   * Adds a {@code LIKE} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @throws NullPointerException if {@code left} is null
+   */
   public void like(PropertyMetamodel<?> left, CharSequence right) {
     Objects.requireNonNull(left);
-    add(new Criterion.Like(new Operand.Prop(left), right, LikeOption.none()));
+    if (right != null) {
+      add(new Criterion.Like(new Operand.Prop(left), right, LikeOption.none()));
+    }
   }
 
+  /**
+   * Adds a {@code LIKE} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param option the option
+   * @throws NullPointerException if {@code left} is null
+   */
   public void like(PropertyMetamodel<?> left, CharSequence right, LikeOption option) {
     Objects.requireNonNull(left);
-    add(new Criterion.Like(new Operand.Prop(left), right, option));
+    if (right != null) {
+      add(new Criterion.Like(new Operand.Prop(left), right, option));
+    }
   }
 
+  /**
+   * Adds a {@code NOT LIKE} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @throws NullPointerException if {@code left} is null
+   */
   public void notLike(PropertyMetamodel<?> left, CharSequence right) {
     Objects.requireNonNull(left);
-    add(new Criterion.NotLike(new Operand.Prop(left), right, LikeOption.none()));
+    if (right != null) {
+      add(new Criterion.NotLike(new Operand.Prop(left), right, LikeOption.none()));
+    }
   }
 
+  /**
+   * Adds a {@code NOT LIKE} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param option the option
+   * @throws NullPointerException if {@code left} is null
+   */
   public void notLike(PropertyMetamodel<?> left, CharSequence right, LikeOption option) {
     Objects.requireNonNull(left);
-    add(new Criterion.NotLike(new Operand.Prop(left), right, option));
+    if (right != null) {
+      add(new Criterion.NotLike(new Operand.Prop(left), right, option));
+    }
   }
 
+  /**
+   * Adds a {@code BETWEEN} operator.
+   *
+   * <p>If either of the {@code start} parameter or the {@code end} parameter is null, the query
+   * condition does'nt include the operator.
+   *
+   * @param propertyMetamodel the left hand operand
+   * @param start the first argument of the right hand operand
+   * @param end the second argument of the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code propertyMetamodel} is null
+   */
   public <PROPERTY> void between(
       PropertyMetamodel<PROPERTY> propertyMetamodel, PROPERTY start, PROPERTY end) {
     Objects.requireNonNull(propertyMetamodel);
-    add(
-        new Criterion.Between(
-            new Operand.Prop(propertyMetamodel),
-            new Operand.Param(propertyMetamodel, start),
-            new Operand.Param(propertyMetamodel, end)));
+    if (start != null && end != null) {
+      add(
+          new Criterion.Between(
+              new Operand.Prop(propertyMetamodel),
+              new Operand.Param(propertyMetamodel, start),
+              new Operand.Param(propertyMetamodel, end)));
+    }
   }
 
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void in(PropertyMetamodel<PROPERTY> left, List<PROPERTY> right) {
     Objects.requireNonNull(left);
-    Objects.requireNonNull(right);
-    add(
-        new Criterion.In(
-            new Operand.Prop(left),
-            right.stream().map(p -> new Operand.Param(left, p)).collect(toList())));
+    if (right != null) {
+      add(
+          new Criterion.In(
+              new Operand.Prop(left),
+              right.stream().map(p -> new Operand.Param(left, p)).collect(toList())));
+    }
   }
 
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void notIn(PropertyMetamodel<PROPERTY> left, List<PROPERTY> right) {
     Objects.requireNonNull(left);
-    Objects.requireNonNull(right);
-    add(
-        new Criterion.NotIn(
-            new Operand.Prop(left),
-            right.stream().map(p -> new Operand.Param(left, p)).collect(toList())));
+    if (right != null) {
+      add(
+          new Criterion.NotIn(
+              new Operand.Prop(left),
+              right.stream().map(p -> new Operand.Param(left, p)).collect(toList())));
+    }
   }
 
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void in(
       PropertyMetamodel<PROPERTY> left, SubSelectContext<PropertyMetamodel<PROPERTY>> right) {
     Objects.requireNonNull(left);
@@ -97,6 +172,14 @@ public class WhereDeclaration extends ComparisonDeclaration {
     add(new Criterion.InSubQuery(new Operand.Prop(left), right.get()));
   }
 
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY> void notIn(
       PropertyMetamodel<PROPERTY> left, SubSelectContext<PropertyMetamodel<PROPERTY>> right) {
     Objects.requireNonNull(left);
@@ -104,40 +187,75 @@ public class WhereDeclaration extends ComparisonDeclaration {
     add(new Criterion.NotInSubQuery(new Operand.Prop(left), right.get()));
   }
 
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY1, PROPERTY2> void in(
       Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
       List<Tuple2<PROPERTY1, PROPERTY2>> right) {
-    Operand.Prop prop1 = new Operand.Prop(left.getItem1());
-    Operand.Prop prop2 = new Operand.Prop(left.getItem2());
-    List<Tuple2<Operand.Param, Operand.Param>> params =
-        right.stream()
-            .map(
-                pair -> {
-                  Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
-                  Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
-                  return new Tuple2<>(param1, param2);
-                })
-            .collect(toList());
-    add(new Criterion.InTuple2(new Tuple2<>(prop1, prop2), params));
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      List<Tuple2<Operand.Param, Operand.Param>> params =
+          right.stream()
+              .map(
+                  pair -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
+                    return new Tuple2<>(param1, param2);
+                  })
+              .collect(toList());
+      add(new Criterion.InTuple2(new Tuple2<>(prop1, prop2), params));
+    }
   }
 
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition does'nt include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY1, PROPERTY2> void notIn(
       Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
       List<Tuple2<PROPERTY1, PROPERTY2>> right) {
-    Operand.Prop prop1 = new Operand.Prop(left.getItem1());
-    Operand.Prop prop2 = new Operand.Prop(left.getItem2());
-    List<Tuple2<Operand.Param, Operand.Param>> params =
-        right.stream()
-            .map(
-                pair -> {
-                  Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
-                  Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
-                  return new Tuple2<>(param1, param2);
-                })
-            .collect(toList());
-    add(new Criterion.NotInTuple2(new Tuple2<>(prop1, prop2), params));
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      List<Tuple2<Operand.Param, Operand.Param>> params =
+          right.stream()
+              .map(
+                  pair -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
+                    return new Tuple2<>(param1, param2);
+                  })
+              .collect(toList());
+      add(new Criterion.NotInTuple2(new Tuple2<>(prop1, prop2), params));
+    }
   }
 
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY1, PROPERTY2> void in(
       Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
       SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>> right) {
@@ -148,6 +266,15 @@ public class WhereDeclaration extends ComparisonDeclaration {
     add(new Criterion.InTuple2SubQuery(new Tuple2<>(prop1, prop2), right.get()));
   }
 
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} or {@code right} is null
+   */
   public <PROPERTY1, PROPERTY2> void notIn(
       Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
       SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>> right) {
@@ -158,17 +285,38 @@ public class WhereDeclaration extends ComparisonDeclaration {
     add(new Criterion.NotInTuple2SubQuery(new Tuple2<>(prop1, prop2), right.get()));
   }
 
+  /**
+   * Adds a {@code EXISTS} operator.
+   *
+   * @param subSelectContext the sub-select context
+   * @throws NullPointerException if {@code subSelectContext} is null
+   */
   public void exists(SubSelectContext<?> subSelectContext) {
     Objects.requireNonNull(subSelectContext);
     add(new Criterion.Exists(subSelectContext.get()));
   }
 
+  /**
+   * Adds a {@code NOT EXISTS} operator.
+   *
+   * @param subSelectContext the sub-select context
+   * @throws NullPointerException if {@code subSelectContext} is null
+   */
   public void notExists(SubSelectContext<?> subSelectContext) {
     Objects.requireNonNull(subSelectContext);
     add(new Criterion.NotExists(subSelectContext.get()));
   }
 
+  /**
+   * Creates a sub-select context.
+   *
+   * @param entityMetamodel the entity model
+   * @param <ENTITY> the entity type
+   * @return the sub-select context
+   * @throws NullPointerException if {@code entityMetamodel} is null
+   */
   public <ENTITY> SubSelectFromDeclaration<ENTITY> from(EntityMetamodel<ENTITY> entityMetamodel) {
+    Objects.requireNonNull(entityMetamodel);
     return new SubSelectFromDeclaration<>(entityMetamodel);
   }
 }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/query/BuilderSupport.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/query/BuilderSupport.java
@@ -112,12 +112,12 @@ public class BuilderSupport {
 
     @Override
     public void visit(Criterion.Eq c) {
-      equality(c.left, c.right, "=");
+      comparison(c.left, c.right, "=");
     }
 
     @Override
     public void visit(Criterion.Ne c) {
-      equality(c.left, c.right, "<>");
+      comparison(c.left, c.right, "<>");
     }
 
     @Override
@@ -228,37 +228,6 @@ public class BuilderSupport {
     @Override
     public void visit(Criterion.Not criterion) {
       not(criterion.criterionList);
-    }
-
-    private void equality(Operand.Prop left, Operand right, String op) {
-      if (isParamNull(right)) {
-        if (op.equals("=")) {
-          isNull(left);
-        } else if (op.equals("<>")) {
-          isNotNull(left);
-        } else {
-          throw new IllegalStateException("The operator is illegal. " + op);
-        }
-      } else {
-        comparison(left, right, op);
-      }
-    }
-
-    private boolean isParamNull(Operand operand) {
-      return operand.accept(
-          new Operand.Visitor<Boolean>() {
-
-            @Override
-            public Boolean visit(Operand.Param operand) {
-              InParameter<?> parameter = operand.createInParameter(config);
-              return parameter.getWrapper().get() == null;
-            }
-
-            @Override
-            public Boolean visit(Operand.Prop operand) {
-              return false;
-            }
-          });
     }
 
     private void comparison(Operand.Prop left, Operand right, String op) {

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/NativeSqlSelectTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/NativeSqlSelectTest.java
@@ -78,8 +78,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID = t0_.ID and t0_.ID = 1 and t0_.ID is null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID = t0_.ID and t0_.ID = 1", sql.getFormattedSql());
   }
 
   @Test
@@ -98,8 +97,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID <> t0_.ID and t0_.ID <> 1 and t0_.ID is not null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID <> t0_.ID and t0_.ID <> 1", sql.getFormattedSql());
   }
 
   @Test
@@ -118,8 +116,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID >= t0_.ID and t0_.ID >= 1 and t0_.ID >= null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID >= t0_.ID and t0_.ID >= 1", sql.getFormattedSql());
   }
 
   @Test
@@ -138,8 +135,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID > t0_.ID and t0_.ID > 1 and t0_.ID > null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID > t0_.ID and t0_.ID > 1", sql.getFormattedSql());
   }
 
   @Test
@@ -158,8 +154,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID <= t0_.ID and t0_.ID <= 1 and t0_.ID <= null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID <= t0_.ID and t0_.ID <= 1", sql.getFormattedSql());
   }
 
   @Test
@@ -178,8 +173,7 @@ class NativeSqlSelectTest {
 
     Sql<?> sql = stmt.asSql();
     assertEquals(
-        "select t0_.ID from EMP t0_ where t0_.ID < t0_.ID and t0_.ID < 1 and t0_.ID < null",
-        sql.getFormattedSql());
+        "select t0_.ID from EMP t0_ where t0_.ID < t0_.ID and t0_.ID < 1", sql.getFormattedSql());
   }
 
   @Test
@@ -201,9 +195,54 @@ class NativeSqlSelectTest {
   }
 
   @Test
+  void where_eqOrIsNull() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.eqOrIsNull(e.id, 1);
+                  c.eqOrIsNull(e.id, null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where t0_.ID = 1 and t0_.ID is null", sql.getFormattedSql());
+  }
+
+  @Test
+  void where_neOrIsNotNull() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.neOrIsNotNull(e.id, 1);
+                  c.neOrIsNotNull(e.id, null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where t0_.ID <> 1 and t0_.ID is not null",
+        sql.getFormattedSql());
+  }
+
+  @Test
   void where_like() {
     Emp_ e = new Emp_();
-    Buildable<?> stmt = nativeSql.from(e).where(c -> c.like(e.name, "a$")).select(e.id);
+    Buildable<?> stmt =
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.like(e.name, "a$");
+                  c.like(e.name, null);
+                })
+            .select(e.id);
 
     Sql<?> sql = stmt.asSql();
     assertEquals("select t0_.ID from EMP t0_ where t0_.NAME like 'a$'", sql.getFormattedSql());
@@ -276,7 +315,17 @@ class NativeSqlSelectTest {
   @Test
   void where_between() {
     Emp_ e = new Emp_();
-    Buildable<?> stmt = nativeSql.from(e).where(c -> c.between(e.id, 1, 10)).select(e.id);
+    Buildable<?> stmt =
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.between(e.id, 1, 10);
+                  c.between(e.id, null, 10);
+                  c.between(e.id, 1, null);
+                  c.between(e.id, null, null);
+                })
+            .select(e.id);
 
     Sql<?> sql = stmt.asSql();
     assertEquals("select t0_.ID from EMP t0_ where t0_.ID between 1 and 10", sql.getFormattedSql());
@@ -285,7 +334,15 @@ class NativeSqlSelectTest {
   @Test
   void where_in() {
     Emp_ e = new Emp_();
-    Buildable<?> stmt = nativeSql.from(e).where(c -> c.in(e.id, Arrays.asList(1, 2))).select(e.id);
+    Buildable<?> stmt =
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.in(e.id, Arrays.asList(1, 2));
+                  c.in(e.id, (List<Integer>) null);
+                })
+            .select(e.id);
 
     Sql<?> sql = stmt.asSql();
     assertEquals("select t0_.ID from EMP t0_ where t0_.ID in (1, 2)", sql.getFormattedSql());
@@ -295,7 +352,14 @@ class NativeSqlSelectTest {
   void where_notIn() {
     Emp_ e = new Emp_();
     Buildable<?> stmt =
-        nativeSql.from(e).where(c -> c.notIn(e.id, Arrays.asList(1, 2))).select(e.id);
+        nativeSql
+            .from(e)
+            .where(
+                c -> {
+                  c.notIn(e.id, Arrays.asList(1, 2));
+                  c.notIn(e.id, (List<Integer>) null);
+                })
+            .select(e.id);
 
     Sql<?> sql = stmt.asSql();
     assertEquals("select t0_.ID from EMP t0_ where t0_.ID not in (1, 2)", sql.getFormattedSql());
@@ -308,10 +372,12 @@ class NativeSqlSelectTest {
         nativeSql
             .from(e)
             .where(
-                c ->
-                    c.in(
-                        new Tuple2<>(e.id, e.name),
-                        Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b"))))
+                c -> {
+                  c.in(
+                      new Tuple2<>(e.id, e.name),
+                      Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b")));
+                  c.in(new Tuple2<>(e.id, e.name), (List<Tuple2<Integer, String>>) null);
+                })
             .select(e.id);
 
     Sql<?> sql = stmt.asSql();
@@ -327,10 +393,12 @@ class NativeSqlSelectTest {
         nativeSql
             .from(e)
             .where(
-                c ->
-                    c.notIn(
-                        new Tuple2<>(e.id, e.name),
-                        Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b"))))
+                c -> {
+                  c.notIn(
+                      new Tuple2<>(e.id, e.name),
+                      Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b")));
+                  c.notIn(new Tuple2<>(e.id, e.name), (List<Tuple2<Integer, String>>) null);
+                })
             .select(e.id);
 
     Sql<?> sql = stmt.asSql();

--- a/test-criteria/src/test/java/example/EntityqlSelectTest.java
+++ b/test-criteria/src/test/java/example/EntityqlSelectTest.java
@@ -127,15 +127,15 @@ public class EntityqlSelectTest {
 
   @Test
   void where_dynamic() {
-    List<Employee> list = where_dynamic(null);
+    List<Employee> list = where_dynamic("C%", false);
     assertEquals(3, list.size());
 
-    List<Employee> list2 = where_dynamic("C%");
+    List<Employee> list2 = where_dynamic("C%", true);
     assertEquals(1, list2.size());
   }
 
   @SuppressWarnings("UnnecessaryLocalVariable")
-  private List<Employee> where_dynamic(String name) {
+  private List<Employee> where_dynamic(String name, boolean enableNameCondition) {
     Employee_ e = new Employee_();
     List<Employee> list =
         entityql
@@ -143,7 +143,7 @@ public class EntityqlSelectTest {
             .where(
                 c -> {
                   c.eq(e.departmentId, 1);
-                  if (name != null) {
+                  if (enableNameCondition) {
                     c.like(e.employeeName, name);
                   }
                 })
@@ -213,7 +213,7 @@ public class EntityqlSelectTest {
     Address_ a = new Address_();
 
     List<Address> list = entityql.from(a).where(c -> c.like(a.street, null)).fetch();
-    assertEquals(0, list.size());
+    assertEquals(15, list.size());
   }
 
   @Test


### PR DESCRIPTION
If the right hand operand is null, the operator is not included in the query condition.

The following two code fragments issue a same SQL statement:

```java
entityql()
    .from(e)
    .where(
        c -> {
            if (min != null) {
                c.ge(e.age, min);
            }
            if (max != null) {
                c.le(e.age, max);
            }
        })
    .fetch();
```

```java
entityql()
    .from(e)
    .where(
        c -> {
            c.ge(e.age, min);
            c.le(e.age, max);
        })
    .fetch();
```