### PR TITLE
Improve the performance of annotation processing in Eclipse

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -44,6 +44,8 @@ public class MoreElements implements Elements {
 
   private final Elements elementUtils;
 
+  private final Map<Class<?>, TypeElement> typeElementCache = new HashMap<>(64);
+
   public MoreElements(Context ctx, ProcessingEnvironment env) {
     assertNotNull(ctx, env);
     this.ctx = ctx;
@@ -200,7 +202,7 @@ public class MoreElements implements Elements {
       return getEnclosedTypeElement(topElement, Arrays.asList(parts).subList(1, parts.length));
     }
     try {
-      return elementUtils.getTypeElement(binaryName);
+      return getTypeElement(binaryName);
     } catch (NullPointerException ignored) {
       return null;
     }
@@ -208,7 +210,8 @@ public class MoreElements implements Elements {
 
   public TypeElement getTypeElement(Class<?> clazz) {
     assertNotNull(clazz);
-    return elementUtils.getTypeElement(clazz.getCanonicalName());
+    return typeElementCache.computeIfAbsent(
+        clazz, k -> elementUtils.getTypeElement(k.getCanonicalName()));
   }
 
   private TypeElement getEnclosedTypeElement(TypeElement typeElement, List<String> enclosedNames) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
@@ -160,12 +160,7 @@ public class MoreTypes implements Types {
     if (element == null) {
       return null;
     }
-    TypeElement typeElement = ctx.getMoreElements().toTypeElement(element);
-    if (typeElement == null) {
-      return null;
-    }
-    // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544288
-    return ctx.getMoreElements().getTypeElement(typeElement.getQualifiedName());
+    return ctx.getMoreElements().toTypeElement(element);
   }
 
   public DeclaredType toDeclaredType(TypeMirror typeMirror) {


### PR DESCRIPTION
In Eclipse, using annotation processing with Java 9 or higher leads to poorer performance. This pull request is aimed at avoiding this performance degradation.