### PR TITLE
Support to include/exclude properties in the Criteria INSERT/UPDATE statements

### DIFF
--- a/docs/criteria-api.rst
+++ b/docs/criteria-api.rst
@@ -1193,6 +1193,8 @@ We support the following settings:
 * sqlLogType
 * batchSize
 * excludeNull
+* include
+* exclude
 
 They are all optional.
 
@@ -1220,6 +1222,16 @@ You can apply them as follows:
                   c.value(d.version, 1);
                 })
             .execute();
+
+.. code-block:: java
+
+    Department_ d = new Department_();
+
+    Department department = ...;
+
+    Result<Department> result = entityql.insert(d, department, settings ->
+        settings.exclude(d.departmentName, d.location)
+    ).execute();
 
 Insert statement (Entityql)
 ----------------------------
@@ -1330,6 +1342,8 @@ We support the following settings:
 * sqlLogType
 * suppressOptimisticLockException
 * excludeNull
+* include
+* exclude
 
 They are all optional.
 
@@ -1351,6 +1365,16 @@ You can apply them as follows:
     }).set(c -> {
       c.value(e.employeeName, "aaa");
     }).execute();
+
+.. code-block:: java
+
+    Employee_ e = new Employee_();
+
+    Employee employee = ...;
+
+    Result<Employee> result = entityql.update(e, employee, settings ->
+      settings.exclude(e.hiredate, e.salary)
+    ).execute();
 
 .. note::
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/InsertSettings.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/InsertSettings.java
@@ -1,11 +1,17 @@
 package org.seasar.doma.jdbc.criteria.context;
 
 import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 
 /** Represents the settings for an INSERT criteria query. */
 public class InsertSettings extends Settings {
   private int batchSize = 0;
   private boolean excludeNull;
+  private final List<PropertyMetamodel<?>> includedProperties = new ArrayList<>();
+  private final List<PropertyMetamodel<?>> excludedProperties = new ArrayList<>();
 
   /**
    * Returns the batch size.
@@ -48,5 +54,41 @@ public class InsertSettings extends Settings {
    */
   public void setExcludeNull(boolean excludeNull) {
     this.excludeNull = excludeNull;
+  }
+
+  /**
+   * Returns the included properties.
+   *
+   * @return the included properties
+   */
+  public List<PropertyMetamodel<?>> include() {
+    return includedProperties;
+  }
+
+  /**
+   * Sets the included properties.
+   *
+   * @param propertyMetamodels the included properties
+   */
+  public void include(PropertyMetamodel<?>... propertyMetamodels) {
+    Collections.addAll(includedProperties, propertyMetamodels);
+  }
+
+  /**
+   * Returns the excluded properties.
+   *
+   * @return the excluded properties
+   */
+  public List<PropertyMetamodel<?>> exclude() {
+    return excludedProperties;
+  }
+
+  /**
+   * Sets the excluded properties.
+   *
+   * @param propertyMetamodels the excluded properties
+   */
+  public void exclude(PropertyMetamodel<?>... propertyMetamodels) {
+    Collections.addAll(excludedProperties, propertyMetamodels);
   }
 }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/UpdateSettings.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/context/UpdateSettings.java
