### PR TITLE
Avoid unexpected token errors.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
         token: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
         inputs: |
           { "ref": "${{ github.sha }}",
-            "pull_request_title": "${{ (github.event.pull_request && github.event.pull_request.title) || null }}",
             "pull_request_number": "${{ (github.event.pull_request && github.event.pull_request.number) || null }}",
             "pull_request_sha": "${{ (github.event.pull_request && github.event.pull_request.head.sha) || null }}",
-            "message": "${{ (github.event.commits[0] && github.event.commits[0].message) || null }}" }
+            "pull_request_title": "",
+            "message": "" }


### PR DESCRIPTION
I think that string values must be escaped.