### PR TITLE
Fix expression equality in the Criteria API

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/AggregateFunction.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/AggregateFunction.java
@@ -43,7 +43,7 @@ public interface AggregateFunction<PROPERTY> extends PropertyMetamodel<PROPERTY>
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof AbstractFunction)) return false;
+      if (o == null || getClass() != o.getClass()) return false;
       AbstractFunction<?> that = (AbstractFunction<?>) o;
       return name.equals(that.name) && argument.equals(that.argument);
     }
@@ -123,6 +123,20 @@ public interface AggregateFunction<PROPERTY> extends PropertyMetamodel<PROPERTY>
         AggregateFunction.Visitor v = (AggregateFunction.Visitor) visitor;
         v.visit(this);
       }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      Count count = (Count) o;
+      return distinct == count.distinct;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), distinct);
     }
   }
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/ArithmeticExpression.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/ArithmeticExpression.java
@@ -32,7 +32,7 @@ public interface ArithmeticExpression<PROPERTY> extends PropertyMetamodel<PROPER
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof AbstractArithmeticExpression)) return false;
+      if (o == null || getClass() != o.getClass()) return false;
       AbstractArithmeticExpression<?> that = (AbstractArithmeticExpression<?>) o;
       return propertyMetamodel.equals(that.propertyMetamodel)
           && left.equals(that.left)

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/StringExpression.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/expression/StringExpression.java
@@ -34,7 +34,7 @@ public interface StringExpression<PROPERTY> extends PropertyMetamodel<PROPERTY> 
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof StringExpression.OneArgumentStringExpression)) return false;
+      if (o == null || getClass() != o.getClass()) return false;
       OneArgumentStringExpression<?> that = (OneArgumentStringExpression<?>) o;
       return argument.equals(that.argument);
     }
@@ -80,7 +80,7 @@ public interface StringExpression<PROPERTY> extends PropertyMetamodel<PROPERTY> 
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof StringExpression.TwoArgumentsStringExpression)) return false;
+      if (o == null || getClass() != o.getClass()) return false;
       TwoArgumentsStringExpression<?> that = (TwoArgumentsStringExpression<?>) o;
       return propertyMetamodel.equals(that.propertyMetamodel)
           && first.equals(that.first)

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/expression/ExpressionsTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/expression/ExpressionsTest.java
@@ -25,6 +25,7 @@ import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 import org.seasar.doma.DomaIllegalArgumentException;
 import org.seasar.doma.jdbc.criteria.entity.Emp_;
+import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 
 class ExpressionsTest {
 
@@ -228,5 +229,42 @@ class ExpressionsTest {
 
     assertEquals("sum", sum(e.id).getName());
     assertEquals(e.id, sum(e.id).argument());
+  }
+
+  @Test
+  void testEquality() {
+    PropertyMetamodel<?> sum = sum(e.id);
+    PropertyMetamodel<?> div = div(sum(e.id), 1);
+    PropertyMetamodel<?> mod = mod(sum(e.id), 1);
+    PropertyMetamodel<?> mul = mul(sum(e.id), 1);
+    PropertyMetamodel<?> sub = sub(sum(e.id), 1);
+    PropertyMetamodel<?> add = add(sum(e.id), 1);
+
+    assertEquals(sum, sum(e.id));
+    assertEquals(div, div(sum(e.id), 1));
+    assertEquals(mod, mod(sum(e.id), 1));
+    assertEquals(mul, mul(sum(e.id), 1));
+    assertEquals(sub, sub(sum(e.id), 1));
+    assertEquals(add, add(sum(e.id), 1));
+
+    assertNotEquals(sum, div);
+    assertNotEquals(sum, mod);
+    assertNotEquals(sum, mul);
+    assertNotEquals(sum, sub);
+    assertNotEquals(sum, add);
+
+    assertNotEquals(div, mod);
+    assertNotEquals(div, mul);
+    assertNotEquals(div, sub);
+    assertNotEquals(div, add);
+
+    assertNotEquals(mod, mul);
+    assertNotEquals(mod, sub);
+    assertNotEquals(mod, add);
+
+    assertNotEquals(mul, sub);
+    assertNotEquals(mul, add);
+
+    assertNotEquals(sub, add);
   }
 }


### PR DESCRIPTION
In the Criteria API, we have fixed the issue where different expressions were mistakenly regarded as having the same value.