### PR TITLE
Provide shadowed doma-processor jar

### DIFF
--- a/doma-processor/build.gradle.kts
+++ b/doma-processor/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+}
+
 description = "doma-processor"
 
 dependencies {


### PR DESCRIPTION
This feature is optional.

To use the shadowed jar, use the `all` classifier in the dependency notation:

```
dependencies {
    annotationProcessor("org.seasar.doma:doma-processor:2.54.1:all")
}
```
