### PR TITLE
Support MySQL 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver: [h2, mysql, postgresql, sqlserver, oracle]
+        driver: [h2, mysql, mysql8, postgresql, sqlserver, oracle]
     timeout-minutes: 15
 
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -312,6 +312,10 @@ configure(integrationTestProjects) {
             prepare("mysql")
         }
 
+        val mysql8 by registering(Test::class) {
+            prepare("mysql8")
+        }
+
         val oracle by registering(Test::class) {
             prepare("oracle")
         }

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dialect/MysqlForUpdateTransformer.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dialect/MysqlForUpdateTransformer.java
@@ -1,15 +1,29 @@
 package org.seasar.doma.internal.jdbc.dialect;
 
+import java.util.Objects;
 import org.seasar.doma.internal.jdbc.sql.node.ForUpdateClauseNode;
+import org.seasar.doma.internal.jdbc.sql.node.FragmentNode;
 import org.seasar.doma.internal.jdbc.sql.node.SelectStatementNode;
 import org.seasar.doma.jdbc.SelectForUpdateType;
 import org.seasar.doma.jdbc.SqlNode;
+import org.seasar.doma.jdbc.dialect.MysqlDialect;
 
 public class MysqlForUpdateTransformer extends StandardForUpdateTransformer {
 
+  private final MysqlDialect.MySqlVersion version;
+
   public MysqlForUpdateTransformer(
       SelectForUpdateType forUpdateType, int waitSeconds, String... aliases) {
+    this(forUpdateType, waitSeconds, aliases, MysqlDialect.DEFAULT_VERSION);
+  }
+
+  public MysqlForUpdateTransformer(
+      SelectForUpdateType forUpdateType,
+      int waitSeconds,
+      String[] aliases,
+      MysqlDialect.MySqlVersion version) {
     super(forUpdateType, waitSeconds, aliases);
+    this.version = Objects.requireNonNull(version);
   }
 
   @Override
@@ -19,8 +33,6 @@ public class MysqlForUpdateTransformer extends StandardForUpdateTransformer {
     }
     processed = true;
 
-    ForUpdateClauseNode forUpdate = new ForUpdateClauseNode("for update");
-
     SelectStatementNode result = new SelectStatementNode();
     result.setSelectClauseNode(node.getSelectClauseNode());
     result.setFromClauseNode(node.getFromClauseNode());
@@ -28,8 +40,32 @@ public class MysqlForUpdateTransformer extends StandardForUpdateTransformer {
     result.setGroupByClauseNode(node.getGroupByClauseNode());
     result.setHavingClauseNode(node.getHavingClauseNode());
     result.setOrderByClauseNode(node.getOrderByClauseNode());
-    result.setForUpdateClauseNode(forUpdate);
+    result.setForUpdateClauseNode(createForUpdateClauseNode());
     result.setOptionClauseNode(node.getOptionClauseNode());
     return result;
+  }
+
+  protected ForUpdateClauseNode createForUpdateClauseNode() {
+    ForUpdateClauseNode forUpdate = new ForUpdateClauseNode("for update");
+    switch (version) {
+      case V5:
+        break;
+      case V8:
+        StringBuilder buf = new StringBuilder(100);
+        if (aliases.length > 0) {
+          buf.append(" of ");
+          for (String alias : aliases) {
+            buf.append(alias);
+            buf.append(", ");
+          }
+          buf.setLength(buf.length() - 2);
+        }
+        if (forUpdateType == SelectForUpdateType.NOWAIT) {
+          buf.append(" nowait ");
+        }
+        forUpdate.appendNode(new FragmentNode(buf.toString()));
+        break;
+    }
+    return forUpdate;
   }
 }

--- a/doma-core/src/test/java/org/seasar/doma/internal/jdbc/dialect/MysqlForUpdateTransformerTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/jdbc/dialect/MysqlForUpdateTransformerTest.java
@@ -11,6 +11,7 @@ import org.seasar.doma.jdbc.PreparedSql;
 import org.seasar.doma.jdbc.SelectForUpdateType;
 import org.seasar.doma.jdbc.SqlKind;
 import org.seasar.doma.jdbc.SqlNode;
