### PR TITLE
Add support for handling multiple AnnotateWith

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplGenerator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplGenerator.java
@@ -133,7 +133,7 @@ public class DaoImplGenerator extends AbstractGenerator {
     if (daoMeta.hasUserDefinedConfig()) {
       Code configCode = createConfigCode();
       printNoArgConstructor(configCode);
-      if (daoMeta.getAnnotateWithAnnot() == null) {
+      if (daoMeta.getAnnotateWithAnnots().isEmpty()) {
         boolean required = areJdbcConstructorsRequired();
         if (required) {
           printConnectionArgConstructor(configCode);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMeta.java
@@ -21,7 +21,7 @@ public class DaoMeta implements TypeElementMeta {
 
   private final DaoAnnot daoAnnot;
 
-  private AnnotateWithAnnot annotateWithAnnot;
+  private List<AnnotateWithAnnot> annotateWithAnnots = Collections.emptyList();
 
   private TypeMirror type;
 
@@ -90,23 +90,22 @@ public class DaoMeta implements TypeElementMeta {
     return daoAnnot.getAccessLevelValue();
   }
 
-  public AnnotateWithAnnot getAnnotateWithAnnot() {
-    return annotateWithAnnot;
+  public List<AnnotateWithAnnot> getAnnotateWithAnnots() {
+    return annotateWithAnnots;
   }
 
-  public void setAnnotateWithAnnot(AnnotateWithAnnot annotateWithAnnot) {
-    this.annotateWithAnnot = annotateWithAnnot;
+  public void setAnnotateWithAnnots(List<AnnotateWithAnnot> annotateWithAnnots) {
+    this.annotateWithAnnots = annotateWithAnnots;
   }
 
   public List<AnnotationAnnot> getAnnotationMirrors(AnnotationTarget target) {
     assertNotNull(target);
-    if (annotateWithAnnot == null || annotateWithAnnot.getAnnotationsValue() == null) {
-      return Collections.emptyList();
-    }
     List<AnnotationAnnot> results = new ArrayList<>();
-    for (AnnotationAnnot annotationAnnot : annotateWithAnnot.getAnnotationsValue()) {
-      if (target.name().contentEquals(annotationAnnot.getTargetValue().getSimpleName())) {
-        results.add(annotationAnnot);
+    for (AnnotateWithAnnot annotateWithAnnot : annotateWithAnnots) {
+      for (AnnotationAnnot annotationAnnot : annotateWithAnnot.getAnnotationsValue()) {
+        if (target.name().contentEquals(annotationAnnot.getTargetValue().getSimpleName())) {
+          results.add(annotationAnnot);
+        }
       }
     }
     return results;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
@@ -219,11 +219,9 @@ public class DaoMetaFactory implements TypeElementMetaFactory<DaoMeta> {
   }
 
   private void doAnnotateWith(DaoMeta daoMeta) {
-    AnnotateWithAnnot annotateWithAnnot =
-        ctx.getAnnotations().newAnnotateWithAnnot(daoMeta.getTypeElement());
-    if (annotateWithAnnot != null) {
-      daoMeta.setAnnotateWithAnnot(annotateWithAnnot);
-    }
+    List<AnnotateWithAnnot> annotateWithAnnots =
+        ctx.getAnnotations().newAnnotateWithAnnots(daoMeta.getTypeElement());
+    daoMeta.setAnnotateWithAnnots(annotateWithAnnots);
   }
 
   private void doParentDao(DaoMeta daoMeta) {

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
@@ -129,7 +129,8 @@ class DaoProcessorTest extends CompilerSupport {
           invocationContext(OnlyDefaultMethodsExtendsDao.class),
           invocationContext(
               ApplicationScopedDao.class,
-              "-Adoma.cdi.ApplicationScoped=" + ApplicationScoped.class.getCanonicalName()));
+              "-Adoma.cdi.ApplicationScoped=" + ApplicationScoped.class.getCanonicalName()),
+          invocationContext(MultipleAnnotateWithDao.class));
     }
 
     private TestTemplateInvocationContext invocationContext(Class<?> clazz, String... options) {

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotateWithDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotateWithDao.java
@@ -1,0 +1,28 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+import org.seasar.doma.AnnotateWith;
+import org.seasar.doma.Annotation;
+import org.seasar.doma.AnnotationTarget;
+import org.seasar.doma.Dao;
+import org.seasar.doma.Insert;
+import org.seasar.doma.internal.apt.processor.entity.Emp;
+
+@Dao
+@MultipleAnnotationConfig1
+@MultipleAnnotationConfig2
+@AnnotateWith(
+    annotations = {
+      @Annotation(
+          target = AnnotationTarget.CONSTRUCTOR_PARAMETER,
+          type = ConstructorParameterAnnotation.class,
+          elements = "aaa = 1, bbb = true"),
+      @Annotation(
+          target = AnnotationTarget.CONSTRUCTOR_PARAMETER,
+          type = ConstructorParameterAnnotation2.class,
+          elements = "aaa = 1, bbb = true")
+    })
+public interface MultipleAnnotateWithDao {
+
+  @Insert
+  int insert(Emp emp);
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotationConfig1.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotationConfig1.java
@@ -1,0 +1,24 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.seasar.doma.AnnotateWith;
+import org.seasar.doma.Annotation;
+import org.seasar.doma.AnnotationTarget;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AnnotateWith(
+    annotations = {
+      @Annotation(
+          target = AnnotationTarget.CLASS,
+          type = ClassAnnotation.class,
+          elements = "aaa = 1, bbb = true"),
+      @Annotation(
+          target = AnnotationTarget.CLASS,
+          type = ClassAnnotation2.class,
+          elements = "aaa = 1, bbb = true"),
+    })
+public @interface MultipleAnnotationConfig1 {}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotationConfig2.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/MultipleAnnotationConfig2.java
@@ -1,0 +1,24 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.seasar.doma.AnnotateWith;
+import org.seasar.doma.Annotation;
+import org.seasar.doma.AnnotationTarget;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AnnotateWith(
+    annotations = {
+      @Annotation(
+          target = AnnotationTarget.CONSTRUCTOR,
+          type = ConstructorAnnotation.class,
+          elements = "aaa = 1, bbb = true"),
+      @Annotation(
+          target = AnnotationTarget.CONSTRUCTOR,
+          type = ConstructorAnnotation2.class,
+          elements = "aaa = 1, bbb = true"),
+    })
+public @interface MultipleAnnotationConfig2 {}

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_MultipleAnnotateWithDao.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_MultipleAnnotateWithDao.txt
@@ -1,0 +1,62 @@
+package org.seasar.doma.internal.apt.processor.dao;
+
+/** */
+@org.seasar.doma.internal.apt.processor.dao.ClassAnnotation(aaa = 1, bbb = true)
+@org.seasar.doma.internal.apt.processor.dao.ClassAnnotation2(aaa = 1, bbb = true)
+@javax.annotation.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+@org.seasar.doma.DaoImplementation
+public class MultipleAnnotateWithDaoImpl implements org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDao, org.seasar.doma.jdbc.ConfigProvider {
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    private static final java.lang.reflect.Method __method0 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDao.class, "insert", org.seasar.doma.internal.apt.processor.entity.Emp.class);
+
+    private final org.seasar.doma.internal.jdbc.dao.DaoImplSupport __support;
+
+    /**
+     * @param config the config
+     */
+    @org.seasar.doma.internal.apt.processor.dao.ConstructorAnnotation(aaa = 1, bbb = true)
+    @org.seasar.doma.internal.apt.processor.dao.ConstructorAnnotation2(aaa = 1, bbb = true)
+    public MultipleAnnotateWithDaoImpl(@org.seasar.doma.internal.apt.processor.dao.ConstructorParameterAnnotation(aaa = 1, bbb = true) @org.seasar.doma.internal.apt.processor.dao.ConstructorParameterAnnotation2(aaa = 1, bbb = true) org.seasar.doma.jdbc.Config config) {
+        __support = new org.seasar.doma.internal.jdbc.dao.DaoImplSupport(config);
+    }
+
+    @Override
+    public org.seasar.doma.jdbc.Config getConfig() {
+        return __support.getConfig();
+    }
+
+    @Override
+    public int insert(org.seasar.doma.internal.apt.processor.entity.Emp emp) {
+        __support.entering("org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDaoImpl", "insert", emp);
+        try {
+            if (emp == null) {
+                throw new org.seasar.doma.DomaNullPointerException("emp");
+            }
+            org.seasar.doma.jdbc.query.AutoInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoInsertQuery(__method0, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
+            __query.setMethod(__method0);
+            __query.setConfig(__support.getConfig());
+            __query.setEntity(emp);
+            __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDaoImpl");
+            __query.setCallerMethodName("insert");
+            __query.setQueryTimeout(-1);
+            __query.setSqlLogType(org.seasar.doma.jdbc.SqlLogType.FORMATTED);
+            __query.setNullExcluded(false);
+            __query.setIncludedPropertyNames();
+            __query.setExcludedPropertyNames();
+            __query.prepare();
+            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method0, __query);
+            int __result = __command.execute();
+            __query.complete();
+            __support.exiting("org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDaoImpl", "insert", __result);
+            return __result;
+        } catch (java.lang.RuntimeException __e) {
+            __support.throwing("org.seasar.doma.internal.apt.processor.dao.MultipleAnnotateWithDaoImpl", "insert", __e);
+            throw __e;
+        }
+    }
+
+}


### PR DESCRIPTION
## Overview

Add support for handling multiple `@AnnotateWith`.

## Motivation

If I want to handle two `Config` using `Qualifier` in an application that uses 'doma-spring-boot (So if I want to handle two `DataSources`), I have to copy `ConfigAutowireable` and define the following annotation.

```java
@AnnotateWith(annotations = {
    @Annotation(target = AnnotationTarget.CLASS, type = Repository.class),
    @Annotation(target = AnnotationTarget.CONSTRUCTOR, type = Autowired.class),
    @Annotation(target = AnnotationTarget.CONSTRUCTOR_PARAMETER, type = Qualifier.class, elements = "\"secondary\"") })
public @interface SecondaryConfigAutowireable {
}
```

When Doma is able to handle multiple `@AnnotateWith`, I only need to define the difference that uses `Qualifier`.

```java
@AnnotateWith(annotations = {
    @Annotation(target = AnnotationTarget.CONSTRUCTOR_PARAMETER, type = Qualifier.class, elements = "\"secondary\"") })
public @interface UseSecondaryConfig {
}
```

The DAO interface is defined as follows:

```java
@Dao
@ConfigAutowireable //Built-in doma-spring-boot
@UseSecondaryConfig
public interface SecondaryDao {
```