### PR TITLE
Add DuplicateKeyType to MultiInsert

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/MultiInsert.java
+++ b/doma-core/src/main/java/org/seasar/doma/MultiInsert.java
@@ -9,6 +9,7 @@ import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.JdbcException;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.UniqueConstraintException;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 /**
  * Indicates a multi-row insert.
@@ -70,4 +71,20 @@ public @interface MultiInsert {
    * @return the output format of SQL logs.
    */
   SqlLogType sqlLog() default SqlLogType.FORMATTED;
+
+  /**
+   * This variable represents the type of duplicate key handling strategy for an insert operation.
+   * It can have one of three values:
+   *
+   * <ul>
+   *   <li>UPDATE: If a duplicate key is encountered, the existing row in the table will be updated.
+   *   <li>IGNORE: If a duplicate key is encountered, the insert operation will be ignored, and no
+   *       changes will be made to the table.
+   *   <li>EXCEPTION: If a duplicate key is encountered, the operation will throw an exception,
+   *       indicating that a duplicate key exists.
+   * </ul>
+   *
+   * @return the type of duplicate key handling strategy for an insert operation.
+   */
+  DuplicateKeyType duplicateKeyType() default DuplicateKeyType.EXCEPTION;
 }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlMultiInsertStatement.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlMultiInsertStatement.java
@@ -42,7 +42,7 @@ public class EntityqlMultiInsertStatement<ENTITY>
    *
    * @return statement
    */
