### PR TITLE
Fix #983 provides processor missing for apt module

### DIFF
--- a/doma-processor/src/module/org.seasar.doma.processor/module-info.java
+++ b/doma-processor/src/module/org.seasar.doma.processor/module-info.java
@@ -1,4 +1,14 @@
 module org.seasar.doma.processor {
   requires java.compiler;
   requires org.seasar.doma.core;
+  provides javax.annotation.processing.Processor with 
+    org.seasar.doma.internal.apt.processor.DomainProcessor,
+    org.seasar.doma.internal.apt.processor.DataTypeProcessor,
+    org.seasar.doma.internal.apt.processor.ExternalDomainProcessor,
+    org.seasar.doma.internal.apt.processor.DomainConvertersProcessor,
+    org.seasar.doma.internal.apt.processor.EmbeddableProcessor,
+    org.seasar.doma.internal.apt.processor.EntityProcessor,
+    org.seasar.doma.internal.apt.processor.DaoProcessor,
+    org.seasar.doma.internal.apt.processor.ScopeProcessor,
+    org.seasar.doma.internal.apt.processor.SingletonConfigProcessor;
 }


### PR DESCRIPTION
This fix will allow the annotation processor to run in a modular build environment.

Maven nor Gradle support this currently but it is supported by javac:

https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-processor-module-path