### PR TITLE
Savepoint was logged as rolled back when released

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
@@ -351,7 +351,6 @@ public class LocalTransaction {
       rollbackInternal("releaseSavepoint");
       throw new JdbcException(Message.DOMA2060, e, savepointName, e);
     }
-    jdbcLogger.logTransactionSavepointRolledback(className, "setSavepoint", id, savepointName);
   }
 
   /**


### PR DESCRIPTION
JdbcLogger has no interface to log when savepoint released. You cannot log any info here.

If it should be logged, reject this PR and extend JdbcLogger interface.