-  public EntityqlMultiInsertStatement<ENTITY> onDuplicateKeyUpdate() {
+  public Statement<MultiResult<ENTITY>> onDuplicateKeyUpdate() {
     this.duplicateKeyType = DuplicateKeyType.UPDATE;
     return this;
   }
@@ -52,7 +52,7 @@ public class EntityqlMultiInsertStatement<ENTITY>
    *
    * @return statement
    */
-  public EntityqlMultiInsertStatement<ENTITY> onDuplicateKeyIgnore() {
+  public Statement<MultiResult<ENTITY>> onDuplicateKeyIgnore() {
     this.duplicateKeyType = DuplicateKeyType.IGNORE;
     return this;
   }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlMultiInsertStatement.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/EntityqlMultiInsertStatement.java
@@ -13,6 +13,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.EntityMetamodel;
 import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.AutoMultiInsertQuery;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 import org.seasar.doma.jdbc.query.Query;
 
 public class EntityqlMultiInsertStatement<ENTITY>
@@ -23,6 +24,7 @@ public class EntityqlMultiInsertStatement<ENTITY>
   private final EntityMetamodel<ENTITY> entityMetamodel;
   private final List<ENTITY> entities;
   private final InsertSettings settings;
+  private DuplicateKeyType duplicateKeyType = DuplicateKeyType.EXCEPTION;
 
   public EntityqlMultiInsertStatement(
       Config config,
@@ -33,6 +35,26 @@ public class EntityqlMultiInsertStatement<ENTITY>
     this.entityMetamodel = Objects.requireNonNull(entityMetamodel);
     this.entities = Objects.requireNonNull(entities);
     this.settings = Objects.requireNonNull(settings);
+  }
+
+  /**
+   * Create statement that inserts or updates
+   *
+   * @return statement
+   */
+  public EntityqlMultiInsertStatement<ENTITY> onDuplicateKeyUpdate() {
+    this.duplicateKeyType = DuplicateKeyType.UPDATE;
+    return this;
+  }
+
+  /**
+   * Create statement that inserts or ignore
+   *
+   * @return statement
+   */
+  public EntityqlMultiInsertStatement<ENTITY> onDuplicateKeyIgnore() {
+    this.duplicateKeyType = DuplicateKeyType.IGNORE;
+    return this;
   }
 
   /**
@@ -64,6 +86,7 @@ public class EntityqlMultiInsertStatement<ENTITY>
     query.setExcludedPropertyNames(
         settings.exclude().stream().map(PropertyMetamodel::getName).toArray(String[]::new));
     query.setMessage(settings.getComment());
+    query.setDuplicateKeyType(this.duplicateKeyType);
     query.prepare();
     InsertCommand command =
         config.getCommandImplementors().createInsertCommand(EXECUTE_METHOD, query);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/MssqlUpsertAssembler.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/MssqlUpsertAssembler.java
@@ -1,12 +1,14 @@
 package org.seasar.doma.jdbc.dialect;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.seasar.doma.internal.jdbc.sql.PreparedSqlBuilder;
 import org.seasar.doma.jdbc.entity.EntityPropertyType;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 import org.seasar.doma.jdbc.query.QueryOperand;
-import org.seasar.doma.jdbc.query.QueryOperandPair;
+import org.seasar.doma.jdbc.query.QueryOperandPairList;
+import org.seasar.doma.jdbc.query.QueryRows;
 import org.seasar.doma.jdbc.query.UpsertAssembler;
 import org.seasar.doma.jdbc.query.UpsertAssemblerContext;
 import org.seasar.doma.jdbc.query.UpsertAssemblerSupport;
@@ -17,8 +19,8 @@ public class MssqlUpsertAssembler implements UpsertAssembler {
   private final DuplicateKeyType duplicateKeyType;
   private final UpsertAssemblerSupport upsertAssemblerSupport;
   private final List<? extends EntityPropertyType<?, ?>> keys;
-  private final List<QueryOperandPair> insertValues;
-  private final List<QueryOperandPair> setValues;
+  private final QueryRows insertValues;
+  private final QueryOperandPairList setValues;
   private final QueryOperand.Visitor queryOperandVisitor = new QueryOperandVisitor();
 
   public MssqlUpsertAssembler(UpsertAssemblerContext context) {
@@ -38,55 +40,84 @@ public class MssqlUpsertAssembler implements UpsertAssembler {
     buf.appendSql(" using (");
     excludeQuery();
     buf.appendSql(" on ");
-    for (EntityPropertyType<?, ?> key : keys) {
-      targetColumn(key);
-      buf.appendSql(" = ");
-      excludeColumn(key);
-      buf.appendSql(" and ");
-    }
-    buf.cutBackSql(5);
-    buf.appendSql(" when not matched then insert (");
-    for (QueryOperandPair pair : insertValues) {
-      column(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(") values (");
-    for (QueryOperandPair pair : insertValues) {
-      excludeColumn(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(")");
+    join(
+        keys,
+        " and ",
+        "",
+        "",
+        buf,
+        key -> {
+          targetColumn(key);
+          buf.appendSql(" = ");
+          excludeColumn(key);
+        });
+    buf.appendSql(" when not matched then insert ");
+    join(
+        setValues.getPairs(),
+        ", ",
+        "(",
+        ")",
+        buf,
+        p -> {
+          column(p.getLeft().getEntityPropertyType());
+        });
+    buf.appendSql(" values ");
+    join(
+        insertValues.getRows(),
+        ", ",
+        "",
+        "",
+        buf,
+        row -> {
+          join(
+              row.getPairs(),
+              ", ",
+              "(",
+              ")",
+              buf,
+              p -> {
+                excludeColumn(p.getLeft().getEntityPropertyType());
+              });
+        });
     if (duplicateKeyType == DuplicateKeyType.UPDATE) {
       buf.appendSql(" when matched then update set ");
-      for (QueryOperandPair pair : setValues) {
-        targetColumn(pair.getLeft().getEntityPropertyType());
-        buf.appendSql(" = ");
-        pair.getRight().accept(queryOperandVisitor);
-        buf.appendSql(", ");
-      }
-      buf.cutBackSql(2);
+      join(
+          setValues.getPairs(),
+          ", ",
+          "",
+          "",
+          buf,
+          p -> {
+            targetColumn(p.getLeft().getEntityPropertyType());
+            buf.appendSql(" = ");
+            p.getRight().accept(queryOperandVisitor);
+          });
     }
     buf.appendSql(";");
   }
 
   private void excludeQuery() {
-    buf.appendSql("values (");
-    for (QueryOperandPair pair : insertValues) {
-      pair.getRight().accept(queryOperandVisitor);
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(")) as ");
+    buf.appendSql("values ");
+    join(
+        insertValues.first().getPairs(),
+        ", ",
+        "(",
+        ")",
+        buf,
+        p -> {
+          p.getRight().accept(queryOperandVisitor);
+        });
+    buf.appendSql(") as ");
     excludeAlias();
-    buf.appendSql(" (");
-    for (QueryOperandPair pair : insertValues) {
-      column(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(")");
+    join(
+        insertValues.first().getPairs(),
+        ", ",
+        " (",
+        ")",
+        buf,
+        p -> {
+          column(p.getLeft().getEntityPropertyType());
+        });
   }
 
   private void tableNameAndAlias(EntityType<?> entityType) {
@@ -120,6 +151,22 @@ public class MssqlUpsertAssembler implements UpsertAssembler {
         this.upsertAssemblerSupport.excludeProp(
             propertyType, UpsertAssemblerSupport.ColumnNameType.NAME);
     buf.appendSql(sql);
+  }
+
+  private <T> void join(
+      List<T> list,
+      String delimiter,
+      String start,
+      String end,
+      PreparedSqlBuilder buf,
+      Consumer<T> consumer) {
+    buf.appendSql(start);
+    for (T val : list) {
+      consumer.accept(val);
+      buf.appendSql(delimiter);
+    }
+    buf.cutBackSql(delimiter.length());
+    buf.appendSql(end);
   }
 
   class QueryOperandVisitor implements QueryOperand.Visitor {

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/OracleUpsertAssembler.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/OracleUpsertAssembler.java
@@ -1,14 +1,12 @@
 package org.seasar.doma.jdbc.dialect;
 
 import java.util.List;
-import java.util.function.Consumer;
 import org.seasar.doma.internal.jdbc.sql.PreparedSqlBuilder;
 import org.seasar.doma.jdbc.entity.EntityPropertyType;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 import org.seasar.doma.jdbc.query.QueryOperand;
-import org.seasar.doma.jdbc.query.QueryOperandPairList;
-import org.seasar.doma.jdbc.query.QueryRows;
+import org.seasar.doma.jdbc.query.QueryOperandPair;
 import org.seasar.doma.jdbc.query.UpsertAssembler;
 import org.seasar.doma.jdbc.query.UpsertAssemblerContext;
 import org.seasar.doma.jdbc.query.UpsertAssemblerSupport;
@@ -19,8 +17,8 @@ public class OracleUpsertAssembler implements UpsertAssembler {
   private final DuplicateKeyType duplicateKeyType;
   private final UpsertAssemblerSupport upsertAssemblerSupport;
   private final List<? extends EntityPropertyType<?, ?>> keys;
-  private final QueryRows insertValues;
-  private final QueryOperandPairList setValues;
+  private final List<QueryOperandPair> insertValues;
+  private final List<QueryOperandPair> setValues;
   private final QueryOperand.Visitor queryOperandVisitor = new QueryOperandVisitor();
 
   public OracleUpsertAssembler(UpsertAssemblerContext context) {
@@ -28,9 +26,12 @@ public class OracleUpsertAssembler implements UpsertAssembler {
     this.entityType = context.entityType;
     this.duplicateKeyType = context.duplicateKeyType;
     this.keys = context.keys;
-    this.insertValues = context.insertValues;
-    this.setValues = context.setValues;
+    this.insertValues = context.insertValues.first().getPairs();
+    this.setValues = context.setValues.getPairs();
     this.upsertAssemblerSupport = new UpsertAssemblerSupport(context.naming, context.dialect);
+    if (context.insertValues.getRows().size() > 1) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Override
@@ -41,75 +42,48 @@ public class OracleUpsertAssembler implements UpsertAssembler {
     excludeQuery();
     buf.appendSql(") ");
     excludeAlias();
-    buf.appendSql(" on ");
-    join(
-        keys,
-        " and ",
-        "(",
-        ")",
-        buf,
-        key -> {
-          targetColumn(key);
-          buf.appendSql(" = ");
-          excludeColumn(key);
-        });
-    buf.appendSql(" when not matched then insert ");
-    join(
-        setValues.getPairs(),
-        ", ",
-        "(",
-        ")",
-        buf,
-        p -> {
-          column(p.getLeft().getEntityPropertyType());
-        });
-    buf.appendSql(" values ");
-    join(
-        insertValues.getRows(),
-        ", ",
-        "",
-        "",
-        buf,
-        row -> {
-          join(
-              row.getPairs(),
-              ", ",
-              "(",
-              ")",
-              buf,
-              p -> {
-                excludeColumn(p.getLeft().getEntityPropertyType());
-              });
-        });
+    buf.appendSql(" on (");
+    for (EntityPropertyType<?, ?> key : keys) {
+      targetColumn(key);
+      buf.appendSql(" = ");
+      excludeColumn(key);
+      buf.appendSql(" and ");
+    }
+    buf.cutBackSql(5);
+    buf.appendSql(") when not matched then insert (");
+    for (QueryOperandPair pair : insertValues) {
+      column(pair.getLeft().getEntityPropertyType());
+      buf.appendSql(", ");
+    }
+    buf.cutBackSql(2);
+    buf.appendSql(") values (");
+    for (QueryOperandPair pair : insertValues) {
+      excludeColumn(pair.getLeft().getEntityPropertyType());
+      buf.appendSql(", ");
+    }
+    buf.cutBackSql(2);
+    buf.appendSql(")");
     if (duplicateKeyType == DuplicateKeyType.UPDATE) {
       buf.appendSql(" when matched then update set ");
-      join(
-          setValues.getPairs(),
-          ", ",
-          "",
-          "",
-          buf,
-          p -> {
-            targetColumn(p.getLeft().getEntityPropertyType());
-            buf.appendSql(" = ");
-            p.getRight().accept(queryOperandVisitor);
-          });
+      for (QueryOperandPair pair : setValues) {
+        targetColumn(pair.getLeft().getEntityPropertyType());
+        buf.appendSql(" = ");
+        pair.getRight().accept(queryOperandVisitor);
+        buf.appendSql(", ");
+      }
+      buf.cutBackSql(2);
     }
   }
 
   private void excludeQuery() {
     buf.appendSql("select ");
-    join(
-        insertValues.first().getPairs(),
-        ", ",
-        "",
-        "",
-        buf,
-        p -> {
-          p.getRight().accept(queryOperandVisitor);
-          buf.appendSql(" as ");
-          column(p.getLeft().getEntityPropertyType());
-        });
+    for (QueryOperandPair pair : insertValues) {
+      pair.getRight().accept(queryOperandVisitor);
+      buf.appendSql(" as ");
+      column(pair.getLeft().getEntityPropertyType());
+      buf.appendSql(", ");
+    }
+    buf.cutBackSql(2);
     buf.appendSql(" from dual");
   }
 
@@ -144,22 +118,6 @@ public class OracleUpsertAssembler implements UpsertAssembler {
         this.upsertAssemblerSupport.excludeProp(
             propertyType, UpsertAssemblerSupport.ColumnNameType.NAME);
     buf.appendSql(sql);
-  }
-
-  private <T> void join(
-      List<T> list,
-      String delimiter,
-      String start,
-      String end,
-      PreparedSqlBuilder buf,
-      Consumer<T> consumer) {
-    buf.appendSql(start);
-    for (T val : list) {
-      consumer.accept(val);
-      buf.appendSql(delimiter);
-    }
-    buf.cutBackSql(delimiter.length());
-    buf.appendSql(end);
   }
 
   class QueryOperandVisitor implements QueryOperand.Visitor {

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/OracleUpsertAssembler.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/dialect/OracleUpsertAssembler.java
@@ -1,12 +1,14 @@
 package org.seasar.doma.jdbc.dialect;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.seasar.doma.internal.jdbc.sql.PreparedSqlBuilder;
 import org.seasar.doma.jdbc.entity.EntityPropertyType;
 import org.seasar.doma.jdbc.entity.EntityType;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 import org.seasar.doma.jdbc.query.QueryOperand;
-import org.seasar.doma.jdbc.query.QueryOperandPair;
+import org.seasar.doma.jdbc.query.QueryOperandPairList;
+import org.seasar.doma.jdbc.query.QueryRows;
 import org.seasar.doma.jdbc.query.UpsertAssembler;
 import org.seasar.doma.jdbc.query.UpsertAssemblerContext;
 import org.seasar.doma.jdbc.query.UpsertAssemblerSupport;
@@ -17,8 +19,8 @@ public class OracleUpsertAssembler implements UpsertAssembler {
   private final DuplicateKeyType duplicateKeyType;
   private final UpsertAssemblerSupport upsertAssemblerSupport;
   private final List<? extends EntityPropertyType<?, ?>> keys;
-  private final List<QueryOperandPair> insertValues;
-  private final List<QueryOperandPair> setValues;
+  private final QueryRows insertValues;
+  private final QueryOperandPairList setValues;
   private final QueryOperand.Visitor queryOperandVisitor = new QueryOperandVisitor();
 
   public OracleUpsertAssembler(UpsertAssemblerContext context) {
@@ -39,48 +41,75 @@ public class OracleUpsertAssembler implements UpsertAssembler {
     excludeQuery();
     buf.appendSql(") ");
     excludeAlias();
-    buf.appendSql(" on (");
-    for (EntityPropertyType<?, ?> key : keys) {
-      targetColumn(key);
-      buf.appendSql(" = ");
-      excludeColumn(key);
-      buf.appendSql(" and ");
-    }
-    buf.cutBackSql(5);
-    buf.appendSql(") when not matched then insert (");
-    for (QueryOperandPair pair : insertValues) {
-      column(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(") values (");
-    for (QueryOperandPair pair : insertValues) {
-      excludeColumn(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
-    buf.appendSql(")");
+    buf.appendSql(" on ");
+    join(
+        keys,
+        " and ",
+        "(",
+        ")",
+        buf,
+        key -> {
+          targetColumn(key);
+          buf.appendSql(" = ");
+          excludeColumn(key);
+        });
+    buf.appendSql(" when not matched then insert ");
+    join(
+        setValues.getPairs(),
+        ", ",
+        "(",
+        ")",
+        buf,
+        p -> {
+          column(p.getLeft().getEntityPropertyType());
+        });
+    buf.appendSql(" values ");
+    join(
+        insertValues.getRows(),
+        ", ",
+        "",
+        "",
+        buf,
+        row -> {
+          join(
+              row.getPairs(),
+              ", ",
+              "(",
+              ")",
+              buf,
+              p -> {
+                excludeColumn(p.getLeft().getEntityPropertyType());
+              });
+        });
     if (duplicateKeyType == DuplicateKeyType.UPDATE) {
       buf.appendSql(" when matched then update set ");
-      for (QueryOperandPair pair : setValues) {
-        targetColumn(pair.getLeft().getEntityPropertyType());
-        buf.appendSql(" = ");
-        pair.getRight().accept(queryOperandVisitor);
-        buf.appendSql(", ");
-      }
-      buf.cutBackSql(2);
+      join(
+          setValues.getPairs(),
+          ", ",
+          "",
+          "",
+          buf,
+          p -> {
+            targetColumn(p.getLeft().getEntityPropertyType());
+            buf.appendSql(" = ");
+            p.getRight().accept(queryOperandVisitor);
+          });
     }
   }
 
   private void excludeQuery() {
     buf.appendSql("select ");
-    for (QueryOperandPair pair : insertValues) {
-      pair.getRight().accept(queryOperandVisitor);
-      buf.appendSql(" as ");
-      column(pair.getLeft().getEntityPropertyType());
-      buf.appendSql(", ");
-    }
-    buf.cutBackSql(2);
+    join(
+        insertValues.first().getPairs(),
+        ", ",
+        "",
+        "",
+        buf,
+        p -> {
+          p.getRight().accept(queryOperandVisitor);
+          buf.appendSql(" as ");
+          column(p.getLeft().getEntityPropertyType());
+        });
     buf.appendSql(" from dual");
   }
 
@@ -115,6 +144,22 @@ public class OracleUpsertAssembler implements UpsertAssembler {
         this.upsertAssemblerSupport.excludeProp(
             propertyType, UpsertAssemblerSupport.ColumnNameType.NAME);
     buf.appendSql(sql);
+  }
+
+  private <T> void join(
+      List<T> list,
+      String delimiter,
+      String start,
+      String end,
+      PreparedSqlBuilder buf,
+      Consumer<T> consumer) {
+    buf.appendSql(start);
+    for (T val : list) {
+      consumer.accept(val);
+      buf.appendSql(delimiter);
+    }
+    buf.cutBackSql(delimiter.length());
+    buf.appendSql(end);
   }
 
   class QueryOperandVisitor implements QueryOperand.Visitor {

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/query/AutoMultiInsertQuery.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/query/AutoMultiInsertQuery.java
@@ -188,7 +188,7 @@ public class AutoMultiInsertQuery<ENTITY> extends AutoModifyQuery<ENTITY> implem
 
   private void assembleUpsertSql(PreparedSqlBuilder builder, Naming naming, Dialect dialect) {
     UpsertAssemblerContext context =
-        UpsertAssemblerContextBuilder.buildFromEntity(
+        UpsertAssemblerContextBuilder.buildFromEntityList(
             builder,
             entityType,
             duplicateKeyType,
@@ -196,7 +196,7 @@ public class AutoMultiInsertQuery<ENTITY> extends AutoModifyQuery<ENTITY> implem
             dialect,
             idPropertyTypes,
             targetPropertyTypes,
-            entity);
+            entities);
     UpsertAssembler upsertAssembler = dialect.getUpsertAssembler(context);
     upsertAssembler.assemble();
     sql = builder.build(this::comment);

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/query/AutoMultiInsertQuery.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/query/AutoMultiInsertQuery.java
@@ -232,6 +232,10 @@ public class AutoMultiInsertQuery<ENTITY> extends AutoModifyQuery<ENTITY> implem
     }
   }
 
+  public void setDuplicateKeyType(DuplicateKeyType duplicateKeyType) {
+    this.duplicateKeyType = duplicateKeyType;
+  }
+
   protected static class AutoPreInsertContext<E> extends AbstractPreInsertContext<E> {
 
     public AutoPreInsertContext(

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/query/QueryOperandPairList.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/query/QueryOperandPairList.java
@@ -1,0 +1,19 @@
+package org.seasar.doma.jdbc.query;
+
+import java.util.List;
+
+public class QueryOperandPairList {
+  private final List<QueryOperandPair> pairs;
+
+  public QueryOperandPairList(List<QueryOperandPair> pairs) {
+    this.pairs = pairs;
+  }
+
+  public List<QueryOperandPair> getPairs() {
+    return pairs;
+  }
+
+  public boolean isEmpty() {
+    return pairs.isEmpty();
+  }
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/query/QueryRows.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/query/QueryRows.java
@@ -1,0 +1,27 @@
+package org.seasar.doma.jdbc.query;
+
+import java.util.List;
+
+public class QueryRows {
+  private final List<QueryOperandPairList> rows;
+
+  public QueryRows(List<QueryOperandPairList> rows) {
+    this.rows = rows;
+  }
+
+  public List<QueryOperandPairList> getRows() {
+    return rows;
+  }
+
+  public boolean isEmpty() {
+    return rows.isEmpty();
+  }
+
+  public boolean hasEmptyValueRow() {
+    return rows.stream().anyMatch(QueryOperandPairList::isEmpty);
+  }
+
+  public QueryOperandPairList first() {
+    return rows.get(0);
+  }
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/query/UpsertAssemblerContext.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/query/UpsertAssemblerContext.java
@@ -32,10 +32,10 @@ public class UpsertAssemblerContext {
   public final List<? extends EntityPropertyType<?, ?>> keys;
 
   /** values clause property-parameter pair list */
-  public final List<QueryOperandPair> insertValues;
+  public final QueryRows insertValues;
 
   /** set clause property-value pair list */
-  public final List<QueryOperandPair> setValues;
+  public final QueryOperandPairList setValues;
 
   /**
    * Constructs an instance of UpsertAssemblerContext with the specified prepared SQL builder,
@@ -60,8 +60,8 @@ public class UpsertAssemblerContext {
       Dialect dialect,
       boolean isKeysSpecified,
       List<? extends EntityPropertyType<?, ?>> keys,
-      List<QueryOperandPair> insertValues,
-      List<QueryOperandPair> setValues) {
+      QueryRows insertValues,
+      QueryOperandPairList setValues) {
     Objects.requireNonNull(buf);
     Objects.requireNonNull(entityType);
     Objects.requireNonNull(duplicateKeyType);
@@ -79,7 +79,7 @@ public class UpsertAssemblerContext {
           "keys",
           "The keys must not be empty when performing an upsert. At least one key must be specified.");
     }
-    if (insertValues.isEmpty()) {
+    if (insertValues.isEmpty() || insertValues.hasEmptyValueRow()) {
       throw new DomaIllegalArgumentException(
           "insertValues",
           "The insertValues must not be empty when performing an upsert. At least one insert value must be specified.");

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/annot/MultiInsertAnnot.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/annot/MultiInsertAnnot.java
@@ -10,6 +10,7 @@ import javax.lang.model.element.VariableElement;
 import org.seasar.doma.internal.apt.AptIllegalStateException;
 import org.seasar.doma.internal.apt.util.AnnotationValueUtil;
 import org.seasar.doma.jdbc.SqlLogType;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 public class MultiInsertAnnot extends AbstractAnnot {
 
@@ -20,12 +21,16 @@ public class MultiInsertAnnot extends AbstractAnnot {
 
   private static final String SQL_LOG = "sqlLog";
 
+  private static final String DUPLICATE_KEY_TYPE = "duplicateKeyType";
+
   private final AnnotationValue queryTimeout;
   private final AnnotationValue include;
 
   private final AnnotationValue exclude;
 
   private final AnnotationValue sqlLog;
+
+  private final AnnotationValue duplicateKeyType;
 
   MultiInsertAnnot(AnnotationMirror annotationMirror, Map<String, AnnotationValue> values) {
     super(annotationMirror);
@@ -37,6 +42,7 @@ public class MultiInsertAnnot extends AbstractAnnot {
     // nullable values
     this.include = values.get(INCLUDE);
     this.exclude = values.get(EXCLUDE);
+    this.duplicateKeyType = values.get(DUPLICATE_KEY_TYPE);
   }
 
   public AnnotationValue getQueryTimeout() {
@@ -69,6 +75,14 @@ public class MultiInsertAnnot extends AbstractAnnot {
 
   public List<String> getExcludeValue() {
     return AnnotationValueUtil.toStringList(exclude);
+  }
+
+  public DuplicateKeyType getDuplicateKeyValue() {
+    VariableElement enumConstant = AnnotationValueUtil.toEnumConstant(duplicateKeyType);
+    if (enumConstant == null) {
+      throw new AptIllegalStateException(DUPLICATE_KEY_TYPE);
+    }
+    return DuplicateKeyType.valueOf(enumConstant.getSimpleName().toString());
   }
 
   public SqlLogType getSqlLogValue() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplQueryMethodGenerator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplQueryMethodGenerator.java
@@ -364,6 +364,11 @@ public class DaoImplQueryMethodGenerator extends AbstractGenerator
         /* 5 */ methodName);
     iprint("__query.setMethod(%1$s);%n", methodName);
     iprint("__query.setConfig(__support.getConfig());%n");
+    if (m.getDuplicateKeyType() != null) {
+      iprint(
+          "__query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.%1$s);%n",
+          m.getDuplicateKeyType());
+    }
     iprint("__query.setEntities(%1$s);%n", m.getEntityParameterName());
     iprint("__query.setCallerClassName(\"%1$s\");%n", className);
     iprint("__query.setCallerMethodName(\"%1$s\");%n", m.getName());

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/AutoMultiInsertQueryMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/AutoMultiInsertQueryMeta.java
@@ -6,6 +6,7 @@ import javax.lang.model.element.TypeElement;
 import org.seasar.doma.internal.apt.annot.MultiInsertAnnot;
 import org.seasar.doma.internal.apt.cttype.EntityCtType;
 import org.seasar.doma.jdbc.SqlLogType;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 public class AutoMultiInsertQueryMeta extends AbstractQueryMeta {
 
@@ -14,6 +15,8 @@ public class AutoMultiInsertQueryMeta extends AbstractQueryMeta {
   private String entityParameterName;
 
   private MultiInsertAnnot multiInsertAnnot;
+
+  private DuplicateKeyType duplicateKeyType;
 
   public AutoMultiInsertQueryMeta(TypeElement daoElement, ExecutableElement methodElement) {
     super(daoElement, methodElement);
@@ -57,6 +60,14 @@ public class AutoMultiInsertQueryMeta extends AbstractQueryMeta {
 
   public SqlLogType getSqlLogType() {
     return multiInsertAnnot.getSqlLogValue();
+  }
+
+  public DuplicateKeyType getDuplicateKeyType() {
+    return this.duplicateKeyType;
+  }
+
+  public void setDuplicateKeyType(DuplicateKeyType duplicateKeyType) {
+    this.duplicateKeyType = duplicateKeyType;
   }
 
   @Override

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/AutoMultiInsertQueryMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/AutoMultiInsertQueryMetaFactory.java
@@ -11,6 +11,7 @@ import org.seasar.doma.internal.apt.cttype.CtType;
 import org.seasar.doma.internal.apt.cttype.EntityCtType;
 import org.seasar.doma.internal.apt.cttype.IterableCtType;
 import org.seasar.doma.internal.apt.cttype.SimpleCtTypeVisitor;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 import org.seasar.doma.message.Message;
 
 public class AutoMultiInsertQueryMetaFactory
@@ -38,8 +39,10 @@ public class AutoMultiInsertQueryMetaFactory
     AutoMultiInsertQueryMeta queryMeta = new AutoMultiInsertQueryMeta(daoElement, methodElement);
     MultiInsertAnnot insertAnnot = ctx.getAnnotations().newMultiInsertAnnot(methodElement);
     if (insertAnnot != null) {
+      DuplicateKeyType duplicateKeyType = insertAnnot.getDuplicateKeyValue();
       queryMeta.setMultiInsertAnnot(insertAnnot);
       queryMeta.setQueryKind(QueryKind.AUTO_MULTI_INSERT);
+      queryMeta.setDuplicateKeyType(duplicateKeyType);
       return queryMeta;
     }
     return null;

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoMultiInsertDao.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/AutoMultiInsertDao.java
@@ -7,6 +7,7 @@ import org.seasar.doma.internal.apt.processor.entity.Emp;
 import org.seasar.doma.internal.apt.processor.entity.ImmutableEmp;
 import org.seasar.doma.jdbc.MultiResult;
 import org.seasar.doma.jdbc.SqlLogType;
+import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 @SuppressWarnings("deprecation")
 @Dao(config = MyConfig.class)
@@ -26,6 +27,15 @@ public interface AutoMultiInsertDao {
 
   @MultiInsert(sqlLog = SqlLogType.NONE)
   int insertWithSqlLog(List<Emp> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.IGNORE)
+  int insertDuplicateKeyIgnore(List<Emp> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.UPDATE)
+  int insertDuplicateKeyUpdate(List<Emp> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.EXCEPTION)
+  int insertDuplicateKeyException(List<Emp> entities);
 
   @MultiInsert
   MultiResult<ImmutableEmp> insertImmutableEntities(List<ImmutableEmp> entities);

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AutoMultiInsertDao.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest_AutoMultiInsertDao.txt
@@ -19,7 +19,13 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
 
     private static final java.lang.reflect.Method __method4 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertWithSqlLog", java.util.List.class);
 
-    private static final java.lang.reflect.Method __method5 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertImmutableEntities", java.util.List.class);
+    private static final java.lang.reflect.Method __method5 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertDuplicateKeyIgnore", java.util.List.class);
+
+    private static final java.lang.reflect.Method __method6 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertDuplicateKeyUpdate", java.util.List.class);
+
+    private static final java.lang.reflect.Method __method7 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertDuplicateKeyException", java.util.List.class);
+
+    private static final java.lang.reflect.Method __method8 = org.seasar.doma.internal.jdbc.dao.DaoImplSupport.getDeclaredMethod(org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDao.class, "insertImmutableEntities", java.util.List.class);
 
     private final org.seasar.doma.internal.jdbc.dao.DaoImplSupport __support;
 
@@ -80,6 +86,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method0, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
             __query.setMethod(__method0);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insert");
@@ -109,6 +116,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method1, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
             __query.setMethod(__method1);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insertWithExclude");
@@ -138,6 +146,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method2, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
             __query.setMethod(__method2);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insertWithInclude");
@@ -167,6 +176,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method3, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
             __query.setMethod(__method3);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insertWithQueryTimeout");
@@ -196,6 +206,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method4, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
             __query.setMethod(__method4);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insertWithSqlLog");
@@ -216,15 +227,106 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
     }
 
     @Override
+    public int insertDuplicateKeyIgnore(java.util.List<org.seasar.doma.internal.apt.processor.entity.Emp> entities) {
+        __support.entering("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyIgnore", entities);
+        try {
+            if (entities == null) {
+                throw new org.seasar.doma.DomaNullPointerException("entities");
+            }
+            org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method5, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
+            __query.setMethod(__method5);
+            __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.IGNORE);
+            __query.setEntities(entities);
+            __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
+            __query.setCallerMethodName("insertDuplicateKeyIgnore");
+            __query.setQueryTimeout(-1);
+            __query.setSqlLogType(org.seasar.doma.jdbc.SqlLogType.FORMATTED);
+            __query.setIncludedPropertyNames();
+            __query.setExcludedPropertyNames();
+            __query.prepare();
+            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method5, __query);
+            int __result = __command.execute();
+            __query.complete();
+            __support.exiting("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyIgnore", __result);
+            return __result;
+        } catch (java.lang.RuntimeException __e) {
+            __support.throwing("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyIgnore", __e);
+            throw __e;
+        }
+    }
+
+    @Override
+    public int insertDuplicateKeyUpdate(java.util.List<org.seasar.doma.internal.apt.processor.entity.Emp> entities) {
+        __support.entering("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyUpdate", entities);
+        try {
+            if (entities == null) {
+                throw new org.seasar.doma.DomaNullPointerException("entities");
+            }
+            org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method6, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
+            __query.setMethod(__method6);
+            __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.UPDATE);
+            __query.setEntities(entities);
+            __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
+            __query.setCallerMethodName("insertDuplicateKeyUpdate");
+            __query.setQueryTimeout(-1);
+            __query.setSqlLogType(org.seasar.doma.jdbc.SqlLogType.FORMATTED);
+            __query.setIncludedPropertyNames();
+            __query.setExcludedPropertyNames();
+            __query.prepare();
+            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method6, __query);
+            int __result = __command.execute();
+            __query.complete();
+            __support.exiting("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyUpdate", __result);
+            return __result;
+        } catch (java.lang.RuntimeException __e) {
+            __support.throwing("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyUpdate", __e);
+            throw __e;
+        }
+    }
+
+    @Override
+    public int insertDuplicateKeyException(java.util.List<org.seasar.doma.internal.apt.processor.entity.Emp> entities) {
+        __support.entering("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyException", entities);
+        try {
+            if (entities == null) {
+                throw new org.seasar.doma.DomaNullPointerException("entities");
+            }
+            org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.Emp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method7, org.seasar.doma.internal.apt.processor.entity._Emp.getSingletonInternal());
+            __query.setMethod(__method7);
+            __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
+            __query.setEntities(entities);
+            __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
+            __query.setCallerMethodName("insertDuplicateKeyException");
+            __query.setQueryTimeout(-1);
+            __query.setSqlLogType(org.seasar.doma.jdbc.SqlLogType.FORMATTED);
+            __query.setIncludedPropertyNames();
+            __query.setExcludedPropertyNames();
+            __query.prepare();
+            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method7, __query);
+            int __result = __command.execute();
+            __query.complete();
+            __support.exiting("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyException", __result);
+            return __result;
+        } catch (java.lang.RuntimeException __e) {
+            __support.throwing("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertDuplicateKeyException", __e);
+            throw __e;
+        }
+    }
+
+    @Override
     public org.seasar.doma.jdbc.MultiResult<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp> insertImmutableEntities(java.util.List<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp> entities) {
         __support.entering("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl", "insertImmutableEntities", entities);
         try {
             if (entities == null) {
                 throw new org.seasar.doma.DomaNullPointerException("entities");
             }
-            org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method5, org.seasar.doma.internal.apt.processor.entity._ImmutableEmp.getSingletonInternal());
-            __query.setMethod(__method5);
+            org.seasar.doma.jdbc.query.AutoMultiInsertQuery<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp> __query = __support.getQueryImplementors().createAutoMultiInsertQuery(__method8, org.seasar.doma.internal.apt.processor.entity._ImmutableEmp.getSingletonInternal());
+            __query.setMethod(__method8);
             __query.setConfig(__support.getConfig());
+            __query.setDuplicateKeyType(org.seasar.doma.jdbc.query.DuplicateKeyType.EXCEPTION);
             __query.setEntities(entities);
             __query.setCallerClassName("org.seasar.doma.internal.apt.processor.dao.AutoMultiInsertDaoImpl");
             __query.setCallerMethodName("insertImmutableEntities");
@@ -233,7 +335,7 @@ public class AutoMultiInsertDaoImpl implements org.seasar.doma.internal.apt.proc
             __query.setIncludedPropertyNames();
             __query.setExcludedPropertyNames();
             __query.prepare();
-            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method5, __query);
+            org.seasar.doma.jdbc.command.InsertCommand __command = __support.getCommandImplementors().createInsertCommand(__method8, __query);
             int __count = __command.execute();
             __query.complete();
             org.seasar.doma.jdbc.MultiResult<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp> __result = new org.seasar.doma.jdbc.MultiResult<org.seasar.doma.internal.apt.processor.entity.ImmutableEmp>(__count, __query.getEntities());

