### PR TITLE
Use env context instead of vars context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
+  env:
+    JDK_DISTRIBUTION: "zulu"
+    JDK_VERSION_OLDEST: "8"
+    JDK_VERSION_LATEST: "21"
+    JDK_VERSION_LATEST_LTS: "21"
 
 jobs:
   build:
@@ -17,11 +22,11 @@ jobs:
       - name: Set up JDKs
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ vars.JDK_DISTRIBUTION }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: |
-            ${{ vars.JDK_VERSION_OLDEST }}
-            ${{ vars.JDK_VERSION_LATEST }}
-            ${{ vars.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
+            ${{ env.JDK_VERSION_LATEST }}
+            ${{ env.JDK_VERSION_LATEST_LTS }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +37,7 @@ jobs:
       - name: Assemble and Check
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ vars.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ vars.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           assemble check
 
       - name: Upload reports
@@ -56,11 +61,11 @@ jobs:
       - name: Set up JDKs
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ vars.JDK_DISTRIBUTION }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: |
-            ${{ vars.JDK_VERSION_OLDEST }}
-            ${{ vars.JDK_VERSION_LATEST }}
-            ${{ vars.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
+            ${{ env.JDK_VERSION_LATEST }}
+            ${{ env.JDK_VERSION_LATEST_LTS }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,8 +77,8 @@ jobs:
         run: >
           ./gradlew
           -Pdriver=${{ matrix.driver }}
-          -PtestJavaLangVersion=${{ vars.JDK_VERSION_OLDEST }}
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ vars.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ vars.JDK_VERSION_LATEST }}_X64
+          -PtestJavaLangVersion=${{ env.JDK_VERSION_OLDEST }}
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           integration-test-java:test
           integration-test-kotlin:test
 
@@ -81,8 +86,8 @@ jobs:
         run: >
           ./gradlew
           -Pdriver=${{ matrix.driver }}
-          -PtestJavaLangVersion=${{ vars.JDK_VERSION_LATEST }}
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ vars.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ vars.JDK_VERSION_LATEST }}_X64
+          -PtestJavaLangVersion=${{ env.JDK_VERSION_LATEST }}
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           -PtestUseModule=true
           integration-test-java:test
           integration-test-java-additional:test
@@ -91,7 +96,7 @@ jobs:
         run: >
           ./gradlew
           -Pdriver=${{ matrix.driver }}
-          -PtestJavaLangVersion=${{ vars.JDK_VERSION_LATEST_LTS }}
+          -PtestJavaLangVersion=${{ env.JDK_VERSION_LATEST_LTS }}
           -PtestUseModule=true
           integration-test-java:test
           integration-test-java-additional:test
@@ -116,11 +121,11 @@ jobs:
       - name: Set up JDKs
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ vars.JDK_DISTRIBUTION }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: |
-            ${{ vars.JDK_VERSION_OLDEST }}
-            ${{ vars.JDK_VERSION_LATEST }}
-            ${{ vars.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
+            ${{ env.JDK_VERSION_LATEST }}
+            ${{ env.JDK_VERSION_LATEST_LTS }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -136,7 +141,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ vars.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ vars.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           publishToSonatype closeAndReleaseSonatypeStagingRepository
 
       - name: Upload reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
-  env:
-    JDK_DISTRIBUTION: "zulu"
-    JDK_VERSION_OLDEST: "8"
-    JDK_VERSION_LATEST: "21"
-    JDK_VERSION_LATEST_LTS: "21"
+
+env:
+  JDK_DISTRIBUTION: zulu
+  JDK_VERSION_OLDEST: 8
+  JDK_VERSION_LATEST: 21
+  JDK_VERSION_LATEST_LTS: 21
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  env:
+    JDK_DISTRIBUTION: "zulu"
+    JDK_VERSION_OLDEST: "8"
+    JDK_VERSION_LATEST: "21"
+    JDK_VERSION_LATEST_LTS: "21"
 
 jobs:
   CodeQL-Build:
@@ -22,11 +27,11 @@ jobs:
       - name: Set up JDKs
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ vars.JDK_DISTRIBUTION }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: |
-            ${{ vars.JDK_VERSION_OLDEST }}
-            ${{ vars.JDK_VERSION_LATEST }}
-            ${{ vars.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
+            ${{ env.JDK_VERSION_LATEST }}
+            ${{ env.JDK_VERSION_LATEST_LTS }}
 
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2.11.0
@@ -34,7 +39,7 @@ jobs:
       - name: Build
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ vars.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ vars.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           assemble check
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,11 +4,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-  env:
-    JDK_DISTRIBUTION: "zulu"
-    JDK_VERSION_OLDEST: "8"
-    JDK_VERSION_LATEST: "21"
-    JDK_VERSION_LATEST_LTS: "21"
+
+env:
+  JDK_DISTRIBUTION: zulu
+  JDK_VERSION_OLDEST: 8
+  JDK_VERSION_LATEST: 21
+  JDK_VERSION_LATEST_LTS: 21
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: 'Release version'
         required: false
+  env:
+    JDK_DISTRIBUTION: "zulu"
+    JDK_VERSION_LATEST_LTS: "21"
 
 jobs:
   release:
@@ -39,8 +42,8 @@ jobs:
       - name: Set up the latest LTS JDK
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ vars.JDK_DISTRIBUTION }}
-          java-version: ${{ vars.JDK_VERSION_LATEST_LTS }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+          java-version: ${{ env.JDK_VERSION_LATEST_LTS }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@ on:
       version:
         description: 'Release version'
         required: false
-  env:
-    JDK_DISTRIBUTION: "zulu"
-    JDK_VERSION_LATEST_LTS: "21"
+
+env:
+  JDK_DISTRIBUTION: zulu
+  JDK_VERSION_LATEST_LTS: 21
 
 jobs:
   release:


### PR DESCRIPTION
Because actions variables are not passed to workflows that are triggered by a pull request from a fork.