### PR TITLE
Improving KSetDeclaration

### DIFF
--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSetDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSetDeclaration.kt
@@ -5,11 +5,11 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel
 
 class KSetDeclaration(private val declaration: SetDeclaration) {
 
-    fun <PROPERTY> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.value(left, right)
     }
 
-    fun <PROPERTY> value(
+    fun <PROPERTY : Any> value(
         left: PropertyMetamodel<PROPERTY>,
         right: PropertyMetamodel<PROPERTY>,
     ) {

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSetDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSetDeclaration.kt
@@ -5,7 +5,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel
 
 class KSetDeclaration(private val declaration: SetDeclaration) {
 
-    fun <PROPERTY> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.value(left, right)
     }
 


### PR DESCRIPTION
I want to avoid nullable value when no-nullable column. Therefore using type-cast. but occurs a problem.

```kotlin
// type-cast on Kotlin(nullable) -> ok
value(e.employeeName as PropertyMetamodel<String?>, null as String?)
// type-cast on Kotlin(non-null) -> should be compile-error, but it no error occurs.
value(e.employeeName as PropertyMetamodel<String>, null as String?)
// as it is -> ok
value(e.employeeName, null as String?)
```

Removing the nullable will resolve the issue.