--- a/integration-test-java/src/main/java/org/seasar/doma/it/dao/CompKeyDeptDao.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/dao/CompKeyDeptDao.java
@@ -4,9 +4,11 @@ import java.util.List;
 import org.seasar.doma.BatchInsert;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
+import org.seasar.doma.MultiInsert;
 import org.seasar.doma.Select;
 import org.seasar.doma.it.entity.CompKeyDept;
 import org.seasar.doma.jdbc.BatchResult;
+import org.seasar.doma.jdbc.MultiResult;
 import org.seasar.doma.jdbc.Result;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
@@ -27,4 +29,10 @@ public interface CompKeyDeptDao {
 
   @BatchInsert(duplicateKeyType = DuplicateKeyType.IGNORE)
   BatchResult<CompKeyDept> insertOnDuplicateKeyIgnore(List<CompKeyDept> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.UPDATE)
+  MultiResult<CompKeyDept> insertMultiRowsOnDuplicateKeyUpdate(List<CompKeyDept> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.IGNORE)
+  MultiResult<CompKeyDept> insertMultiRowsOnDuplicateKeyIgnore(List<CompKeyDept> entities);
 }

--- a/integration-test-java/src/main/java/org/seasar/doma/it/dao/DeptDao.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/dao/DeptDao.java
@@ -58,4 +58,10 @@ public interface DeptDao {
 
   @MultiInsert
   MultiResult<Dept> insertMultiRows(List<Dept> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.IGNORE)
+  MultiResult<Dept> insertMultiRowsOnDuplicateKeyIgnore(List<Dept> entities);
+
+  @MultiInsert(duplicateKeyType = DuplicateKeyType.UPDATE)
+  MultiResult<Dept> insertMultiRowsOnDuplicateKeyUpdate(List<Dept> entities);
 }

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
@@ -27,6 +27,8 @@ import org.seasar.doma.it.dao.BusinessmanDao;
 import org.seasar.doma.it.dao.BusinessmanDaoImpl;
 import org.seasar.doma.it.dao.CompKeyDepartmentDao;
 import org.seasar.doma.it.dao.CompKeyDepartmentDaoImpl;
