### PR TITLE
Enable removal of comments from SQL templates

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
@@ -424,14 +424,14 @@ public class SqlParser {
   }
 
   protected void parseBlockComment() {
-    if (!config.shouldRemoveBlockComments()) {
+    if (!config.shouldRemoveBlockComment(token)) {
       CommentNode node = new CommentNode(token);
       appendNode(node);
     }
   }
 
   protected void parseLineComment() {
-    if (!config.shouldRemoveLineComments()) {
+    if (!config.shouldRemoveLineComment(token)) {
       CommentNode node = new CommentNode(token);
       appendNode(node);
     }

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/SqlParser.java
@@ -48,6 +48,7 @@ import org.seasar.doma.internal.jdbc.sql.node.WordNode;
 import org.seasar.doma.internal.util.StringUtil;
 import org.seasar.doma.jdbc.JdbcException;
 import org.seasar.doma.jdbc.SqlNode;
+import org.seasar.doma.jdbc.SqlParserConfig;
 import org.seasar.doma.message.Message;
 
 public class SqlParser {
@@ -59,6 +60,8 @@ public class SqlParser {
 
   protected final String sql;
 
+  protected final SqlParserConfig config;
+
   protected final SqlTokenizer tokenizer;
 
   protected final AnonymousNode rootNode;
@@ -68,8 +71,13 @@ public class SqlParser {
   protected String token;
 
   public SqlParser(String sql) {
-    assertNotNull(sql);
+    this(sql, SqlParserConfig.DEFAULT);
+  }
+
+  public SqlParser(String sql, SqlParserConfig config) {
+    assertNotNull(sql, config);
     this.sql = sql;
+    this.config = config;
     tokenizer = new SqlTokenizer(sql);
     rootNode = new AnonymousNode();
     nodeStack.push(rootNode);
@@ -227,9 +235,13 @@ public class SqlParser {
             break;
           }
         case BLOCK_COMMENT:
+          {
+            parseBlockComment();
+            break;
+          }
         case LINE_COMMENT:
           {
-            parseComment();
+            parseLineComment();
             break;
           }
         case OTHER:
@@ -411,9 +423,18 @@ public class SqlParser {
     appendNode(node);
   }
 
-  protected void parseComment() {
-    CommentNode node = new CommentNode(token);
-    appendNode(node);
+  protected void parseBlockComment() {
+    if (!config.shouldRemoveBlockComments()) {
+      CommentNode node = new CommentNode(token);
+      appendNode(node);
+    }
+  }
+
+  protected void parseLineComment() {
+    if (!config.shouldRemoveLineComments()) {
+      CommentNode node = new CommentNode(token);
+      appendNode(node);
+    }
   }
 
   protected void parseOpenedParens() {

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/AbstractSqlFileRepository.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/AbstractSqlFileRepository.java
@@ -16,6 +16,16 @@ import org.seasar.doma.message.Message;
 /** A skeletal implementation of the {@link SqlFileRepository} interface. */
 public abstract class AbstractSqlFileRepository implements SqlFileRepository {
 
+  protected final SqlParserConfig sqlParserConfig;
+
+  protected AbstractSqlFileRepository() {
+    this(SqlParserConfig.DEFAULT);
+  }
+
+  protected AbstractSqlFileRepository(SqlParserConfig sqlParserConfig) {
+    this.sqlParserConfig = Objects.requireNonNull(sqlParserConfig);
+  }
+
   @Override
   public final SqlFile getSqlFile(Method method, String path, Dialect dialect) {
     if (method == null) {
@@ -100,7 +110,7 @@ public abstract class AbstractSqlFileRepository implements SqlFileRepository {
    * @return the SQL node
    */
   protected final SqlNode parse(String sql) {
-    SqlParser parser = new SqlParser(sql);
+    SqlParser parser = new SqlParser(sql, sqlParserConfig);
     return parser.parse();
   }
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/GreedyCacheSqlFileRepository.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/GreedyCacheSqlFileRepository.java
@@ -10,6 +10,12 @@ public class GreedyCacheSqlFileRepository extends AbstractSqlFileRepository {
 
   protected final ConcurrentMap<CacheKey, SqlFile> sqlFileMap = new ConcurrentHashMap<>(200);
 
+  public GreedyCacheSqlFileRepository() {}
+
+  public GreedyCacheSqlFileRepository(SqlParserConfig sqlParserConfig) {
+    super(sqlParserConfig);
+  }
+
   @Override
   protected SqlFile getSqlFileWithCacheControl(Method method, String path, Dialect dialect) {
     CacheKey key = new CacheKey(method, path);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/NoCacheSqlFileRepository.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/NoCacheSqlFileRepository.java
@@ -6,6 +6,12 @@ import org.seasar.doma.jdbc.dialect.Dialect;
 /** An SQL file repository that does not cache the results of SQL parsing. */
 public class NoCacheSqlFileRepository extends AbstractSqlFileRepository {
 
+  public NoCacheSqlFileRepository() {}
+
+  public NoCacheSqlFileRepository(SqlParserConfig sqlParserConfig) {
+    super(sqlParserConfig);
+  }
+
   @Override
   protected SqlFile getSqlFileWithCacheControl(Method method, String path, Dialect dialect) {
     return createSqlFile(method, path, dialect);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/SqlParserConfig.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/SqlParserConfig.java
@@ -1,0 +1,33 @@
+package org.seasar.doma.jdbc;
+
+/** A configuration for SQL parser. */
+public interface SqlParserConfig {
+
+  /** The default implementation. */
+  SqlParserConfig DEFAULT =
+      new SqlParserConfig() {
+        @Override
+        public boolean shouldRemoveBlockComments() {
+          return false;
+        }
+
+        @Override
+        public boolean shouldRemoveLineComments() {
+          return false;
+        }
+      };
+
+  /**
+   * Returns whether block comments should be removed.
+   *
+   * @return whether block comments should be removed
+   */
+  boolean shouldRemoveBlockComments();
+
+  /**
+   * Returns whether line comments should be removed.
+   *
+   * @return whether line comments should be removed
+   */
+  boolean shouldRemoveLineComments();
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/SqlParserConfig.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/SqlParserConfig.java
@@ -7,12 +7,12 @@ public interface SqlParserConfig {
   SqlParserConfig DEFAULT =
       new SqlParserConfig() {
         @Override
-        public boolean shouldRemoveBlockComments() {
+        public boolean shouldRemoveBlockComment(String comment) {
           return false;
         }
 
         @Override
-        public boolean shouldRemoveLineComments() {
+        public boolean shouldRemoveLineComment(String comment) {
           return false;
         }
       };
@@ -20,14 +20,16 @@ public interface SqlParserConfig {
   /**
    * Returns whether block comments should be removed.
    *
+   * @param comment the block comment
    * @return whether block comments should be removed
    */
-  boolean shouldRemoveBlockComments();
+  boolean shouldRemoveBlockComment(String comment);
 
   /**
    * Returns whether line comments should be removed.
    *
+   * @param comment the line comment
    * @return whether line comments should be removed
    */
-  boolean shouldRemoveLineComments();
+  boolean shouldRemoveLineComment(String comment);
 }

--- a/doma-core/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/jdbc/sql/SqlParserTest.java
@@ -992,12 +992,12 @@ public class SqlParserTest {
         new SqlParserConfig() {
 
           @Override
-          public boolean shouldRemoveBlockComments() {
+          public boolean shouldRemoveBlockComment(String comment) {
             return true;
           }
 
           @Override
-          public boolean shouldRemoveLineComments() {
+          public boolean shouldRemoveLineComment(String comment) {
             return true;
           }
         };

--- a/integration-test-common/src/main/java/org/seasar/doma/it/AppConfig.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/AppConfig.java
@@ -3,10 +3,12 @@ package org.seasar.doma.it;
 import java.util.Objects;
 import javax.sql.DataSource;
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.GreedyCacheSqlFileRepository;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.RequiresNewController;
 import org.seasar.doma.jdbc.SimpleDataSource;
+import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.dialect.Dialect;
 import org.seasar.doma.jdbc.tx.LocalTransaction;
 import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
@@ -27,6 +29,9 @@ public class AppConfig implements Config {
   private final LocalTransactionDataSource dataSource;
 
   private final LocalTransactionManager transactionManager;
+
+  private final SqlFileRepository sqlFileRepository =
+      new GreedyCacheSqlFileRepository(new LineCommentRemovalSqlParserConfig());
 
   public AppConfig(Dialect dialect, Dbms dbms, String url, String user, String password) {
     Objects.requireNonNull(dialect);
@@ -100,5 +105,10 @@ public class AppConfig implements Config {
   @Override
   public JdbcLogger getJdbcLogger() {
     return jdbcLogger;
+  }
+
+  @Override
+  public SqlFileRepository getSqlFileRepository() {
+    return sqlFileRepository;
   }
 }

--- a/integration-test-common/src/main/java/org/seasar/doma/it/LineCommentRemovalSqlParserConfig.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/LineCommentRemovalSqlParserConfig.java
@@ -5,12 +5,12 @@ import org.seasar.doma.jdbc.SqlParserConfig;
 public class LineCommentRemovalSqlParserConfig implements SqlParserConfig {
 
   @Override
-  public boolean shouldRemoveBlockComments() {
+  public boolean shouldRemoveBlockComment(String comment) {
     return false;
   }
 
   @Override
-  public boolean shouldRemoveLineComments() {
+  public boolean shouldRemoveLineComment(String comment) {
     return true;
   }
 }

--- a/integration-test-common/src/main/java/org/seasar/doma/it/LineCommentRemovalSqlParserConfig.java
+++ b/integration-test-common/src/main/java/org/seasar/doma/it/LineCommentRemovalSqlParserConfig.java
@@ -1,0 +1,16 @@
+package org.seasar.doma.it;
+
+import org.seasar.doma.jdbc.SqlParserConfig;
+
+public class LineCommentRemovalSqlParserConfig implements SqlParserConfig {
+
+  @Override
+  public boolean shouldRemoveBlockComments() {
+    return false;
+  }
+
+  @Override
+  public boolean shouldRemoveLineComments() {
+    return true;
+  }
+}

--- a/integration-test-java/src/main/resources/META-INF/org/seasar/doma/it/dao/EmployeeDao/selectById.sql
+++ b/integration-test-java/src/main/resources/META-INF/org/seasar/doma/it/dao/EmployeeDao/selectById.sql
@@ -1,1 +1,9 @@
-select * from EMPLOYEE where EMPLOYEE_ID = /*employeeId*/0
+/**
+ * This comment will not be removed
+ */
+select
+  * 
+from
+  EMPLOYEE -- this comment will be removed
+where  
+  EMPLOYEE_ID = /*employeeId*/0 -- this comment will be also removed


### PR DESCRIPTION
We offer an option to remove block comments and line comments from SQL templates.

Which comments to delete will be indicated in the implementation class of `SqlParserConfig`:

```java
public class LineCommentRemovalSqlParserConfig implements SqlParserConfig {

  @Override
  public boolean shouldRemoveBlockComment(String comment) {
    return false;
  }

  @Override
  public boolean shouldRemoveLineComment(String comment) {
    return true;
  }
}
```

Pass an instance of the above class to the constructor of the implementation class of `SqlFileRepository`:

```java
public class AppConfig implements Config {

  ...

  private final SqlFileRepository sqlFileRepository =
      new GreedyCacheSqlFileRepository(new LineCommentRemovalSqlParserConfig());

  @Override
  public SqlFileRepository getSqlFileRepository() {
    return sqlFileRepository;
  }
}
```

Let's apply the above configuration to the following SQL template:

```sql
/**
 * This comment will not be removed
 */
select
  * 
from
  EMPLOYEE -- this comment will be removed
where  
  EMPLOYEE_ID = /*employeeId*/0 -- this comment will be also removed
```

The result of the application is as follows:
```sql
/**
 * This comment will not be removed
 */
select
  * 
from
  EMPLOYEE 
where  
  EMPLOYEE_ID = ? 
```