### PR TITLE
Replaced full-width space with half-width space

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -465,7 +465,7 @@ public enum Message implements MessageResource {
           + "The method must have the return type \"{1}\" and must be non-private and non-args."),
   DOMA4105("You can annotate only classes, interfaces, enums and records with @Domain"),
   DOMA4106(
-      "The factory method　\"{0}\" is not found. "
+      "The factory method \"{0}\" is not found. "
           + "The method must have the return type \"{1}\" and the parameter type \"{2}\" and must be non-private and static. "
           + "The type parameter of the method must be same with the type parameter of the class. "
           + "Define the factory method. "


### PR DESCRIPTION
hello,

I found there is a full-width space in DOMA error message.
I think this should be half-width, so I modified it.