+import org.seasar.doma.it.dao.CompKeyDeptDao;
+import org.seasar.doma.it.dao.CompKeyDeptDaoImpl;
 import org.seasar.doma.it.dao.DepartmentDao;
 import org.seasar.doma.it.dao.DepartmentDaoImpl;
 import org.seasar.doma.it.dao.DeptDao;
@@ -51,6 +53,7 @@ import org.seasar.doma.it.domain.Salary;
 import org.seasar.doma.it.embeddable.StaffInfo;
 import org.seasar.doma.it.entity.Businessman;
 import org.seasar.doma.it.entity.CompKeyDepartment;
+import org.seasar.doma.it.entity.CompKeyDept;
 import org.seasar.doma.it.entity.Department;
 import org.seasar.doma.it.entity.Dept;
 import org.seasar.doma.it.entity.IdentityStrategy;
@@ -408,5 +411,168 @@ public class AutoMultiInsertTest {
     DepartmentDao dao = new DepartmentDaoImpl(config);
     int result = dao.insertMultiRows(Collections.emptyList());
     assertEquals(0, result);
+  }
+
+  @Test
+  public void insert_DuplicateKeyType_UPDATE(Config config) throws Exception {
+    DeptDao dao = new DeptDaoImpl(config);
+    Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
+    Dept dept2 = new Dept(new Identity<>(1), 60, "DEVELOPMENT", new Location<>("KYOTO"), null);
+    MultiResult<Dept> result = dao.insertMultiRowsOnDuplicateKeyUpdate(Arrays.asList(dept1, dept2));
+    // insert result entities
+    Dept resultDept1 = result.component1().get(0);
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId().getValue());
+    assertEquals(Integer.valueOf(50), resultDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(U)_postI(U)", resultDept1.getDepartmentName());
+    assertEquals("TOKYO", resultDept1.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept1.getVersion());
+    Dept resultDept2 = result.component1().get(1);
+    assertEquals(Integer.valueOf(1), resultDept2.getDepartmentId().getValue());
+    assertEquals(Integer.valueOf(60), resultDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(U)_postI(U)", resultDept2.getDepartmentName());
+    assertEquals("KYOTO", resultDept2.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept2.getVersion());
+    // insert result count
+    assertEquals(2, result.component2());
+    // reload from database
+    Dept reloadDept1 = dao.selectById(dept1.getDepartmentId().getValue());
+    Dept reloadDept2 = dao.selectById(dept2.getDepartmentId().getValue());
+    // inserted
+    assertEquals(50, reloadDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(U)", reloadDept1.getDepartmentName());
+    assertEquals("TOKYO", reloadDept1.getLocation().getValue());
+    assertEquals(1, reloadDept1.getVersion());
+    // updated
+    assertEquals(60, reloadDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(U)", reloadDept2.getDepartmentName());
+    assertEquals("KYOTO", reloadDept2.getLocation().getValue());
+    assertEquals(1, reloadDept2.getVersion());
+  }
+
+  @Test
+  public void insert_DuplicateKeyType_IGNORE(Config config) throws Exception {
+    DeptDao dao = new DeptDaoImpl(config);
+    Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
+    Dept dept2 = new Dept(new Identity<>(1), 60, "DEVELOPMENT", new Location<>("KYOTO"), null);
+    MultiResult<Dept> result = dao.insertMultiRowsOnDuplicateKeyIgnore(Arrays.asList(dept1, dept2));
+
+    // insert result entities
+    Dept resultDept1 = result.component1().get(0);
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId().getValue());
+    assertEquals(Integer.valueOf(50), resultDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(I)_postI(I)", resultDept1.getDepartmentName());
+    assertEquals("TOKYO", resultDept1.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept1.getVersion());
+    Dept resultDept2 = result.component1().get(1);
+    assertEquals(Integer.valueOf(1), resultDept2.getDepartmentId().getValue());
+    assertEquals(Integer.valueOf(60), resultDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(I)_postI(I)", resultDept2.getDepartmentName());
+    assertEquals("KYOTO", resultDept2.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept2.getVersion());
+    // insert result count
+    assertEquals(2, result.component2());
+    // reload from database
+    Dept reloadDept1 = dao.selectById(dept1.getDepartmentId().getValue());
+    Dept reloadDept2 = dao.selectById(dept2.getDepartmentId().getValue());
+    // inserted
+    assertEquals(50, reloadDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(I)", reloadDept1.getDepartmentName());
+    assertEquals("TOKYO", reloadDept1.getLocation().getValue());
+    assertEquals(1, reloadDept1.getVersion());
+    // ignored
+    assertEquals(10, reloadDept2.getDepartmentNo());
+    assertEquals("ACCOUNTING", reloadDept2.getDepartmentName());
+    assertEquals("NEW YORK", reloadDept2.getLocation().getValue());
+    assertEquals(1, reloadDept2.getVersion());
+  }
+
+  @Test
+  public void insert_DuplicateKeyType_UPDATE_compositeKey(Config config) throws Exception {
+    CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
+    CompKeyDept dept1 =
+        new CompKeyDept(
+            new Identity<>(5), new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
+    CompKeyDept dept2 =
+        new CompKeyDept(
+            new Identity<>(1), new Identity<>(1), 60, "DEVELOPMENT", new Location<>("KYOTO"), null);
+    MultiResult<CompKeyDept> result =
+        dao.insertMultiRowsOnDuplicateKeyUpdate(Arrays.asList(dept1, dept2));
+
+    // insert result entities
+    CompKeyDept resultDept1 = result.component1().get(0);
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId1().getValue());
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId2().getValue());
+    assertEquals(Integer.valueOf(50), resultDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(U)_postI(U)", resultDept1.getDepartmentName());
+    assertEquals("TOKYO", resultDept1.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept1.getVersion());
+    CompKeyDept resultDept2 = result.component1().get(1);
+    assertEquals(Integer.valueOf(1), resultDept2.getDepartmentId1().getValue());
+    assertEquals(Integer.valueOf(60), resultDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(U)_postI(U)", resultDept2.getDepartmentName());
+    assertEquals("KYOTO", resultDept2.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept2.getVersion());
+    // insert result count
+    assertEquals(2, result.component2());
+    // reload from database
+    CompKeyDept reloadDept1 =
+        dao.selectByIds(dept1.getDepartmentId1().getValue(), dept1.getDepartmentId2().getValue());
+    CompKeyDept reloadDept2 =
+        dao.selectByIds(dept2.getDepartmentId1().getValue(), dept2.getDepartmentId2().getValue());
+    // inserted
+    assertEquals(50, reloadDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(U)", reloadDept1.getDepartmentName());
+    assertEquals("TOKYO", reloadDept1.getLocation().getValue());
+    assertEquals(1, reloadDept1.getVersion());
+    // updated
+    assertEquals(60, reloadDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(U)", reloadDept2.getDepartmentName());
+    assertEquals("KYOTO", reloadDept2.getLocation().getValue());
+    assertEquals(1, reloadDept2.getVersion());
+  }
+
+  @Test
+  public void insert_DuplicateKeyType_IGNORE_compositeKey(Config config) throws Exception {
+    CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
+    CompKeyDept dept1 =
+        new CompKeyDept(
+            new Identity<>(5), new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
+    CompKeyDept dept2 =
+        new CompKeyDept(
+            new Identity<>(1), new Identity<>(1), 60, "DEVELOPMENT", new Location<>("KYOTO"), null);
+    MultiResult<CompKeyDept> result =
+        dao.insertMultiRowsOnDuplicateKeyIgnore(Arrays.asList(dept1, dept2));
+
+    // insert result entities
+    CompKeyDept resultDept1 = result.component1().get(0);
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId1().getValue());
+    assertEquals(Integer.valueOf(5), resultDept1.getDepartmentId2().getValue());
+    assertEquals(Integer.valueOf(50), resultDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(I)_postI(I)", resultDept1.getDepartmentName());
+    assertEquals("TOKYO", resultDept1.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept1.getVersion());
+    CompKeyDept resultDept2 = result.component1().get(1);
+    assertEquals(Integer.valueOf(1), resultDept2.getDepartmentId1().getValue());
+    assertEquals(Integer.valueOf(60), resultDept2.getDepartmentNo());
+    assertEquals("DEVELOPMENT_preI(I)_postI(I)", resultDept2.getDepartmentName());
+    assertEquals("KYOTO", resultDept2.getLocation().getValue());
+    assertEquals(Integer.valueOf(1), resultDept2.getVersion());
+    // insert result count
+    assertEquals(2, result.component2());
+    // reload from database
+    CompKeyDept reloadDept1 =
+        dao.selectByIds(dept1.getDepartmentId1().getValue(), dept1.getDepartmentId2().getValue());
+    CompKeyDept reloadDept2 =
+        dao.selectByIds(dept2.getDepartmentId1().getValue(), dept2.getDepartmentId2().getValue());
+    // inserted
+    assertEquals(50, reloadDept1.getDepartmentNo());
+    assertEquals("PLANNING_preI(I)", reloadDept1.getDepartmentName());
+    assertEquals("TOKYO", reloadDept1.getLocation().getValue());
+    assertEquals(1, reloadDept1.getVersion());
+    // ignored
+    assertEquals(10, reloadDept2.getDepartmentNo());
+    assertEquals("ACCOUNTING", reloadDept2.getDepartmentName());
+    assertEquals("NEW YORK", reloadDept2.getLocation().getValue());
+    assertEquals(1, reloadDept2.getVersion());
   }
 }

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
@@ -433,7 +433,12 @@ public class AutoMultiInsertTest {
     assertEquals("KYOTO", resultDept2.getLocation().getValue());
     assertEquals(Integer.valueOf(1), resultDept2.getVersion());
     // insert result count
-    assertEquals(2, result.component2());
+    if (config.getDialect().getName().equals("mysql")
+        || config.getDialect().getName().equals("mariadb")) {
+      assertEquals(3, result.component2());
+    } else {
+      assertEquals(2, result.component2());
+    }
     // reload from database
     Dept reloadDept1 = dao.selectById(dept1.getDepartmentId().getValue());
     Dept reloadDept2 = dao.selectById(dept2.getDepartmentId().getValue());
@@ -470,7 +475,7 @@ public class AutoMultiInsertTest {
     assertEquals("KYOTO", resultDept2.getLocation().getValue());
     assertEquals(Integer.valueOf(1), resultDept2.getVersion());
     // insert result count
-    assertEquals(2, result.component2());
+    assertEquals(1, result.component2());
     // reload from database
     Dept reloadDept1 = dao.selectById(dept1.getDepartmentId().getValue());
     Dept reloadDept2 = dao.selectById(dept2.getDepartmentId().getValue());
@@ -513,7 +518,12 @@ public class AutoMultiInsertTest {
     assertEquals("KYOTO", resultDept2.getLocation().getValue());
     assertEquals(Integer.valueOf(1), resultDept2.getVersion());
     // insert result count
-    assertEquals(2, result.component2());
+    if (config.getDialect().getName().equals("mysql")
+        || config.getDialect().getName().equals("mariadb")) {
+      assertEquals(3, result.component2());
+    } else {
+      assertEquals(2, result.component2());
+    }
     // reload from database
     CompKeyDept reloadDept1 =
         dao.selectByIds(dept1.getDepartmentId1().getValue(), dept1.getDepartmentId2().getValue());
@@ -558,7 +568,7 @@ public class AutoMultiInsertTest {
     assertEquals("KYOTO", resultDept2.getLocation().getValue());
     assertEquals(Integer.valueOf(1), resultDept2.getVersion());
     // insert result count
-    assertEquals(2, result.component2());
+    assertEquals(1, result.component2());
     // reload from database
     CompKeyDept reloadDept1 =
         dao.selectByIds(dept1.getDepartmentId1().getValue(), dept1.getDepartmentId2().getValue());

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
@@ -414,7 +414,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.H2})
+  @Run(unless = {Dbms.H2, Dbms.SQLSERVER, Dbms.ORACLE})
   public void insert_DuplicateKeyType_UPDATE(Config config) throws Exception {
     DeptDao dao = new DeptDaoImpl(config);
     Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
@@ -456,7 +456,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.H2})
+  @Run(unless = {Dbms.H2, Dbms.SQLSERVER, Dbms.ORACLE})
   public void insert_DuplicateKeyType_IGNORE(Config config) throws Exception {
     DeptDao dao = new DeptDaoImpl(config);
     Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
@@ -494,7 +494,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.H2})
+  @Run(unless = {Dbms.H2, Dbms.SQLSERVER, Dbms.ORACLE})
   public void insert_DuplicateKeyType_UPDATE_compositeKey(Config config) throws Exception {
     CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
     CompKeyDept dept1 =
@@ -545,7 +545,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
-  @Run(unless = {Dbms.H2})
+  @Run(unless = {Dbms.H2, Dbms.SQLSERVER, Dbms.ORACLE})
   public void insert_DuplicateKeyType_IGNORE_compositeKey(Config config) throws Exception {
     CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
     CompKeyDept dept1 =

--- a/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/auto/AutoMultiInsertTest.java
@@ -414,6 +414,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
+  @Run(unless = {Dbms.H2})
   public void insert_DuplicateKeyType_UPDATE(Config config) throws Exception {
     DeptDao dao = new DeptDaoImpl(config);
     Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
@@ -455,6 +456,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
+  @Run(unless = {Dbms.H2})
   public void insert_DuplicateKeyType_IGNORE(Config config) throws Exception {
     DeptDao dao = new DeptDaoImpl(config);
     Dept dept1 = new Dept(new Identity<>(5), 50, "PLANNING", new Location<>("TOKYO"), null);
@@ -492,6 +494,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
+  @Run(unless = {Dbms.H2})
   public void insert_DuplicateKeyType_UPDATE_compositeKey(Config config) throws Exception {
     CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
     CompKeyDept dept1 =
@@ -542,6 +545,7 @@ public class AutoMultiInsertTest {
   }
 
   @Test
+  @Run(unless = {Dbms.H2})
   public void insert_DuplicateKeyType_IGNORE_compositeKey(Config config) throws Exception {
     CompKeyDeptDao dao = new CompKeyDeptDaoImpl(config);
     CompKeyDept dept1 =

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/EntityqlMultiInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/EntityqlMultiInsertTest.java
@@ -7,6 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.seasar.doma.it.Dbms;
@@ -59,6 +62,105 @@ public class EntityqlMultiInsertTest {
             .orderBy(c -> c.asc(d.departmentId))
             .fetch();
     assertEquals(2, departments2.size());
+  }
+
+  @Test
+  @Run(unless = {Dbms.ORACLE, Dbms.SQLSERVER, Dbms.H2})
+  void testIgnore() {
+    Department_ d = new Department_();
+
+    Department department = new Department();
+    department.setDepartmentId(99);
+    department.setDepartmentNo(99);
+    department.setDepartmentName("aaa");
+    department.setLocation("bbb");
+
+    Department department2 = new Department();
+    department2.setDepartmentId(100);
+    department2.setDepartmentNo(100);
+    department2.setDepartmentName("ccc");
+    department2.setLocation("ddd");
+
+    Department department3 = new Department();
+    department3.setDepartmentId(101);
+    department3.setDepartmentNo(101);
+    department3.setDepartmentName("eee");
+    department3.setLocation("fff");
+
+    entityql.insertMulti(d, Arrays.asList(department, department2)).execute();
+
+    department.setDepartmentName("aaa_updated");
+    department.setLocation("bbb_updated");
+
+    List<Department> departments = Arrays.asList(department, department3);
+    MultiResult<Department> result =
+        entityql.insertMulti(d, departments).onDuplicateKeyIgnore().execute();
+    assertEquals(departments, result.getEntities());
+    assertEquals(1, result.getCount());
+
+    List<Integer> ids = departments.stream().map(Department::getDepartmentId).collect(toList());
+
+    Map<Integer, Department> departments2 =
+        entityql
+            .from(d)
+            .where(c -> c.in(d.departmentId, ids))
+            .orderBy(c -> c.asc(d.departmentId))
+            .stream()
+            .collect(Collectors.toMap(Department::getDepartmentId, Function.identity()));
+    assertEquals(2, departments2.size());
+    assertEquals("aaa", departments2.get(99).getDepartmentName());
+  }
+
+  @Test
+  @Run(unless = {Dbms.ORACLE, Dbms.SQLSERVER, Dbms.H2})
+  void testUpdate() {
+    Department_ d = new Department_();
+
+    Department department = new Department();
+    department.setDepartmentId(99);
+    department.setDepartmentNo(99);
+    department.setDepartmentName("aaa");
+    department.setLocation("bbb");
+
+    Department department2 = new Department();
+    department2.setDepartmentId(100);
+    department2.setDepartmentNo(100);
+    department2.setDepartmentName("ccc");
+    department2.setLocation("ddd");
+
+    Department department3 = new Department();
+    department3.setDepartmentId(101);
+    department3.setDepartmentNo(101);
+    department3.setDepartmentName("eee");
+    department3.setLocation("fff");
+
+    entityql.insertMulti(d, Arrays.asList(department, department2)).execute();
+
+    department.setDepartmentName("aaa_updated");
+    department.setLocation("bbb_updated");
+
+    List<Department> departments = Arrays.asList(department, department3);
+    MultiResult<Department> result =
+        entityql.insertMulti(d, departments).onDuplicateKeyUpdate().execute();
+    assertEquals(departments, result.getEntities());
+    if (dialect.getName().equals("mysql") || dialect.getName().equals("mariadb")) {
+      assertEquals(3, result.getCount());
+    } else {
+      assertEquals(2, result.getCount());
+    }
+
+    List<Integer> ids = departments.stream().map(Department::getDepartmentId).collect(toList());
+
+    Map<Integer, Department> departments2 =
+        entityql
+            .from(d)
+            .where(c -> c.in(d.departmentId, ids))
+            .orderBy(c -> c.asc(d.departmentId))
+            .stream()
+            .collect(Collectors.toMap(Department::getDepartmentId, Function.identity()));
+    assertEquals(2, departments2.size());
+    assertEquals("aaa_updated", departments2.get(99).getDepartmentName());
+    assertEquals("eee", departments2.get(101).getDepartmentName());
   }
 
   @Test


### PR DESCRIPTION
I will enable passing DuplicateKeyType when using MultiInsert.
I am modifying the UpsertAssembler to accept multiple values.

I could not implement upsert for SQL Server, Oracle, and H2 due to lack of knowledge. Therefore, I am throwing an exception in UpsertAssembler when multiple values are received.