### PR TITLE
Removed duplicate Dbms.MYSQL8 entry in ArrayTest

### DIFF
--- a/integration-test-java/src/test/java/org/seasar/doma/it/other/ArrayTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/other/ArrayTest.java
@@ -22,7 +22,6 @@ import org.seasar.doma.jdbc.Config;
       Dbms.H2,
       Dbms.MYSQL,
       Dbms.MYSQL8,
-      Dbms.MYSQL8,
       Dbms.ORACLE,
       Dbms.DB2,
       Dbms.SQLSERVER,


### PR DESCRIPTION
This PR removes a duplicate entry of `Dbms.MYSQL8` in the `@Run` annotation of the `ArrayTest` class. 
The duplicate entry does not affect the functionality of the test, but it may cause confusion for developers reading the code. This change will make the code cleaner and easier to understand.