### PR TITLE
Return non-nullable type from the fetchOne method

### DIFF
--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/jdbc/criteria/statement/KListable.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/jdbc/criteria/statement/KListable.kt
@@ -8,7 +8,11 @@ interface KListable<ELEMENT> : KStatement<List<ELEMENT>> {
         return execute()
     }
 
-    fun fetchOne(): ELEMENT? {
+    fun fetchOne(): ELEMENT {
+        return execute().first()
+    }
+
+    fun fetchOneOrNull(): ELEMENT? {
         return execute().firstOrNull()
     }
 


### PR DESCRIPTION
To return nullable type, use the fetchOneOrNull method instead.