### PR TITLE
Reduced unnecessary calls to Connection#setTransactionIsolation(level) in LocalTransaction

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
@@ -134,7 +134,7 @@ public class LocalTransaction {
           Connection connection = JdbcUtil.getConnection(dataSource);
 
           @SuppressWarnings("ReassignedVariable")
-          int currentTransactionIsolation = TransactionIsolationLevel.DEFAULT.getLevel();
+          Integer currentTransactionIsolation = null;
           if (transactionIsolationLevel != null
               && transactionIsolationLevel != TransactionIsolationLevel.DEFAULT) {
             try {
@@ -427,9 +427,8 @@ public class LocalTransaction {
     LocalTransactionConnection localTransactionConnection = context.getConnection();
     Connection connection = localTransactionConnection.getWrappedConnection();
 
-    int isolationLevel = localTransactionConnection.getPreservedTransactionIsolation();
-    if (isolationLevel != TransactionIsolationLevel.DEFAULT.getLevel()
-        && isolationLevel != Connection.TRANSACTION_NONE) {
+    Integer isolationLevel = localTransactionConnection.getPreservedTransactionIsolation();
+    if (isolationLevel != null && isolationLevel != Connection.TRANSACTION_NONE) {
       try {
         //noinspection MagicConstant
         connection.setTransactionIsolation(isolationLevel);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionConnection.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionConnection.java
@@ -19,7 +19,7 @@ class LocalTransactionConnection implements Connection {
 
   private final Connection connection;
 
-  private final int preservedTransactionIsolation;
+  private final Integer preservedTransactionIsolation;
 
   private final boolean preservedAutoCommitState;
 
@@ -31,7 +31,9 @@ class LocalTransactionConnection implements Connection {
    * @param preservedAutoCommitState the auto commit state to be preserved
    */
   public LocalTransactionConnection(
-      Connection connection, int preservedTransactionIsolation, boolean preservedAutoCommitState) {
+      Connection connection,
+      Integer preservedTransactionIsolation,
+      boolean preservedAutoCommitState) {
     assertNotNull(connection);
     assertTrue(!(connection instanceof LocalTransactionConnection));
     this.connection = connection;
@@ -39,7 +41,7 @@ class LocalTransactionConnection implements Connection {
     this.preservedAutoCommitState = preservedAutoCommitState;
   }
 
-  protected int getPreservedTransactionIsolation() {
+  protected Integer getPreservedTransactionIsolation() {
     return this.preservedTransactionIsolation;
   }
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionConnection.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionConnection.java
@@ -152,7 +152,6 @@ class LocalTransactionConnection implements Connection {
 
   @Override
   public int getTransactionIsolation() throws SQLException {
-    //noinspection MagicConstant
     return connection.getTransactionIsolation();
   }
 

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/tx/KeepAliveLocalTransactionTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/tx/KeepAliveLocalTransactionTest.java
@@ -106,7 +106,7 @@ public class KeepAliveLocalTransactionTest {
         new LocalTransactionDataSource(new MockDataSource(connection));
     LocalTransaction transaction = dataSource.getKeepAliveLocalTransaction(jdbcLogger);
     try {
-      transaction.begin(TransactionIsolationLevel.READ_COMMITTED);
+      transaction.begin(TransactionIsolationLevel.SERIALIZABLE);
       dataSource.getConnection();
       fail();
     } catch (JdbcException expected) {

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/tx/LocalTransactionTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/tx/LocalTransactionTest.java
@@ -105,7 +105,7 @@ public class LocalTransactionTest {
     LocalTransaction transaction = dataSource.getLocalTransaction(jdbcLogger);
 
     try {
-      transaction.begin(TransactionIsolationLevel.READ_COMMITTED);
+      transaction.begin(TransactionIsolationLevel.SERIALIZABLE);
       dataSource.getConnection();
       fail();
     } catch (JdbcException expected) {


### PR DESCRIPTION
This PR reduces the possibility of pinning in AWS RDS Proxy.
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-managing.html#rds-proxy-pinning