@@ -1,6 +1,10 @@
 package org.seasar.doma.jdbc.criteria.context;
 
 import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 
 /** Represents the settings for an UPDATE criteria query. */
 public class UpdateSettings extends Settings {
@@ -9,6 +13,8 @@ public class UpdateSettings extends Settings {
   private boolean ignoreVersion;
   private boolean suppressOptimisticLockException;
   private boolean excludeNull;
+  private final List<PropertyMetamodel<?>> includedProperties = new ArrayList<>();
+  private final List<PropertyMetamodel<?>> excludedProperties = new ArrayList<>();
 
   /**
    * Returns the batch size.
@@ -114,5 +120,41 @@ public class UpdateSettings extends Settings {
    */
   public void setExcludeNull(boolean excludeNull) {
     this.excludeNull = excludeNull;
+  }
+
+  /**
+   * Returns the included properties.
+   *
+   * @return the included properties
+   */
+  public List<PropertyMetamodel<?>> include() {
+    return includedProperties;
+  }
+
+  /**
+   * Sets the included properties.
+   *
+   * @param propertyMetamodels the included properties
+   */
+  public void include(PropertyMetamodel<?>... propertyMetamodels) {
+    Collections.addAll(includedProperties, propertyMetamodels);
+  }
+
+  /**
+   * Returns the excluded properties.
+   *
+   * @return the excluded properties
+   */
+  public List<PropertyMetamodel<?>> exclude() {
+    return excludedProperties;
+  }
+
+  /**
+   * Sets the excluded properties.
+   *
+   * @param propertyMetamodels the excluded properties
+   */
+  public void exclude(PropertyMetamodel<?>... propertyMetamodels) {
+    Collections.addAll(excludedProperties, propertyMetamodels);
   }
 }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlInsertStatement.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlInsertStatement.java
@@ -7,6 +7,7 @@ import org.seasar.doma.jdbc.command.Command;
 import org.seasar.doma.jdbc.command.InsertCommand;
 import org.seasar.doma.jdbc.criteria.context.InsertSettings;
 import org.seasar.doma.jdbc.criteria.metamodel.EntityMetamodel;
+import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.AutoInsertQuery;
 import org.seasar.doma.jdbc.query.Query;
@@ -54,8 +55,10 @@ public class EntityqlInsertStatement<ENTITY>
     query.setQueryTimeout(settings.getQueryTimeout());
     query.setSqlLogType(settings.getSqlLogType());
     query.setNullExcluded(settings.getExcludeNull());
-    query.setIncludedPropertyNames();
-    query.setExcludedPropertyNames();
+    query.setIncludedPropertyNames(
+        settings.include().stream().map(PropertyMetamodel::getName).toArray(String[]::new));
+    query.setExcludedPropertyNames(
+        settings.exclude().stream().map(PropertyMetamodel::getName).toArray(String[]::new));
     query.setMessage(settings.getComment());
     query.prepare();
     InsertCommand command =

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlUpdateStatement.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlUpdateStatement.java
@@ -8,6 +8,7 @@ import org.seasar.doma.jdbc.command.Command;
 import org.seasar.doma.jdbc.command.UpdateCommand;
 import org.seasar.doma.jdbc.criteria.context.UpdateSettings;
 import org.seasar.doma.jdbc.criteria.metamodel.EntityMetamodel;
+import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.AutoUpdateQuery;
 import org.seasar.doma.jdbc.query.Query;
@@ -60,8 +61,10 @@ public class EntityqlUpdateStatement<ENTITY>
     query.setSqlLogType(settings.getSqlLogType());
     query.setNullExcluded(settings.getExcludeNull());
     query.setVersionIgnored(settings.getIgnoreVersion());
-    query.setIncludedPropertyNames();
-    query.setExcludedPropertyNames();
+    query.setIncludedPropertyNames(
+        settings.include().stream().map(PropertyMetamodel::getName).toArray(String[]::new));
+    query.setExcludedPropertyNames(
+        settings.exclude().stream().map(PropertyMetamodel::getName).toArray(String[]::new));
     query.setUnchangedPropertyIncluded(false);
     query.setOptimisticLockExceptionSuppressed(settings.getSuppressOptimisticLockException());
     query.setMessage(settings.getComment());

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlInsertTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlInsertTest.java
@@ -46,4 +46,35 @@ class EntityqlInsertTest {
     assertEquals(
         "insert into EMP (ID, SALARY, VERSION) values (1, 1000, 1)", sql.getFormattedSql());
   }
+
+  @Test
+  void include() {
+    Emp emp = new Emp();
+    emp.setId(1);
+    emp.setName("aaa");
+    emp.setSalary(new BigDecimal("1000"));
+    emp.setVersion(1);
+
+    Emp_ e = new Emp_();
+    Buildable<?> stmt = entityql.insert(e, emp, settings -> settings.include(e.salary));
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "insert into EMP (ID, SALARY, VERSION) values (1, 1000, 1)", sql.getFormattedSql());
+  }
+
+  @Test
+  void exclude() {
+    Emp emp = new Emp();
+    emp.setId(1);
+    emp.setName("aaa");
+    emp.setSalary(new BigDecimal("1000"));
+    emp.setVersion(1);
+
+    Emp_ e = new Emp_();
+    Buildable<?> stmt = entityql.insert(e, emp, settings -> settings.exclude(e.salary));
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals("insert into EMP (ID, NAME, VERSION) values (1, 'aaa', 1)", sql.getFormattedSql());
+  }
 }

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlUpdateTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/EntityqlUpdateTest.java
@@ -32,6 +32,40 @@ class EntityqlUpdateTest {
   }
 
   @Test
+  void include() {
+    Emp emp = new Emp();
+    emp.setId(1);
+    emp.setName("aaa");
+    emp.setSalary(new BigDecimal("1000"));
+    emp.setVersion(1);
+
+    Emp_ e = new Emp_();
+    Buildable<?> stmt = entityql.update(e, emp, settings -> settings.include(e.salary));
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "update EMP set SALARY = 1000, VERSION = 1 + 1 where ID = 1 and VERSION = 1",
+        sql.getFormattedSql());
+  }
+
+  @Test
+  void exclude() {
+    Emp emp = new Emp();
+    emp.setId(1);
+    emp.setName("aaa");
+    emp.setSalary(new BigDecimal("1000"));
+    emp.setVersion(1);
+
+    Emp_ e = new Emp_();
+    Buildable<?> stmt = entityql.update(e, emp, settings -> settings.exclude(e.salary));
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "update EMP set NAME = 'aaa', VERSION = 1 + 1 where ID = 1 and VERSION = 1",
+        sql.getFormattedSql());
+  }
+
+  @Test
   void ignoreVersion() {
     Emp emp = new Emp();
     emp.setId(1);


### PR DESCRIPTION
For example, use `settings.exclude()` to exclude properties in the UPDATE statement:

```java
Emp emp = new Emp();
emp.setId(1);
emp.setName("aaa");
emp.setAge(20);
emp.setSalary(new BigDecimal("1000"));
emp.setVersion(1);

Emp_ e = new Emp_();
Buildable<?> stmt = entityql.update(e, emp, settings -> settings.exclude(e.age, e.salary));
```