### PR TITLE
Fix a potential memory leak in LocalTransaction

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
@@ -415,7 +415,7 @@ public class LocalTransaction {
    */
   protected void release(LocalTransactionContext context, String callerMethodName) {
     assertNotNull(context, callerMethodName);
-    localTxContextHolder.set(null);
+    localTxContextHolder.remove();
     if (!context.hasConnection()) {
       return;
     }


### PR DESCRIPTION
We use `ThreadLocal.remove()` to prevent memory leaks.