### PR TITLE
Prohibit to treat a basic type as an external domain type

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -921,6 +921,8 @@ public enum Message implements MessageResource {
   DOMA4457("You must always receive the EntityMetamodel as the first parameter"),
   DOMA4458("You can't use static methods"),
   DOMA4459("Must be a public method"),
+  DOMA4460(
+      "The first type argument \"{0}\" of org.seasar.doma.jdbc.domain.DomainConverter must not be a basic type."),
 
   // other
   DOMA5001(

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/ExternalDomainMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/ExternalDomainMetaFactory.java
@@ -128,6 +128,12 @@ public class ExternalDomainMetaFactory implements TypeElementMetaFactory<Externa
             Message.DOMA4203, converterElement, new Object[] {domainElement.getQualifiedName()});
       }
     }
+
+    BasicCtType basicCtType = ctx.getCtTypes().newBasicCtType(declaredType);
+    if (basicCtType != null) {
+      throw new AptException(Message.DOMA4460, converterElement, new Object[] {declaredType});
+    }
+
     meta.setTypeElement(domainElement);
     TypeParametersDef typeParametersDef = ctx.getMoreElements().getTypeParametersDef(domainElement);
     meta.setTypeParametersDef(typeParametersDef);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/BasicTypeConverter.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/BasicTypeConverter.java
@@ -1,0 +1,18 @@
+package org.seasar.doma.internal.apt.processor.domain;
+
+import org.seasar.doma.ExternalDomain;
+import org.seasar.doma.jdbc.domain.DomainConverter;
+
+@ExternalDomain
+public class BasicTypeConverter implements DomainConverter<Boolean, Integer> {
+
+  @Override
+  public Integer fromDomainToValue(Boolean domain) {
+    return null;
+  }
+
+  @Override
+  public Boolean fromValueToDomain(Integer value) {
+    return null;
+  }
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
@@ -108,7 +108,8 @@ class ExternalDomainProcessorTest extends CompilerSupport {
           invocationContext(ConstructorNotFoundDomainConverter.class, Message.DOMA4193),
           invocationContext(AbstractDomainConverter.class, Message.DOMA4192),
           invocationContext(MultidimensionalArrayConverter.class, Message.DOMA4447),
-          invocationContext(ListArrayConverter.class, Message.DOMA4448));
+          invocationContext(ListArrayConverter.class, Message.DOMA4448),
+          invocationContext(BasicTypeConverter.class, Message.DOMA4460));
     }
 
     private TestTemplateInvocationContext invocationContext(


### PR DESCRIPTION
This pull request prohibits, for example, the following class:

```java
@ExternalDomain
public class BooleanConverter implements DomainConverter<Boolean, Integer> {

  @Override
  public Integer fromDomainToValue(Boolean domain) {
    return domain ? 1 : 0;
  }

  @Override
  public Boolean fromValueToDomain(Integer value) {
    return value == 1;
  }
}
```

This is because the Boolean type is a basic type.

See also #933.
