### PR TITLE
Fix a potential memory leak in the suspend method of LocalTransaction

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransaction.java
@@ -216,7 +216,7 @@ public class LocalTransaction {
     if (!isActiveInternal(context)) {
       throw new TransactionNotYetBegunException(Message.DOMA2046);
     }
-    localTxContextHolder.set(null);
+    localTxContextHolder.remove();
     return context;
   }
 


### PR DESCRIPTION
We use `ThreadLocal.remove()` instead of `ThreadLocal.set(null)` to prevent memory leaks.
This PR is related to #1120 