### PR TITLE
Fix: An error occurs if primitive is included (#1048)

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EntityPropertyNameCollector.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EntityPropertyNameCollector.java
@@ -34,13 +34,18 @@ public class EntityPropertyNameCollector {
         t != null && t.asType().getKind() != TypeKind.NONE;
         t = ctx.getMoreTypes().toTypeElement(t.getSuperclass())) {
       for (VariableElement field : ElementFilter.fieldsIn(t.getEnclosedElements())) {
-        TypeElement filedTypeElement = ctx.getMoreTypes().toTypeElement(field.asType());
-        EmbeddableAnnot embeddableAnnot = ctx.getAnnotations().newEmbeddableAnnot(filedTypeElement);
+        if (!isPersistent(field)) {
+          continue;
+        }
         String name = field.getSimpleName().toString();
+        TypeElement filedTypeElement = ctx.getMoreTypes().toTypeElement(field.asType());
+        if (filedTypeElement == null) {
+          names.add(name);
+          continue;
+        }
+        EmbeddableAnnot embeddableAnnot = ctx.getAnnotations().newEmbeddableAnnot(filedTypeElement);
         if (embeddableAnnot == null) {
-          if (isPersistent(field)) {
-            names.add(name);
-          }
+          names.add(name);
         } else {
           EmbeddableMetaFactory embeddableMetaFactory = new EmbeddableMetaFactory(ctx);
           EmbeddableMeta embeddableMeta =

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/ImmutableUser.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/ImmutableUser.java
@@ -8,15 +8,22 @@ public class ImmutableUser {
 
   @Id private final Integer id;
 
+  private final int age;
+
   private final UserAddress address;
 
-  public ImmutableUser(Integer id, UserAddress address) {
+  public ImmutableUser(Integer id, int age, UserAddress address) {
     this.id = id;
+    this.age = age;
     this.address = address;
   }
 
   public Integer getId() {
     return id;
+  }
+
+  public int getAge() {
+    return age;
   }
 
   public UserAddress getAddress() {

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableUser.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableUser.txt
@@ -44,9 +44,9 @@ public final class _ImmutableUser extends org.seasar.doma.jdbc.entity.AbstractEn
         __tableName = "";
         __isQuoteRequired = false;
         java.util.List<org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __idList = new java.util.ArrayList<>();
-        java.util.List<org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __list = new java.util.ArrayList<>(2);
-        java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __map = new java.util.LinkedHashMap<>(2);
-        java.util.Map<String, org.seasar.doma.jdbc.entity.EmbeddedPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __embeddedMap = new java.util.LinkedHashMap<>(2);
+        java.util.List<org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __list = new java.util.ArrayList<>(3);
+        java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __map = new java.util.LinkedHashMap<>(3);
+        java.util.Map<String, org.seasar.doma.jdbc.entity.EmbeddedPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __embeddedMap = new java.util.LinkedHashMap<>(3);
         initializeMaps(__map, __embeddedMap);
         initializeIdList(__map, __idList);
         initializeList(__map, __list);
@@ -58,6 +58,7 @@ public final class _ImmutableUser extends org.seasar.doma.jdbc.entity.AbstractEn
 
     private void initializeMaps(java.util.Map<String, org.seasar.doma.jdbc.entity.EntityPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __map, java.util.Map<String, org.seasar.doma.jdbc.entity.EmbeddedPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __embeddedMap) {
         __map.put("id", new org.seasar.doma.jdbc.entity.AssignedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, java.lang.Integer, java.lang.Integer>(org.seasar.doma.internal.apt.processor.entity.ImmutableUser.class, org.seasar.doma.internal.jdbc.scalar.BasicScalarSuppliers.ofInteger(), "id", "", __namingType, false));
+        __map.put("age", new org.seasar.doma.jdbc.entity.DefaultPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, java.lang.Integer, java.lang.Integer>(org.seasar.doma.internal.apt.processor.entity.ImmutableUser.class, org.seasar.doma.internal.jdbc.scalar.BasicScalarSuppliers.ofPrimitiveInt(), "age", "", __namingType, true, true, false));
         __embeddedMap.put("address", new org.seasar.doma.jdbc.entity.EmbeddedPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, org.seasar.doma.internal.apt.processor.entity.UserAddress>("address", org.seasar.doma.internal.apt.processor.entity.ImmutableUser.class, org.seasar.doma.internal.apt.processor.entity._UserAddress.getSingletonInternal().getEmbeddablePropertyTypes("address", org.seasar.doma.internal.apt.processor.entity.ImmutableUser.class, __namingType)));
         __map.putAll(__embeddedMap.get("address").getEmbeddablePropertyTypeMap());
     }
@@ -199,6 +200,7 @@ public final class _ImmutableUser extends org.seasar.doma.jdbc.entity.AbstractEn
     public org.seasar.doma.internal.apt.processor.entity.ImmutableUser newEntity(java.util.Map<String, org.seasar.doma.jdbc.entity.Property<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?>> __args) {
         return new org.seasar.doma.internal.apt.processor.entity.ImmutableUser(
             (java.lang.Integer)(__args.get("id") != null ? __args.get("id").get() : null),
+            (java.lang.Integer)(__args.get("age") != null ? __args.get("age").get() : null),
             org.seasar.doma.internal.apt.processor.entity._UserAddress.getSingletonInternal().newEmbeddable("address", __args));
     }
 


### PR DESCRIPTION
#1046

An error occurs if primitive is included.

```java
@Entity
public record EmployeeEntity(
  @Id long id, Address address){}
```

```
/Users/yutasaito/dev/oss/doma/test/doma-batch-include-embeddable/src/main/java/com/example/domabatchincludeembeddable/EmployeeDao.java:16: エラー: [DOMA4016] An unexpected error has occurred. It may be a bug in the Doma framework. Report the following stacktrace: java.lang.AssertionError: Null.
public interface EmployeeDao {

  	at org.seasar.doma.internal.util.AssertionUtil.assertNotNull(AssertionUtil.java:15)
  	at org.seasar.doma.internal.apt.annot.Annotations.newEmbeddableAnnot(Annotations.java:166)
  	at org.seasar.doma.internal.apt.meta.entity.EntityPropertyNameCollector.collectNames(EntityPropertyNameCollector.java:38)
  	at org.seasar.doma.internal.apt.meta.entity.EntityPropertyNameCollector.collect(EntityPropertyNameCollector.java:28)
  	at org.seasar.doma.internal.apt.meta.query.AbstractQueryMetaFactory.validateEntityPropertyNames(AbstractQueryMetaFactory.java:64)
  	at org.seasar.doma.internal.apt.meta.query.AutoModifyQueryMetaFactory.doParameters(AutoModifyQueryMetaFactory.java:114)
  	at org.seasar.doma.internal.apt.meta.query.AutoModifyQueryMetaFactory.createQueryMeta(AutoModifyQueryMetaFactory.java:30)

```