+import org.seasar.doma.jdbc.dialect.MysqlDialect;
 
 public class MysqlForUpdateTransformerTest {
 
@@ -19,6 +20,34 @@ public class MysqlForUpdateTransformerTest {
     String expected = "select * from emp order by emp.id for update";
     MysqlForUpdateTransformer transformer =
         new MysqlForUpdateTransformer(SelectForUpdateType.NORMAL, 0);
+    SqlParser parser = new SqlParser("select * from emp order by emp.id");
+    SqlNode sqlNode = transformer.transform(parser.parse());
+    NodePreparedSqlBuilder sqlBuilder =
+        new NodePreparedSqlBuilder(new MockConfig(), SqlKind.SELECT, "dummyPath");
+    PreparedSql sql = sqlBuilder.build(sqlNode, Function.identity());
+    assertEquals(expected, sql.getRawSql());
+  }
+
+  @Test
+  public void testForUpdateNowait_v8() {
+    String expected = "select * from emp order by emp.id for update nowait";
+    MysqlForUpdateTransformer transformer =
+        new MysqlForUpdateTransformer(
+            SelectForUpdateType.NOWAIT, 0, new String[] {}, MysqlDialect.MySqlVersion.V8);
+    SqlParser parser = new SqlParser("select * from emp order by emp.id");
+    SqlNode sqlNode = transformer.transform(parser.parse());
+    NodePreparedSqlBuilder sqlBuilder =
+        new NodePreparedSqlBuilder(new MockConfig(), SqlKind.SELECT, "dummyPath");
+    PreparedSql sql = sqlBuilder.build(sqlNode, Function.identity());
+    assertEquals(expected, sql.getRawSql());
+  }
+
+  @Test
+  public void testForUpdateNowait_alias_v8() {
+    String expected = "select * from emp order by emp.id for update of emp nowait";
+    MysqlForUpdateTransformer transformer =
+        new MysqlForUpdateTransformer(
+            SelectForUpdateType.NOWAIT, 0, new String[] {"emp"}, MysqlDialect.MySqlVersion.V8);
     SqlParser parser = new SqlParser("select * from emp order by emp.id");
     SqlNode sqlNode = transformer.transform(parser.parse());
     NodePreparedSqlBuilder sqlBuilder =

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ testUseModule=false
 driver=h2
 h2.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
 mysql.url=jdbc:tc:mysql:5.7:///test?TC_DAEMON=true&allowMultiQueries=true
+mysql8.url=jdbc:tc:mysql:8.0.36:///test?TC_MY_CNF=mysql_conf_override&TC_DAEMON=true&allowMultiQueries=true
 oracle.url=jdbc:tc:oracle:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgresql:10.16:///test?TC_DAEMON=true
 sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-common/src/main/java/org/seasar/doma/it/Dbms.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/Dbms.java
@@ -9,6 +9,8 @@ public enum Dbms {
 
   MYSQL,
 
+  MYSQL8,
+
   POSTGRESQL,
 
   SQLSERVER,

--- a/integration-test-common/src/main/java/org/seasar/doma/it/IntegrationTestEnvironment.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/IntegrationTestEnvironment.java
@@ -69,6 +69,8 @@ public class IntegrationTestEnvironment
         return Dbms.H2;
       case "mysql":
         return Dbms.MYSQL;
+      case "mysql8":
+        return Dbms.MYSQL8;
       case "oracle":
         return Dbms.ORACLE;
       case "postgresql":
@@ -90,6 +92,8 @@ public class IntegrationTestEnvironment
         return new SqliteDialect();
       case MYSQL:
         return new MysqlDialect();
+      case MYSQL8:
+        return new MysqlDialect(MysqlDialect.MySqlVersion.V8);
       case POSTGRESQL:
         return new PostgresDialect();
       case SQLSERVER:

--- a/integration-test-java-additional/src/test/resources/mysql_conf_override/my.cnf
+++ b/integration-test-java-additional/src/test/resources/mysql_conf_override/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+log_bin_trust_function_creators=ON

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoBatchInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoBatchInsertTest.java
@@ -209,7 +209,7 @@ public class AutoBatchInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER, Dbms.SQLITE})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER, Dbms.SQLITE})
   public void testId_sequence(Config config) throws Exception {
     SequenceStrategyDao dao = new SequenceStrategyDaoImpl(config);
     for (int i = 0; i < 110; i++) {

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoFunctionTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoFunctionTest.java
@@ -69,7 +69,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSet(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     List<Employee> result = dao.func_resultset(Integer.valueOf(1));
@@ -77,7 +77,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSet_check(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     try {
@@ -89,7 +89,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSet_nocheck(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     List<Employee> result = dao.func_resultset_nocheck(Integer.valueOf(1));
@@ -97,7 +97,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSet_map(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     List<Map<String, Object>> result = dao.func_resultset_map(Integer.valueOf(1));
@@ -105,7 +105,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSetAndUpdate(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     List<Employee> result = dao.func_resultset_update(Integer.valueOf(1));
@@ -116,7 +116,7 @@ public class AutoFunctionTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER})
   public void testResultSetAndUpdate2(Config config) throws Exception {
     FunctionDao dao = new FunctionDaoImpl(config);
     List<Employee> result = dao.func_resultset_update2(Integer.valueOf(1));

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoInsertTest.java
@@ -198,7 +198,7 @@ public class AutoInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.MYSQL, Dbms.SQLSERVER, Dbms.SQLITE})
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8, Dbms.SQLSERVER, Dbms.SQLITE})
   public void testId_sequence(Config config) throws Exception {
     SequenceStrategyDao dao = new SequenceStrategyDaoImpl(config);
     for (int i = 0; i < 110; i++) {

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlUpdateTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlUpdateTest.java
@@ -147,7 +147,7 @@ public class NativeSqlUpdateTest {
   }
 
   @Test
-  @Run(unless = Dbms.MYSQL)
+  @Run(unless = {Dbms.MYSQL, Dbms.MYSQL8})
   void expression_select() {
     Employee_ e = new Employee_();
     Employee_ e2 = new Employee_();

--- a/integration-test-java/src/test/java/org/seasar/doma/it/other/ArrayTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/other/ArrayTest.java
@@ -17,7 +17,17 @@ import org.seasar.doma.jdbc.Config;
 
 @ExtendWith(IntegrationTestEnvironment.class)
 @Run(
-    unless = {Dbms.HSQLDB, Dbms.H2, Dbms.MYSQL, Dbms.ORACLE, Dbms.DB2, Dbms.SQLSERVER, Dbms.SQLITE})
+    unless = {
+      Dbms.HSQLDB,
+      Dbms.H2,
+      Dbms.MYSQL,
+      Dbms.MYSQL8,
+      Dbms.MYSQL8,
+      Dbms.ORACLE,
+      Dbms.DB2,
+      Dbms.SQLSERVER,
+      Dbms.SQLITE
+    })
 public class ArrayTest {
 
   @Test

--- a/integration-test-java/src/test/java/org/seasar/doma/it/other/SQLXMLTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/other/SQLXMLTest.java
@@ -31,7 +31,16 @@ import org.seasar.doma.jdbc.Config;
 
 @ExtendWith(IntegrationTestEnvironment.class)
 @Run(
-    unless = {Dbms.HSQLDB, Dbms.H2, Dbms.MYSQL, Dbms.ORACLE, Dbms.DB2, Dbms.SQLSERVER, Dbms.SQLITE})
+    unless = {
+      Dbms.HSQLDB,
+      Dbms.H2,
+      Dbms.MYSQL,
+      Dbms.MYSQL8,
+      Dbms.ORACLE,
+      Dbms.DB2,
+      Dbms.SQLSERVER,
+      Dbms.SQLITE
+    })
 public class SQLXMLTest {
 
   @Test

--- a/integration-test-java/src/test/java/org/seasar/doma/it/sqlfile/SqlFileSelectForUpdateTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/sqlfile/SqlFileSelectForUpdateTest.java
@@ -21,7 +21,16 @@ import org.seasar.doma.message.Message;
 public class SqlFileSelectForUpdateTest {
 
   @Test
-  @Run(unless = {Dbms.H2, Dbms.POSTGRESQL, Dbms.ORACLE, Dbms.MYSQL, Dbms.DB2, Dbms.SQLSERVER})
+  @Run(
+      unless = {
+        Dbms.H2,
+        Dbms.POSTGRESQL,
+        Dbms.ORACLE,
+        Dbms.MYSQL,
+        Dbms.MYSQL8,
+        Dbms.DB2,
+        Dbms.SQLSERVER
+      })
   public void testUnsupported(Config config) throws Exception {
     EmployeeDao dao = new EmployeeDaoImpl(config);
     try {
@@ -47,6 +56,7 @@ public class SqlFileSelectForUpdateTest {
         Dbms.H2,
         Dbms.POSTGRESQL,
         Dbms.MYSQL,
+        Dbms.MYSQL8,
         Dbms.DB2,
         Dbms.SQLSERVER,
         Dbms.SQLITE
@@ -65,6 +75,7 @@ public class SqlFileSelectForUpdateTest {
         Dbms.H2,
         Dbms.ORACLE,
         Dbms.MYSQL,
+        Dbms.MYSQL8,
         Dbms.DB2,
         Dbms.SQLSERVER,
         Dbms.SQLITE
@@ -90,6 +101,7 @@ public class SqlFileSelectForUpdateTest {
         Dbms.H2,
         Dbms.POSTGRESQL,
         Dbms.MYSQL,
+        Dbms.MYSQL8,
         Dbms.DB2,
         Dbms.SQLSERVER,
         Dbms.SQLITE
@@ -106,8 +118,27 @@ public class SqlFileSelectForUpdateTest {
       unless = {
         Dbms.HSQLDB,
         Dbms.H2,
+        Dbms.ORACLE,
+        Dbms.MYSQL,
+        Dbms.DB2,
+        Dbms.SQLSERVER,
+        Dbms.SQLITE
+      })
+  public void testForUpdateNowaitWithTables(Config config) throws Exception {
+    EmployeeDao dao = new EmployeeDaoImpl(config);
+    Employee employee = dao.selectById(1, SelectOptions.get().forUpdateNowait("EMPLOYEE"));
+
+    assertNotNull(employee);
+  }
+
+  @Test
+  @Run(
+      unless = {
+        Dbms.HSQLDB,
+        Dbms.H2,
         Dbms.POSTGRESQL,
         Dbms.MYSQL,
+        Dbms.MYSQL8,
         Dbms.DB2,
         Dbms.SQLSERVER,
         Dbms.SQLITE
@@ -125,6 +156,7 @@ public class SqlFileSelectForUpdateTest {
         Dbms.H2,
         Dbms.POSTGRESQL,
         Dbms.MYSQL,
+        Dbms.MYSQL8,
         Dbms.DB2,
         Dbms.SQLSERVER,
         Dbms.SQLITE

--- a/integration-test-java/src/test/resources/mysql_conf_override/my.cnf
+++ b/integration-test-java/src/test/resources/mysql_conf_override/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+log_bin_trust_function_creators=ON

--- a/integration-test-kotlin/src/test/resources/mysql_conf_override/my.cnf
+++ b/integration-test-kotlin/src/test/resources/mysql_conf_override/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+log_bin_trust_function_creators=ON


### PR DESCRIPTION
The dialect for MySQL 8 can be generated as follows.

```java
MysqlDialect dialect = new MysqlDialect(MysqlDialect.MySqlVersion.V8);
```