### PR TITLE
Fix minor Kotlin doc issue

### DIFF
--- a/docs/kotlin-support.rst
+++ b/docs/kotlin-support.rst
@@ -94,7 +94,7 @@ Dao interfaces
 .. code-block:: java
 
   val dao: PersonDao = ...
-  val person = Person(name = Name("Jhon"), address = Address(city = "Tokyo", street = "Yaesu"))
+  val person = Person(name = Name("John"), address = Address(city = "Tokyo", street = "Yaesu"))
   val (newPerson, count) = dao.insert(person)
 
 .. _kotlin-specific-criteria-api:

--- a/docs/kotlin-support.rst
+++ b/docs/kotlin-support.rst
@@ -85,7 +85,7 @@ Dao interfaces
     fun selectById(id: Int): Person
 
     @Insert
-    fun insert(Person person): Result<Person>
+    fun insert(person: Person): Result<Person>
   }
 
 * Use `Destructuring Declarations <https://kotlinlang.org/docs/reference/multi-declarations.html>`_


### PR DESCRIPTION
## Changes

Fixed some typo in Kotlin document.

## Question

I wonder whether `@Insert` is really supported or not in Kotlin because it seems that doma-processor does not generate `insert` method implementation in `PersonDaoImpl` class.

When I cloned [kotlin-sample](https://github.com/domaframework/kotlin-sample) project and modify `PersonDao` interface to use `@Insert` annotation, ` gradlew build` failed.

```diff
diff --git a/src/main/kotlin/sample/dao/PersonDao.kt b/src/main/kotlin/sample/dao/PersonDao.kt
index 18b3215..5066b70 100644
--- a/src/main/kotlin/sample/dao/PersonDao.kt
+++ b/src/main/kotlin/sample/dao/PersonDao.kt
@@ -1,6 +1,7 @@
 package sample.dao
 
 import org.seasar.doma.Dao
+import org.seasar.doma.Insert
 import org.seasar.doma.Select
 import org.seasar.doma.Sql
 import org.seasar.doma.jdbc.Config
@@ -37,11 +38,8 @@ interface PersonDao {
         }.fetch()
     }
 
-    fun insert(person: Person): Person {
-        val p = Person_()
-        val result = entityql.insert(p, person).execute()
-        return result.entity
-    }
+    @Insert
+    fun insert(person: Person): Result<Person>
 
     fun update(person: Person): Person {
         val p = Person_()
```

```
> Task :compileJava
/Users/oohira/src/github.com/domaframework/kotlin-sample/build/generated/source/kapt/main/sample/dao/PersonDaoImpl.java:6: error: PersonDaoImpl is not abstract and does not override abstract method insert-IoAF18A(Person) in PersonDao
public class PersonDaoImpl implements sample.dao.PersonDao, org.seasar.doma.jdbc.ConfigProvider {
       ^
1 error
```