### PR TITLE
Fix an issue with the incorrect validation of the first type argument in DomainConverter

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -922,7 +922,7 @@ public enum Message implements MessageResource {
   DOMA4458("You can't use static methods"),
   DOMA4459("Must be a public method"),
   DOMA4460(
-      "The first type argument \"{0}\" of org.seasar.doma.jdbc.domain.DomainConverter must not be a basic type."),
+      "The first type argument \"{0}\" of org.seasar.doma.jdbc.domain.DomainConverter must be a basic type, excluding enum types."),
 
   // other
   DOMA5001(

--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -922,7 +922,7 @@ public enum Message implements MessageResource {
   DOMA4458("You can't use static methods"),
   DOMA4459("Must be a public method"),
   DOMA4460(
-      "The first type argument \"{0}\" of org.seasar.doma.jdbc.domain.DomainConverter must be a basic type, excluding enum types."),
+      "The first type argument \"{0}\" of org.seasar.doma.jdbc.domain.DomainConverter must not be a basic type. However, enum types are exceptionally allowed."),
 
   // other
   DOMA5001(

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/ExternalDomainMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/ExternalDomainMetaFactory.java
@@ -130,7 +130,7 @@ public class ExternalDomainMetaFactory implements TypeElementMetaFactory<Externa
     }
 
     BasicCtType basicCtType = ctx.getCtTypes().newBasicCtType(declaredType);
-    if (basicCtType != null) {
+    if (basicCtType != null && !basicCtType.isEnum()) {
       throw new AptException(Message.DOMA4460, converterElement, new Object[] {declaredType});
     }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/Color.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/Color.java
@@ -1,0 +1,6 @@
+package org.seasar.doma.internal.apt.processor.domain;
+
+public enum Color {
+  RED,
+  BLUE
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ColorConverter.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ColorConverter.java
@@ -1,0 +1,17 @@
+package org.seasar.doma.internal.apt.processor.domain;
+
+import org.seasar.doma.ExternalDomain;
+import org.seasar.doma.jdbc.domain.DomainConverter;
+
+@ExternalDomain
+public class ColorConverter implements DomainConverter<Color, String> {
+  @Override
+  public String fromDomainToValue(Color color) {
+    return null;
+  }
+
+  @Override
+  public Color fromValueToDomain(String value) {
+    return null;
+  }
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
@@ -51,6 +51,7 @@ class ExternalDomainProcessorTest extends CompilerSupport {
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
         ExtensionContext context) {
       return Stream.of(
+          invocationContext(ColorConverter.class, Color.class),
           invocationContext(StringArrayConverter.class, String[].class),
           invocationContext(
               UpperBoundParameterizedValueObjectConverter.class,

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest_ColorConverter.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest_ColorConverter.txt
@@ -1,0 +1,50 @@
+package __.org.seasar.doma.internal.apt.processor.domain;
+
+/** */
+@javax.annotation.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+@org.seasar.doma.DomainTypeImplementation
+public final class _Color extends org.seasar.doma.jdbc.domain.AbstractDomainType<java.lang.String, org.seasar.doma.internal.apt.processor.domain.Color> {
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    private static final _Color singleton = new _Color();
+
+    private static final org.seasar.doma.internal.apt.processor.domain.ColorConverter converter = new org.seasar.doma.internal.apt.processor.domain.ColorConverter();
+
+    private _Color() {
+        super(org.seasar.doma.internal.wrapper.WrapperSuppliers.ofString());
+    }
+
+    @Override
+    protected org.seasar.doma.internal.apt.processor.domain.Color newDomain(java.lang.String value) {
+        return converter.fromValueToDomain(value);
+    }
+
+    @Override
+    protected java.lang.String getBasicValue(org.seasar.doma.internal.apt.processor.domain.Color domain) {
+        if (domain == null) {
+            return null;
+        }
+        return converter.fromDomainToValue(domain);
+    }
+
+    @Override
+    public Class<?> getBasicClass() {
+        return java.lang.String.class;
+    }
+
+    @Override
+    public Class<org.seasar.doma.internal.apt.processor.domain.Color> getDomainClass() {
+        return org.seasar.doma.internal.apt.processor.domain.Color.class;
+    }
+
+    /**
+     * @return the singleton
+     */
+    public static _Color getSingletonInternal() {
+        return singleton;
+    }
+
+}


### PR DESCRIPTION
Allowed Enum types as the first type argument in DomainConverter.