### PR TITLE
Deprecate the config element of the Dao annotation

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -104,7 +104,7 @@ Using in DAO interface
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
 
       @Select

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -230,6 +230,8 @@ All JDBC drivers are loaded automatically by the `service provider <service prov
   For example, when you use Apache Tomcat, you will find the case.
   See also: `DriverManager, the service provider mechanism and memory leaks <tomcat driver_>`_
 
+.. _config-configuration-definition:
+
 Configuration definition
 ========================
 
@@ -243,7 +245,6 @@ The simple definition is appropriate in following cases:
 
 .. code-block:: java
 
-  @SingletonConfig
   public class AppConfig implements Config {
 
       private static final AppConfig CONFIG = new AppConfig();
@@ -282,21 +283,22 @@ The simple definition is appropriate in following cases:
       }
   }
 
-.. note::
-
-  Remember to annotate the class with ``@SingletonConfig``
-
-Specify the above class to the config element of ``@Dao``.
+You can use the above ``AppConfig`` class as follows:
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  EmployeeDao dao = new EmployeeDaoImpl(AppConfig.singleton());
+
+The above ``EmployeeDao`` interface must be annotated with the ``@Dao`` annotation as follows:
+
+.. code-block:: java
+
+  @Dao
   public interface EmployeeDao {
 
       @Select
       Employee selectById(Integer id);
   }
-
 
 Advanced definition
 -------------------

--- a/docs/dao.rst
+++ b/docs/dao.rst
@@ -33,7 +33,7 @@ You can get ``Config`` instance associated dao instance if you call ``Config.get
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
 
       default int count() {
@@ -81,7 +81,7 @@ One dao interface can handle more than one entity classes.
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  @Dao
   public interface MyDao {
 
       @Select

--- a/docs/domain.rst
+++ b/docs/domain.rst
@@ -328,7 +328,7 @@ The Domain classes showed above are used as follows:
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
 
       @Select

--- a/docs/kotlin-support.rst
+++ b/docs/kotlin-support.rst
@@ -76,7 +76,7 @@ Dao interfaces
 
 .. code-block:: java
 
-  @Dao(config = AppConfig::class)
+  @Dao
   interface PersonDao {
     @Sql("""
     select * from person where id = /*id*/0

--- a/docs/query/batch-delete.rst
+++ b/docs/query/batch-delete.rst
@@ -9,7 +9,7 @@ Annotate with ``@BatchDelete`` to Dao method for execute batch delete.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @BatchDelete
       int[] delete(List<Employee> employees);

--- a/docs/query/batch-insert.rst
+++ b/docs/query/batch-insert.rst
@@ -9,7 +9,7 @@ Annotate with ``@BatchInsert`` to Dao method for execute batch insert.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @BatchInsert
       int[] insert(List<Employee> employees);

--- a/docs/query/batch-update.rst
+++ b/docs/query/batch-update.rst
@@ -9,7 +9,7 @@ Annotate with ``@BatchUpdate`` to Dao method for execute batch update.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @BatchUpdate
       int[] update(List<Employee> employees);

--- a/docs/query/delete.rst
+++ b/docs/query/delete.rst
@@ -9,7 +9,7 @@ Annotate with ``@Delete`` to Dao method for execute delete.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Delete
       int delete(Employee employee);

--- a/docs/query/function.rst
+++ b/docs/query/function.rst
@@ -9,7 +9,7 @@ To call stored functions, you must annotate DAO methods with the ``@Function`` a
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Function
       Integer execute(@In Integer id, @InOut Reference<BigDecimal> salary);

--- a/docs/query/insert.rst
+++ b/docs/query/insert.rst
@@ -9,7 +9,7 @@ Annotate with ``@Insert`` to Dao method for execute insert.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Insert
       int insert(Employee employee);

--- a/docs/query/procedure.rst
+++ b/docs/query/procedure.rst
@@ -9,7 +9,7 @@ To call stored procedures, you must annotate DAO methods with the ``@Procedure``
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Procedure
       void execute(@In Integer id, @InOut Reference<BigDecimal> salary);

--- a/docs/query/script.rst
+++ b/docs/query/script.rst
@@ -10,7 +10,7 @@ annotate DAO methods with ``@Script``:
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Script
       void createTable();
@@ -71,7 +71,7 @@ You can specify scripts to DAO methods with the ``@Sql`` annotation:
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Sql("create table employee (id integer, name varchar(200))")
       @Script

--- a/docs/query/select.rst
+++ b/docs/query/select.rst
@@ -9,7 +9,7 @@ Annotate with ``@Select`` to Dao method for execute search.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Select
       List<Employee> selectByDepartmentName(String departmentName);
@@ -289,7 +289,7 @@ You define ``SelectOptions`` as Dao method parameter.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Select
       List<Employee> selectByDepartmentName(String departmentName, SelectOptions options);

--- a/docs/query/sql-processor.rst
+++ b/docs/query/sql-processor.rst
@@ -10,7 +10,7 @@ To mark a DAO method as an SQL processor, annotate the method with ``@SqlProcess
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @SqlProcessor
       <R> R process(Integer id, BiFunction<Config, PreparedSql, R> handler);

--- a/docs/query/update.rst
+++ b/docs/query/update.rst
@@ -9,7 +9,7 @@ Annotate with ``@Update`` to Dao method for execute update.
 
 .. code-block:: java
 
-  @Config(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
       @Update
       int update(Employee employee);

--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -11,6 +11,8 @@ This document explains how to configure and use the local transaction.
 If you want to use global transaction, use frameworks or application servers
 which support JTA (Java Transaction API).
 
+See also :ref:`config-configuration-definition` .
+
 Configuration
 =============
 
@@ -28,7 +30,6 @@ Here is an example:
 
 .. code-block:: java
 
-  @SingletonConfig
   public class AppConfig implements Config {
 
       private static final AppConfig CONFIG = new AppConfig();
@@ -67,24 +68,26 @@ Here is an example:
       }
   }
 
-.. note::
-
-  The ``@SingletonConfig`` shows that this class is a singleton class.
-
 Usage
 ======
 
-Let's see examples on the condition that we use the following Dao interface annotated with
-the ``AppConfig`` class which we saw in the `Configuration`_.
+We use the following DAO interface in example code:
 
 .. code-block:: java
 
-  @Dao(config = AppConfig.class)
+  @Dao
   public interface EmployeeDao {
-      ...
+      @Sql("select /*%expand*/* from employee where id = /*id*/0")
+      @Select
+      Employee selectById(Integer id);
+
+      @Update
+      int update(Employee employee);
+
+      @Delete
+      int delete(Employee employee);
   }
 
-The ``dao`` used in the code examples below are instances of this class.
 
 Start and finish transactions
 -----------------------------
@@ -100,6 +103,7 @@ Use a lambda expression to write a process which you want to run in a transactio
 .. code-block:: java
 
   TransactionManager tm = AppConfig.singleton().getTransactionManager();
+  EmployeeDao dao = new EmployeeDaoImpl(AppConfig.singleton());
 
   tm.required(() -> {
       Employee employee = dao.selectById(1);
@@ -119,6 +123,7 @@ Besides throwing an exception, you can use ``setRollbackOnly`` method to rollbac
 .. code-block:: java
 
   TransactionManager tm = AppConfig.singleton().getTransactionManager();
+  EmployeeDao dao = new EmployeeDaoImpl(AppConfig.singleton());
 
   tm.required(() -> {
       Employee employee = dao.selectById(1);
@@ -137,6 +142,7 @@ With a savepoint, you can cancel specific changes in a transaction.
 .. code-block:: java
 
   TransactionManager tm = AppConfig.singleton().getTransactionManager();
+  EmployeeDao dao = new EmployeeDaoImpl(AppConfig.singleton());
 
   tm.required(() -> {
       // Search and update

--- a/doma-core/src/main/java/org/seasar/doma/AnnotateWith.java
+++ b/doma-core/src/main/java/org/seasar/doma/AnnotateWith.java
@@ -50,6 +50,7 @@ import org.seasar.doma.jdbc.Config;
  * }
  * </pre>
  */
+@SuppressWarnings("deprecation")
 @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AnnotateWith {

--- a/doma-core/src/main/java/org/seasar/doma/ArrayFactory.java
+++ b/doma-core/src/main/java/org/seasar/doma/ArrayFactory.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.JdbcException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;ArrayFactory(typeName = &quot;integer&quot;)

--- a/doma-core/src/main/java/org/seasar/doma/BatchDelete.java
+++ b/doma-core/src/main/java/org/seasar/doma/BatchDelete.java
@@ -23,7 +23,7 @@ import org.seasar.doma.jdbc.SqlLogType;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;BatchDelete

--- a/doma-core/src/main/java/org/seasar/doma/BatchInsert.java
+++ b/doma-core/src/main/java/org/seasar/doma/BatchInsert.java
@@ -23,7 +23,7 @@ import org.seasar.doma.jdbc.UniqueConstraintException;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;BatchInsert

--- a/doma-core/src/main/java/org/seasar/doma/BatchUpdate.java
+++ b/doma-core/src/main/java/org/seasar/doma/BatchUpdate.java
@@ -24,7 +24,7 @@ import org.seasar.doma.jdbc.UniqueConstraintException;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;BatchUpdate

--- a/doma-core/src/main/java/org/seasar/doma/BlobFactory.java
+++ b/doma-core/src/main/java/org/seasar/doma/BlobFactory.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.JdbcException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;BlobFactory

--- a/doma-core/src/main/java/org/seasar/doma/ClobFactory.java
+++ b/doma-core/src/main/java/org/seasar/doma/ClobFactory.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.JdbcException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;ClobFactory

--- a/doma-core/src/main/java/org/seasar/doma/Dao.java
+++ b/doma-core/src/main/java/org/seasar/doma/Dao.java
@@ -12,7 +12,7 @@ import org.seasar.doma.jdbc.Config;
  * <p>The annotated interface must be a top level interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Insert
@@ -23,7 +23,7 @@ import org.seasar.doma.jdbc.Config;
  * <p>The interface can extend another DAO interface:
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface WorkerDao {
  *
  *     &#064;Insert
@@ -32,7 +32,7 @@ import org.seasar.doma.jdbc.Config;
  * </pre>
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao extends WorkerDao {
  *
  *     &#064;Insert
@@ -71,7 +71,10 @@ public @interface Dao {
    * instance can be injected by using {@link AnnotateWith}.
    *
    * @return the configuration
+   * @deprecated always pass a {@link Config} instance to the constructor of DAO implementation
+   *     class
    */
+  @Deprecated
   Class<? extends Config> config() default Config.class;
 
   /** @return the access level of the DAO implementation class. */

--- a/doma-core/src/main/java/org/seasar/doma/Delete.java
+++ b/doma-core/src/main/java/org/seasar/doma/Delete.java
@@ -22,7 +22,7 @@ import org.seasar.doma.jdbc.SqlLogType;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Delete

--- a/doma-core/src/main/java/org/seasar/doma/Function.java
+++ b/doma-core/src/main/java/org/seasar/doma/Function.java
@@ -17,7 +17,7 @@ import org.seasar.doma.jdbc.UnknownColumnException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Function

--- a/doma-core/src/main/java/org/seasar/doma/In.java
+++ b/doma-core/src/main/java/org/seasar/doma/In.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * {@link Function} or {@link Procedure}.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Procedure

--- a/doma-core/src/main/java/org/seasar/doma/InOut.java
+++ b/doma-core/src/main/java/org/seasar/doma/InOut.java
@@ -13,7 +13,7 @@ import org.seasar.doma.jdbc.Reference;
  * the parameters of the method that is annotated with {@link Function} or {@link Procedure}.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Procedure
@@ -22,7 +22,7 @@ import org.seasar.doma.jdbc.Reference;
  * </pre>
  *
  * <pre>
- * EmployeeDao dao = new EmployeeDaoImpl();
+ * EmployeeDao dao = new EmployeeDaoImpl(config);
  * Reference&lt;BigDecimal&gt; salaryRef = new Reference&lt;BigDecimal&gt;(new BigDecimal(1000));
  * dao.updateSalary(1, salaryRef);
  * BigDecimal salary = salaryRef.get();

--- a/doma-core/src/main/java/org/seasar/doma/Insert.java
+++ b/doma-core/src/main/java/org/seasar/doma/Insert.java
@@ -22,7 +22,7 @@ import org.seasar.doma.jdbc.UniqueConstraintException;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Insert

--- a/doma-core/src/main/java/org/seasar/doma/NClobFactory.java
+++ b/doma-core/src/main/java/org/seasar/doma/NClobFactory.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.JdbcException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;NClobFactory

--- a/doma-core/src/main/java/org/seasar/doma/Out.java
+++ b/doma-core/src/main/java/org/seasar/doma/Out.java
@@ -13,7 +13,7 @@ import org.seasar.doma.jdbc.Reference;
  * method that is annotated with {@link Function} or {@link Procedure}.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Procedure
@@ -22,7 +22,7 @@ import org.seasar.doma.jdbc.Reference;
  * </pre>
  *
  * <pre>
- * EmployeeDao dao = new EmployeeDaoImpl();
+ * EmployeeDao dao = new EmployeeDaoImpl(config);
  * Reference&lt;BigDecimal&gt; salaryRef = new Reference&lt;BigDecimal&gt;();
  * dao.updateSalary(1, salaryRef);
  * BigDecimal salary = salaryRef.get();

--- a/doma-core/src/main/java/org/seasar/doma/Procedure.java
+++ b/doma-core/src/main/java/org/seasar/doma/Procedure.java
@@ -16,7 +16,7 @@ import org.seasar.doma.jdbc.UnknownColumnException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Procedure

--- a/doma-core/src/main/java/org/seasar/doma/ResultSet.java
+++ b/doma-core/src/main/java/org/seasar/doma/ResultSet.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.ResultMappingException;
  * method that is annotated with {@link Function} or {@link Procedure}.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Procedure
@@ -23,7 +23,7 @@ import org.seasar.doma.jdbc.ResultMappingException;
  * </pre>
  *
  * <pre>
- * EmployeeDao dao = new EmployeeDaoImpl();
+ * EmployeeDao dao = new EmployeeDaoImpl(config);
  * List&lt;Employee&gt; employees = new ArrayList&lt;Employee&gt;();
  * dao.fetchEmployees(10, employees);
  * for (Employee e : employees) {

--- a/doma-core/src/main/java/org/seasar/doma/SQLXMLFactory.java
+++ b/doma-core/src/main/java/org/seasar/doma/SQLXMLFactory.java
@@ -14,7 +14,7 @@ import org.seasar.doma.jdbc.JdbcException;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;SQLXMLFactory

--- a/doma-core/src/main/java/org/seasar/doma/Script.java
+++ b/doma-core/src/main/java/org/seasar/doma/Script.java
@@ -16,7 +16,7 @@ import org.seasar.doma.jdbc.dialect.Dialect;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Script

--- a/doma-core/src/main/java/org/seasar/doma/Select.java
+++ b/doma-core/src/main/java/org/seasar/doma/Select.java
@@ -27,7 +27,7 @@ import org.seasar.doma.jdbc.UnknownColumnException;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Select

--- a/doma-core/src/main/java/org/seasar/doma/SingletonConfig.java
+++ b/doma-core/src/main/java/org/seasar/doma/SingletonConfig.java
@@ -12,9 +12,12 @@ import org.seasar.doma.jdbc.Config;
  *
  * <p>The annotated class must have a static method that returns a singleton. The all constructors
  * of the class must be private.
+ *
+ * @deprecated create a singleton {@link Config} without this annotation
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated
 public @interface SingletonConfig {
 
   /**

--- a/doma-core/src/main/java/org/seasar/doma/Sql.java
+++ b/doma-core/src/main/java/org/seasar/doma/Sql.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Sql("select name from employee where age = &#047;* age *&#047;0)")

--- a/doma-core/src/main/java/org/seasar/doma/SqlProcessor.java
+++ b/doma-core/src/main/java/org/seasar/doma/SqlProcessor.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * <p>The annotated method must be a member of a {@link Dao} annotated interface.
  *
  * <pre>
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *     &#64;SqlProcessor
  *     &lt;R&gt; R process(Integer id, BiFunction&lt;Config, PreparedSql, R&gt; handler);

--- a/doma-core/src/main/java/org/seasar/doma/Update.java
+++ b/doma-core/src/main/java/org/seasar/doma/Update.java
@@ -23,7 +23,7 @@ import org.seasar.doma.jdbc.UniqueConstraintException;
  *     ...
  * }
  *
- * &#064;Dao(config = AppConfig.class)
+ * &#064;Dao
  * public interface EmployeeDao {
  *
  *     &#064;Update

--- a/doma-core/src/test/java/example/dao/EmpDao.java
+++ b/doma-core/src/test/java/example/dao/EmpDao.java
@@ -14,6 +14,7 @@ import org.seasar.doma.SelectType;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = ExampleConfig.class)
 public interface EmpDao {
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/annot/Annotations.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/annot/Annotations.java
@@ -34,7 +34,6 @@ import org.seasar.doma.SQLXMLFactory;
 import org.seasar.doma.Script;
 import org.seasar.doma.Select;
 import org.seasar.doma.SequenceGenerator;
-import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.Sql;
 import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.Table;
@@ -241,9 +240,11 @@ public class Annotations {
     return newInstance(field, SequenceGenerator.class, SequenceGeneratorAnnot::new);
   }
 
+  @SuppressWarnings("deprecation")
   public SingletonConfigAnnot newSingletonConfigAnnot(TypeElement typeElement) {
     assertNotNull(typeElement);
-    return newInstance(typeElement, SingletonConfig.class, SingletonConfigAnnot::new);
+    return newInstance(
+        typeElement, org.seasar.doma.SingletonConfig.class, SingletonConfigAnnot::new);
   }
 
   public SqlAnnot newSqlAnnot(ExecutableElement method) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
@@ -27,7 +27,6 @@ import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import org.seasar.doma.DaoMethod;
-import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.Suppress;
 import org.seasar.doma.internal.Constants;
 import org.seasar.doma.internal.apt.AptException;
@@ -147,7 +146,9 @@ public class DaoMetaFactory implements TypeElementMetaFactory<DaoMeta> {
 
   private void validateUserDefinedConfig(
       TypeElement configElement, DaoMeta daoMeta, DaoAnnot daoAnnot) {
-    SingletonConfig singletonConfig = configElement.getAnnotation(SingletonConfig.class);
+    @SuppressWarnings("deprecation")
+    org.seasar.doma.SingletonConfig singletonConfig =
+        configElement.getAnnotation(org.seasar.doma.SingletonConfig.class);
     if (singletonConfig == null) {
       if (configElement.getModifiers().contains(Modifier.ABSTRACT)) {
         throw new AptException(

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/SingletonConfigProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/SingletonConfigProcessor.java
@@ -10,7 +10,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
-import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.internal.apt.AptException;
 import org.seasar.doma.internal.apt.AptIllegalStateException;
 import org.seasar.doma.internal.apt.Options;
@@ -22,8 +21,9 @@ import org.seasar.doma.message.Message;
 @SupportedOptions({Options.RESOURCES_DIR, Options.TEST, Options.DEBUG, Options.CONFIG_PATH})
 public class SingletonConfigProcessor extends AbstractProcessor {
 
+  @SuppressWarnings("deprecation")
   public SingletonConfigProcessor() {
-    super(SingletonConfig.class);
+    super(org.seasar.doma.SingletonConfig.class);
   }
 
   @Override

--- a/doma-processor/src/test/java/example/dao/EmpDao.java
+++ b/doma-processor/src/test/java/example/dao/EmpDao.java
@@ -14,6 +14,7 @@ import org.seasar.doma.SelectType;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = ExampleConfig.class)
 public interface EmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/MethodNotFoundConfig.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/MethodNotFoundConfig.java
@@ -5,6 +5,7 @@ import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.dialect.Dialect;
 
+@SuppressWarnings("deprecation")
 @SingletonConfig
 public class MethodNotFoundConfig implements Config {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/NoConfig.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/NoConfig.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.config;
 
 import org.seasar.doma.SingletonConfig;
 
+@SuppressWarnings("deprecation")
 @SingletonConfig
 public class NoConfig {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/PublicConstructorConfig.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/PublicConstructorConfig.java
@@ -5,6 +5,7 @@ import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.dialect.Dialect;
 
+@SuppressWarnings("deprecation")
 @SingletonConfig
 public class PublicConstructorConfig implements Config {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/ValidConfig.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/config/ValidConfig.java
@@ -5,6 +5,7 @@ import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.dialect.Dialect;
 
+@SuppressWarnings("deprecation")
 @SingletonConfig
 public class ValidConfig implements Config {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AnnotationConflictedDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AnnotationConflictedDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Delete;
 import org.seasar.doma.Update;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AnnotationConflictedDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AnnotationNotFoundDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AnnotationNotFoundDao.java
@@ -2,6 +2,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AnnotationNotFoundDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ArrayFactoryDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ArrayFactoryDao.java
@@ -4,6 +4,7 @@ import java.sql.Array;
 import org.seasar.doma.ArrayFactory;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ArrayFactoryDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoBatchUpdateDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoBatchUpdateDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.BatchUpdate;
 import org.seasar.doma.Dao;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoBatchUpdateDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoDeleteDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoDeleteDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Delete;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoDeleteDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoFunctionDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoFunctionDao.java
@@ -11,6 +11,7 @@ import org.seasar.doma.ResultSet;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 import org.seasar.doma.jdbc.Reference;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoFunctionDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoFunctionOptionalParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoFunctionOptionalParameterDao.java
@@ -11,7 +11,7 @@ import org.seasar.doma.Out;
 import org.seasar.doma.ResultSet;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface AutoFunctionOptionalParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoInsertDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoInsertDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoInsertDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoProcedureDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoProcedureDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Out;
 import org.seasar.doma.Procedure;
 import org.seasar.doma.jdbc.Reference;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoProcedureDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoProcedureOptionalParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoProcedureOptionalParameterDao.java
@@ -7,7 +7,7 @@ import org.seasar.doma.Out;
 import org.seasar.doma.Procedure;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface AutoProcedureOptionalParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoUpdateDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoUpdateDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Update;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface AutoUpdateDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/BasicResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/BasicResultDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface BasicResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/BlobFactoryDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/BlobFactoryDao.java
@@ -4,6 +4,7 @@ import java.sql.Blob;
 import org.seasar.doma.BlobFactory;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface BlobFactoryDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ClobFactoryDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ClobFactoryDao.java
@@ -4,6 +4,7 @@ import java.sql.Clob;
 import org.seasar.doma.ClobFactory;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ClobFactoryDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/CollectorDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/CollectorDao.java
@@ -14,6 +14,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface CollectorDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/CollectorOptionalParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/CollectorOptionalParameterDao.java
@@ -7,6 +7,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface CollectorOptionalParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ConfigAnnotateWithDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ConfigAnnotateWithDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = ExampleConfig.class)
 @AnnotateWith(
     annotations = {

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoExtendsDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface DaoExtendsDao extends EmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DefaultMethodDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DefaultMethodDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import java.math.BigDecimal;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface DefaultMethodDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DomainParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DomainParameterDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface DomainParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DomainResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DomainResultDao.java
@@ -9,6 +9,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface DomainResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ElementOfParamListUnspecifiedDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ElementOfParamListUnspecifiedDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ElementOfParamListUnspecifiedDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ElementOfParamListWildcardTypeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ElementOfParamListWildcardTypeDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ElementOfParamListWildcardTypeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmbeddedVariableDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmbeddedVariableDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EmbeddedVariableDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmpDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmpDao.java
@@ -10,6 +10,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmpDtoParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmpDtoParameterDao.java
@@ -7,6 +7,7 @@ import org.seasar.doma.Insert;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.EmpDto;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EmpDtoParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmptySqlFileDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EmptySqlFileDao.java
@@ -4,6 +4,7 @@ import example.entity.Emp;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EmptySqlFileDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnsureResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnsureResultDao.java
@@ -7,6 +7,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EnsureResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnsureResultMappingDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnsureResultMappingDao.java
@@ -10,6 +10,7 @@ import org.seasar.doma.ResultSet;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EnsureResultMappingDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EntityResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EntityResultDao.java
@@ -9,6 +9,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EntityResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnumDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/EnumDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface EnumDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/FunctionAbstractEntityListDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/FunctionAbstractEntityListDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Function;
 import org.seasar.doma.internal.apt.processor.entity.AbstractEntity;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface FunctionAbstractEntityListDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/FunctionDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/FunctionDao.java
@@ -12,7 +12,7 @@ import org.seasar.doma.Out;
 import org.seasar.doma.ResultSet;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface FunctionDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalBatchModifyImmutableEmpDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalBatchModifyImmutableEmpDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.BatchInsert;
 import org.seasar.doma.Dao;
 import org.seasar.doma.internal.apt.processor.entity.ImmutableEmp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IllegalBatchModifyImmutableEmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalModifyImmutableEmpDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalModifyImmutableEmpDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 import org.seasar.doma.internal.apt.processor.entity.ImmutableEmp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IllegalModifyImmutableEmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalParameterNameDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IllegalParameterNameDao.java
@@ -4,6 +4,7 @@ import example.entity.Emp;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IllegalParameterNameDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ImmutableEmpDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ImmutableEmpDao.java
@@ -12,6 +12,7 @@ import org.seasar.doma.internal.apt.processor.entity.ImmutableEmp;
 import org.seasar.doma.jdbc.BatchResult;
 import org.seasar.doma.jdbc.Result;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ImmutableEmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IncludeAndExcludeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IncludeAndExcludeDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Update;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IncludeAndExcludeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/Issue82Dao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/Issue82Dao.java
@@ -4,6 +4,7 @@ import example.entity.Emp;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Update;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface Issue82Dao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableRawTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableRawTypeParamDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IterableRawTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableRawTypeReturnDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableRawTypeReturnDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IterableRawTypeReturnDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableWildcardTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableWildcardTypeParamDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IterableWildcardTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableWildcardTypeReturnDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/IterableWildcardTypeReturnDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface IterableWildcardTypeReturnDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MapResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MapResultDao.java
@@ -9,6 +9,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MapResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MethodAccessSqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MethodAccessSqlValidationDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MethodAccessSqlValidationDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultiDaoExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultiDaoExtendsDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MultiDaoExtendsDao extends MyDao, MyDao2 {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultiParamMethodAccessSqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultiParamMethodAccessSqlValidationDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MultiParamMethodAccessSqlValidationDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MyDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MyDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MyDao {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MyDao2.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MyDao2.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface MyDao2 {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NClobFactoryDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NClobFactoryDao.java
@@ -4,6 +4,7 @@ import java.sql.NClob;
 import org.seasar.doma.Dao;
 import org.seasar.doma.NClobFactory;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NClobFactoryDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NameUnsafeDaoImpl.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NameUnsafeDaoImpl.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NameUnsafeDaoImpl {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoConfigDaoExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoConfigDaoExtendsDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NoConfigDaoExtendsDao extends NoConfigEmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoConfigDaoExtendsNoConfigDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoConfigDaoExtendsNoConfigDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.Update;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NoConfigDaoExtendsNoConfigDao extends NoConfigEmpDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoTestLiteralDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NoTestLiteralDao.java
@@ -4,6 +4,7 @@ import example.entity.Emp;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NoTestLiteralDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NonDaoExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NonDaoExtendsDao.java
@@ -3,5 +3,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 import java.io.Serializable;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NonDaoExtendsDao extends Serializable {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotInterfaceDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotInterfaceDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public class NotInterfaceDao {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotOnlyDefaultMethodsExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotOnlyDefaultMethodsExtendsDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface NotOnlyDefaultMethodsExtendsDao extends NotOnlyDefaultMethodsChild<String> {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotTopLevelDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/NotTopLevelDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 
 public interface NotTopLevelDao {
 
+  @SuppressWarnings("deprecation")
   @Dao(config = MyConfig.class)
   interface Hoge {}
 }

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OnlyDefaultMethodsExtendsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OnlyDefaultMethodsExtendsDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface OnlyDefaultMethodsExtendsDao extends OnlyDefaultMethods<String> {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalDoubleDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalDoubleDao.java
@@ -16,7 +16,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface OptionalDoubleDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalEntityListDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalEntityListDao.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface OptionalEntityListDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalIntDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalIntDao.java
@@ -16,7 +16,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface OptionalIntDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalLongDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalLongDao.java
@@ -16,7 +16,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.jdbc.Reference;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface OptionalLongDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalMapListDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalMapListDao.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface OptionalMapListDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/OptionalParameterDao.java
@@ -6,7 +6,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@SuppressWarnings({"OptionalUsedAsFieldOrParameterType", "deprecation"})
 @Dao(config = MyConfig.class)
 public interface OptionalParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PackageAccessLevelDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PackageAccessLevelDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class, accessLevel = AccessLevel.PACKAGE)
 public interface PackageAccessLevelDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PackagePrivateDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PackagePrivateDao.java
@@ -4,6 +4,7 @@ import example.entity.Emp;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Update;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 interface PackagePrivateDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedDomainResultDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedDomainResultDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ParameterizedDomainResultDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedParamDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ParameterizedParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedReturnDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ParameterizedReturnDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ParameterizedReturnDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PlainSingletonConfigDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PlainSingletonConfigDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = PlainSingletonConfig.class)
 public interface PlainSingletonConfigDao {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PrimitiveTypeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/PrimitiveTypeDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.In;
 import org.seasar.doma.Select;
 import org.seasar.doma.Update;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface PrimitiveTypeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ProcedureAbstractEntityListDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ProcedureAbstractEntityListDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Procedure;
 import org.seasar.doma.ResultSet;
 import org.seasar.doma.internal.apt.processor.entity.AbstractEntity;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ProcedureAbstractEntityListDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ProcedureDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ProcedureDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.MapKeyNamingType;
 import org.seasar.doma.Procedure;
 import org.seasar.doma.ResultSet;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ProcedureDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/RawTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/RawTypeParamDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface RawTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/RawTypeReturnDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/RawTypeReturnDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface RawTypeReturnDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ReferenceRawTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ReferenceRawTypeParamDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.In;
 import org.seasar.doma.Procedure;
 import org.seasar.doma.jdbc.Reference;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ReferenceRawTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ReferenceWildcardTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ReferenceWildcardTypeParamDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.In;
 import org.seasar.doma.Procedure;
 import org.seasar.doma.jdbc.Reference;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ReferenceWildcardTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ResultStreamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ResultStreamDao.java
@@ -10,6 +10,7 @@ import org.seasar.doma.Suppress;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 import org.seasar.doma.message.Message;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ResultStreamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SQLXMLFactoryDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SQLXMLFactoryDao.java
@@ -4,6 +4,7 @@ import java.sql.SQLXML;
 import org.seasar.doma.Dao;
 import org.seasar.doma.SQLXMLFactory;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SQLXMLFactoryDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ScriptDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/ScriptDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Script;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface ScriptDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SelectAbstractEntityDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SelectAbstractEntityDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.AbstractEntity;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SelectAbstractEntityDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SelectAbstractEntityListDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SelectAbstractEntityListDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.AbstractEntity;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SelectAbstractEntityListDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SingletonConfigAnnotatedConfig.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SingletonConfigAnnotatedConfig.java
@@ -5,6 +5,7 @@ import org.seasar.doma.SingletonConfig;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.dialect.Dialect;
 
+@SuppressWarnings("deprecation")
 @SingletonConfig
 public class SingletonConfigAnnotatedConfig implements Config {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SingletonConfigDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SingletonConfigDao.java
@@ -2,5 +2,6 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = SingletonConfigAnnotatedConfig.class)
 public interface SingletonConfigDao {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileBatchUpdateDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileBatchUpdateDao.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.seasar.doma.BatchUpdate;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileBatchUpdateDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileBatchUpdateEntityDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileBatchUpdateEntityDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.BatchUpdate;
 import org.seasar.doma.Dao;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileBatchUpdateEntityDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileInsertDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileInsertDao.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileInsertDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileInsertEntityDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileInsertEntityDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Insert;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 import org.seasar.doma.internal.apt.processor.entity.ParentEntity;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileInsertEntityDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectBasicDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectBasicDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileSelectBasicDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectDomainDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectDomainDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileSelectDomainDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectEntityDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectEntityDao.java
@@ -7,6 +7,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileSelectEntityDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectMapDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlFileSelectMapDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.MapKeyNamingType;
 import org.seasar.doma.Select;
 import org.seasar.doma.jdbc.SelectOptions;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlFileSelectMapDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorBiFunction1stArgCheckDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorBiFunction1stArgCheckDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.PreparedSql;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorBiFunction1stArgCheckDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorBiFunction2ndArgCheckDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorBiFunction2ndArgCheckDao.java
@@ -5,6 +5,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.Config;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorBiFunction2ndArgCheckDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorMultiBiFunctionsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorMultiBiFunctionsDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorMultiBiFunctionsDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorNoBiFunctionDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorNoBiFunctionDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.SqlProcessor;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorNoBiFunctionDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorRawTypeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorRawTypeDao.java
@@ -4,6 +4,7 @@ import java.util.function.BiFunction;
 import org.seasar.doma.Dao;
 import org.seasar.doma.SqlProcessor;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorRawTypeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorReturnTypeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorReturnTypeDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorReturnTypeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorWildcardTypeDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlProcessorWildcardTypeDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.SqlProcessor;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.PreparedSql;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlProcessorWildcardTypeDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlValidationSkipDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlValidationSkipDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlValidationSkipDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlValidationSkipWithConfigFileDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/SqlValidationSkipWithConfigFileDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlValidationSkipWithConfigFileDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StaticMethodDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StaticMethodDao.java
@@ -2,6 +2,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface StaticMethodDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StreamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StreamDao.java
@@ -10,6 +10,7 @@ import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface StreamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StreamOptionalParameterDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/StreamOptionalParameterDao.java
@@ -8,6 +8,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.SelectType;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface StreamOptionalParameterDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/UnknownBindVariableSqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/UnknownBindVariableSqlValidationDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface UnknownBindVariableSqlValidationDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/UnknownVariableSqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/UnknownVariableSqlValidationDao.java
@@ -4,6 +4,7 @@ import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 import org.seasar.doma.internal.apt.processor.entity.Emp;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface UnknownVariableSqlValidationDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/VarArgsDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/VarArgsDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface VarArgsDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/VirtualDefaultMethodDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/VirtualDefaultMethodDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import java.math.BigDecimal;
 import org.seasar.doma.Dao;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface VirtualDefaultMethodDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/WildcardTypeParamDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/WildcardTypeParamDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface WildcardTypeParamDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/WildcardTypeReturnDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/WildcardTypeReturnDao.java
@@ -3,6 +3,7 @@ package org.seasar.doma.internal.apt.processor.dao;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Select;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface WildcardTypeReturnDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/BatchSqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/BatchSqlValidationDao.java
@@ -6,6 +6,7 @@ import org.seasar.doma.Suppress;
 import org.seasar.doma.internal.apt.processor.dao.MyConfig;
 import org.seasar.doma.message.Message;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface BatchSqlValidationDao {
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/SqlValidationDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/SqlValidationDao.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.seasar.doma.Dao;
 import org.seasar.doma.internal.apt.processor.dao.MyConfig;
 
+@SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
 public interface SqlValidationDao {
 


### PR DESCRIPTION
The config element is redundant and not simple for most use cases.
Always pass a Config instance to DAO implementation class constructor.