### PR TITLE
Prevent unintentionally nullable values in doma-kotlin.

### DIFF
--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/KEntityql.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/KEntityql.kt
@@ -22,7 +22,7 @@ class KEntityql(config: Config) {
 
     private val entityql = org.seasar.doma.jdbc.criteria.Entityql(config)
 
-    fun <ENTITY> from(
+    fun <ENTITY : Any> from(
         entityMetamodel: EntityMetamodel<ENTITY>,
         block: SelectSettings.() -> Unit = {},
     ): KEntityqlSelectStarting<ENTITY> {
@@ -30,7 +30,7 @@ class KEntityql(config: Config) {
         return KEntityqlSelectStarting(statement)
     }
 
-    fun <ENTITY> from(
+    fun <ENTITY : Any> from(
         entityMetamodel: EntityMetamodel<ENTITY>,
         setOperandForSubQuery: KSetOperand<*>,
         block: SelectSettings.() -> Unit = {},
@@ -39,7 +39,7 @@ class KEntityql(config: Config) {
         return KEntityqlSelectStarting(statement)
     }
 
-    fun <ENTITY> update(
+    fun <ENTITY : Any> update(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entity: ENTITY,
         block: UpdateSettings.() -> Unit = {},
@@ -48,7 +48,7 @@ class KEntityql(config: Config) {
         return KEntityqlUpdateStatement(statement)
     }
 
-    fun <ENTITY> delete(
+    fun <ENTITY : Any> delete(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entity: ENTITY,
         block: DeleteSettings.() -> Unit = {},
@@ -57,7 +57,7 @@ class KEntityql(config: Config) {
         return KEntityqlDeleteStatement(statement)
     }
 
-    fun <ENTITY> insert(
+    fun <ENTITY : Any> insert(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entity: ENTITY,
         block: InsertSettings.() -> Unit = {},
@@ -66,7 +66,7 @@ class KEntityql(config: Config) {
         return KEntityqlInsertStatement(statement)
     }
 
-    fun <ENTITY> update(
+    fun <ENTITY : Any> update(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entities: List<ENTITY>,
         block: UpdateSettings.() -> Unit = {},
@@ -75,7 +75,7 @@ class KEntityql(config: Config) {
         return KEntityqlBatchUpdateStatement(statement)
     }
 
-    fun <ENTITY> delete(
+    fun <ENTITY : Any> delete(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entities: List<ENTITY>,
         block: DeleteSettings.() -> Unit = {},
@@ -84,7 +84,7 @@ class KEntityql(config: Config) {
         return KEntityqlBatchDeleteStatement(statement)
     }
 
-    fun <ENTITY> insert(
+    fun <ENTITY : Any> insert(
         entityMetamodel: EntityMetamodel<ENTITY>,
         entities: List<ENTITY>,
         block: InsertSettings.() -> Unit = {},

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/KNativeSql.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/KNativeSql.kt
@@ -16,7 +16,7 @@ class KNativeSql(config: Config?) {
 
     private val nativeSql = org.seasar.doma.jdbc.criteria.NativeSql(config)
 
-    fun <ENTITY> from(
+    fun <ENTITY : Any> from(
         entityMetamodel: EntityMetamodel<ENTITY>,
         block: SelectSettings.() -> Unit = {},
     ): KNativeSqlSelectStarting<ENTITY> {
@@ -24,7 +24,7 @@ class KNativeSql(config: Config?) {
         return KNativeSqlSelectStarting(statement)
     }
 
-    fun <ENTITY> from(
+    fun <ENTITY : Any> from(
         entityMetamodel: EntityMetamodel<ENTITY>,
         setOperandForSubQuery: KSetOperand<*>,
         block: SelectSettings.() -> Unit = {},
@@ -33,7 +33,7 @@ class KNativeSql(config: Config?) {
         return KNativeSqlSelectStarting(statement)
     }
 
-    fun <ENTITY> update(
+    fun <ENTITY : Any> update(
         entityMetamodel: EntityMetamodel<ENTITY>,
         block: UpdateSettings.() -> Unit = {},
     ): KNativeSqlUpdateStarting {
@@ -41,7 +41,7 @@ class KNativeSql(config: Config?) {
         return KNativeSqlUpdateStarting(statement)
     }
 
-    fun <ENTITY> delete(
+    fun <ENTITY : Any> delete(
         entityMetamodel: EntityMetamodel<ENTITY>,
         block: DeleteSettings.() -> Unit = {},
     ): KNativeSqlDeleteStarting {
@@ -49,7 +49,7 @@ class KNativeSql(config: Config?) {
         return KNativeSqlDeleteStarting(statement)
     }
 
-    fun <ENTITY> insert(
+    fun <ENTITY : Any> insert(
         entityMetamodel: EntityMetamodel<ENTITY>,
         block: InsertSettings.() -> Unit = {},
     ): KNativeSqlInsertStarting {


### PR DESCRIPTION
Until now, runtime error when Bellow code.
You can catch the following error at compile time with this pull request.

```
val nullableEmp : Emp? = null
val stmt = entityql.update(e, nullableEmp).execute()
```

I fixed only KEntityql and KNativeSql, but maybe other doma-kotlin code requires review.
