### PR TITLE
Resolve warnings in GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3.4.2
+        uses: gradle/actions/setup-gradle@v3.4.2
 
       - name: Assemble and Check
         run: >
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3.4.2
+        uses: gradle/actions/setup-gradle@v3.4.2
 
       - name: Test with the oldest JDK
         run: >
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3.4.2
+        uses: gradle/actions/setup-gradle@v3.4.2
 
       - name: Publish packages
         env:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3.4.2
+      - uses: gradle/actions/wrapper-validation@v3.4.2


### PR DESCRIPTION
We followed the two documents below:

- https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle
- https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation