### PR TITLE
Return a Connection instead of throwing an exception when no transaction exists

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSource.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSource.java
@@ -7,9 +7,9 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.seasar.doma.DomaNullPointerException;
+import org.seasar.doma.internal.jdbc.util.JdbcUtil;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.SimpleDataSource;
-import org.seasar.doma.message.Message;
 
 /**
  * A data source for local transactions.
@@ -89,7 +89,7 @@ public final class LocalTransactionDataSource implements DataSource {
   private Connection getConnectionInternal() {
     LocalTransactionContext context = localTxContextHolder.get();
     if (context == null) {
-      throw new TransactionNotYetBegunException(Message.DOMA2048);
+      return JdbcUtil.getConnection(dataSource);
     }
     return context.getConnection();
   }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSource.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSource.java
@@ -61,12 +61,13 @@ public final class LocalTransactionDataSource implements DataSource {
   }
 
   /**
-   * {@inheritDoc}
+   * Returns a connection.
    *
-   * <p>
+   * <p>If a transaction has started, it returns the connection under transaction management; if
+   * not, it returns the connection provided by the internal data source.
    *
+   * @return the connection
    * @see LocalTransaction
-   * @throws TransactionNotYetBegunException if the transaction is not yet begun
    */
   @Override
   public Connection getConnection() {
@@ -74,12 +75,13 @@ public final class LocalTransactionDataSource implements DataSource {
   }
 
   /**
-   * {@inheritDoc}
+   * Returns a connection.
    *
-   * <p>
+   * <p>If a transaction has started, it returns the connection under transaction management; if
+   * not, it returns the connection provided by the internal data source.
    *
+   * @return the connection
    * @see LocalTransaction
-   * @throws TransactionNotYetBegunException if the transaction is not yet begun
    */
   @Override
   public Connection getConnection(String username, String password) {

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSourceTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/tx/LocalTransactionDataSourceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
@@ -14,23 +15,20 @@ import org.seasar.doma.jdbc.UtilLoggingJdbcLogger;
 public class LocalTransactionDataSourceTest {
 
   @Test
-  public void testGetConnection() {
+  public void testGetConnection() throws Exception {
     UtilLoggingJdbcLogger jdbcLogger = new UtilLoggingJdbcLogger();
     LocalTransactionDataSource dataSource = new LocalTransactionDataSource(new MockDataSource());
     dataSource.getLocalTransaction(jdbcLogger).begin();
-    dataSource.getConnection();
+    Connection connection = dataSource.getConnection();
+    assertFalse(connection.getAutoCommit());
     dataSource.getLocalTransaction(jdbcLogger).commit();
   }
 
   @Test
-  public void testGetConnection_notYetBegun() {
+  public void testGetConnection_notYetBegun() throws Exception {
     LocalTransactionDataSource dataSource = new LocalTransactionDataSource(new MockDataSource());
-    try {
-      dataSource.getConnection();
-      fail();
-    } catch (TransactionNotYetBegunException expected) {
-      System.out.println(expected.getMessage());
-    }
+    Connection connection = dataSource.getConnection();
+    assertTrue(connection.getAutoCommit());
   }
 
   @Test

--- a/integration-test-common/src/main/java/org/seasar/doma/it/IntegrationTestEnvironment.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/IntegrationTestEnvironment.java
@@ -111,16 +111,11 @@ public class IntegrationTestEnvironment
     if (imported) {
       return;
     }
-    config
-        .getTransactionManager()
-        .required(
-            () -> {
-              try {
-                scriptDao.drop();
-              } catch (ScriptException ignored) {
-              }
-            });
-    config.getTransactionManager().required(scriptDao::create);
+    try {
+      scriptDao.drop();
+    } catch (ScriptException ignored) {
+    }
+    scriptDao.create();
     imported = true;
   }
 


### PR DESCRIPTION
This pull request changes the behavior when obtaining a Connection without starting a local transaction.
Previously, an exception was thrown, but with this pull request, a Connection in auto-commit mode will be returned.