### PR TITLE
Fix typo "IEDA" -> "IDEA"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ You can check the last publication date here:
 
 ### IDE
 
-#### IntelliJ IEDA
+#### IntelliJ IDEA
 
 Import the root directory as a Gradle project.
 


### PR DESCRIPTION
Excuse me for bothering you with a trivial PR. 
It seemed to be a simple typo, so I hope you will consider correcting it.