### PR TITLE
Revert "Update org.jetbrains.kotlin to v1.8.0"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ pluginManagement {
         id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
         id("net.researchgate.release") version "3.0.2"
         id("org.domaframework.doma.compile") version "2.0.0"
-        kotlin("jvm") version "1.8.0"
-        kotlin("kapt") version "1.8.0"
+        kotlin("jvm") version "1.7.22"
+        kotlin("kapt") version "1.7.22"
     }
 }
 


### PR DESCRIPTION
This reverts commit 54f4de0833f5285d7c11deb1a65b56eeffd1037c.

Because CodeQL currently supports versions below 1.7.30.