### PR TITLE
Improving generics type in doma-kotlin

### DIFF
--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KComparisonDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KComparisonDeclaration.kt
@@ -4,67 +4,67 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel
 
 abstract class KComparisonDeclaration<DECLARATION : org.seasar.doma.jdbc.criteria.declaration.ComparisonDeclaration>(protected val declaration: DECLARATION) {
 
-    fun <PROPERTY> eq(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> eq(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.eq(left, right)
     }
 
-    fun <PROPERTY> eq(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> eq(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.eq(left, right)
     }
 
-    fun <PROPERTY> ne(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> ne(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.ne(left, right)
     }
 
-    fun <PROPERTY> ne(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> ne(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.ne(left, right)
     }
 
-    fun <PROPERTY> gt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> gt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.gt(left, right)
     }
 
-    fun <PROPERTY> gt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> gt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.gt(left, right)
     }
 
-    fun <PROPERTY> ge(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> ge(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.ge(left, right)
     }
 
-    fun <PROPERTY> ge(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> ge(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.ge(left, right)
     }
 
-    fun <PROPERTY> lt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> lt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.lt(left, right)
     }
 
-    fun <PROPERTY> lt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> lt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.lt(left, right)
     }
 
-    fun <PROPERTY> le(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> le(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.le(left, right)
     }
 
-    fun <PROPERTY> le(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> le(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.le(left, right)
     }
 
-    fun <PROPERTY> isNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> isNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
         declaration.isNull(propertyMetamodel)
     }
 
-    fun <PROPERTY> isNotNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> isNotNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
         declaration.isNotNull(propertyMetamodel)
     }
 
-    fun <PROPERTY> eqOrIsNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> eqOrIsNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.eqOrIsNull(left, right)
     }
 
-    fun <PROPERTY> neOrIsNotNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> neOrIsNotNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.neOrIsNotNull(left, right)
     }
 

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KInsertSelectDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KInsertSelectDeclaration.kt
@@ -5,7 +5,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.EntityMetamodel
 
 class KInsertSelectDeclaration {
 
-    fun <ENTITY> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
+    fun <ENTITY : Any> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
         val declaration = SubSelectFromDeclaration<ENTITY>(entityMetamodel)
         return KSubSelectFromDeclaration(declaration)
     }

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KJoinDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KJoinDeclaration.kt
@@ -10,162 +10,162 @@ import org.seasar.doma.jdbc.criteria.tuple.Tuple2
 import org.seasar.doma.jdbc.criteria.tuple.Tuple3
 
 class KJoinDeclaration(private val declaration: JoinDeclaration) {
-    fun <PROPERTY> eq(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> eq(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.eq(left, right)
     }
 
-    fun <PROPERTY> eq(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> eq(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.eq(left, right)
     }
 
-    fun <PROPERTY> ne(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> ne(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.ne(left, right)
     }
 
-    fun <PROPERTY> ne(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> ne(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.ne(left, right)
     }
 
-    fun <PROPERTY> gt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> gt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.gt(left, right)
     }
 
-    fun <PROPERTY> gt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> gt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.gt(left, right)
     }
 
-    fun <PROPERTY> ge(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> ge(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.ge(left, right)
     }
 
-    fun <PROPERTY> ge(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> ge(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.ge(left, right)
     }
 
-    fun <PROPERTY> lt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> lt(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.lt(left, right)
     }
 
-    fun <PROPERTY> lt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> lt(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.lt(left, right)
     }
 
-    fun <PROPERTY> le(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> le(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.le(left, right)
     }
 
-    fun <PROPERTY> le(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> le(left: PropertyMetamodel<PROPERTY>, right: PropertyMetamodel<PROPERTY>) {
         declaration.le(left, right)
     }
 
-    fun <PROPERTY> isNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> isNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
         declaration.isNull(propertyMetamodel)
     }
 
-    fun <PROPERTY> isNotNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
+    fun <PROPERTY : Any> isNotNull(propertyMetamodel: PropertyMetamodel<PROPERTY>) {
         declaration.isNotNull(propertyMetamodel)
     }
 
-    fun <PROPERTY> eqOrIsNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> eqOrIsNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.eqOrIsNull(left, right)
     }
 
-    fun <PROPERTY> neOrIsNotNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
+    fun <PROPERTY : Any> neOrIsNotNull(left: PropertyMetamodel<PROPERTY>, right: PROPERTY) {
         declaration.neOrIsNotNull(left, right)
     }
 
-    fun <PROPERTY> like(left: PropertyMetamodel<PROPERTY>, right: CharSequence) {
+    fun <PROPERTY : Any> like(left: PropertyMetamodel<PROPERTY>, right: CharSequence) {
         declaration.like(left, right)
     }
 
-    fun <PROPERTY> like(left: PropertyMetamodel<PROPERTY>, right: CharSequence, option: LikeOption) {
+    fun <PROPERTY : Any> like(left: PropertyMetamodel<PROPERTY>, right: CharSequence, option: LikeOption) {
         declaration.like(left, right, option)
     }
 
-    fun <PROPERTY> notLike(left: PropertyMetamodel<PROPERTY>, right: CharSequence) {
+    fun <PROPERTY : Any> notLike(left: PropertyMetamodel<PROPERTY>, right: CharSequence) {
         declaration.notLike(left, right)
     }
 
-    fun <PROPERTY> notLike(left: PropertyMetamodel<PROPERTY>, right: CharSequence, option: LikeOption) {
+    fun <PROPERTY : Any> notLike(left: PropertyMetamodel<PROPERTY>, right: CharSequence, option: LikeOption) {
         declaration.notLike(left, right, option)
     }
 
-    fun <PROPERTY> between(propertyMetamodel: PropertyMetamodel<PROPERTY>, start: PROPERTY, end: PROPERTY) {
+    fun <PROPERTY : Any> between(propertyMetamodel: PropertyMetamodel<PROPERTY>, start: PROPERTY, end: PROPERTY) {
         declaration.between(propertyMetamodel, start, end)
     }
 
-    fun <PROPERTY> `in`(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>) {
+    fun <PROPERTY : Any> `in`(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY> notIn(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>) {
+    fun <PROPERTY : Any> notIn(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY> `in`(
+    fun <PROPERTY : Any> `in`(
         left: PropertyMetamodel<PROPERTY>,
         right: SubSelectContext<PropertyMetamodel<PROPERTY>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY> notIn(
+    fun <PROPERTY : Any> notIn(
         left: PropertyMetamodel<PROPERTY>,
         right: SubSelectContext<PropertyMetamodel<PROPERTY>>,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> `in`(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: List<Tuple2<PROPERTY1, PROPERTY2>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> notIn(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: List<Tuple2<PROPERTY1, PROPERTY2>>,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> `in`(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> notIn(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>>,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2, PROPERTY3> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any, PROPERTY3 : Any> `in`(
         left: Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>,
         right: List<Tuple3<PROPERTY1, PROPERTY2, PROPERTY3>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2, PROPERTY3> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any, PROPERTY3 : Any> notIn(
         left: Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>,
         right: List<Tuple3<PROPERTY1, PROPERTY2, PROPERTY3>>,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2, PROPERTY3> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any, PROPERTY3 : Any> `in`(
         left: Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>,
         right: SubSelectContext<Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2, PROPERTY3> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any, PROPERTY3 : Any> notIn(
         left: Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>,
         right: SubSelectContext<Tuple3<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>, PropertyMetamodel<PROPERTY3>>>,
     ) {
@@ -184,7 +184,7 @@ class KJoinDeclaration(private val declaration: JoinDeclaration) {
         declaration.notExists(subSelectContext)
     }
 
-    fun <ENTITY> from(
+    fun <ENTITY : Any> from(
         entityMetamodel: EntityMetamodel<ENTITY>,
     ): SubSelectFromDeclaration<ENTITY> {
         return declaration.from(entityMetamodel)

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSubSelectFromDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KSubSelectFromDeclaration.kt
@@ -65,11 +65,11 @@ class KSubSelectFromDeclaration<ENTITY>(private val declaration: SubSelectFromDe
         return declaration.select(entityMetamodel)
     }
 
-    fun <PROPERTY> select(propertyMetamodel: PropertyMetamodel<PROPERTY>): SubSelectContext.Single<PROPERTY> {
+    fun <PROPERTY : Any> select(propertyMetamodel: PropertyMetamodel<PROPERTY>): SubSelectContext.Single<PROPERTY> {
         return declaration.select(propertyMetamodel)
     }
 
-    fun <PROPERTY1, PROPERTY2> select(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> select(
         first: PropertyMetamodel<PROPERTY1>,
         second: PropertyMetamodel<PROPERTY2>,
     ): SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>> {

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KValuesDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KValuesDeclaration.kt
@@ -5,7 +5,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel
 
 class KValuesDeclaration(val declaration: ValuesDeclaration) {
 
-    fun <PROPERTY> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
+    fun <PROPERTY : Any> value(left: PropertyMetamodel<PROPERTY>, right: PROPERTY?) {
         declaration.value(left, right)
     }
 }

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KWhereDeclaration.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/declaration/KWhereDeclaration.kt
@@ -18,7 +18,7 @@ class KWhereDeclaration(declaration: WhereDeclaration) : org.seasar.doma.kotlin.
         declaration.notLike(left, right, option)
     }
 
-    fun <PROPERTY> between(
+    fun <PROPERTY : Any> between(
         propertyMetamodel: PropertyMetamodel<PROPERTY>,
         start: PROPERTY?,
         end: PROPERTY?,
@@ -26,50 +26,50 @@ class KWhereDeclaration(declaration: WhereDeclaration) : org.seasar.doma.kotlin.
         declaration.between(propertyMetamodel, start, end)
     }
 
-    fun <PROPERTY> `in`(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>?) {
+    fun <PROPERTY : Any> `in`(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>?) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY> notIn(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>?) {
+    fun <PROPERTY : Any> notIn(left: PropertyMetamodel<PROPERTY>, right: List<PROPERTY>?) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY> `in`(
+    fun <PROPERTY : Any> `in`(
         left: PropertyMetamodel<PROPERTY>,
         right: SubSelectContext<PropertyMetamodel<PROPERTY>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY> notIn(
+    fun <PROPERTY : Any> notIn(
         left: PropertyMetamodel<PROPERTY>,
         right: SubSelectContext<PropertyMetamodel<PROPERTY>>,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> `in`(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: List<Tuple2<PROPERTY1, PROPERTY2>>?,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> notIn(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: List<Tuple2<PROPERTY1, PROPERTY2>>?,
     ) {
         declaration.notIn(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> `in`(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> `in`(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>>,
     ) {
         declaration.`in`(left, right)
     }
 
-    fun <PROPERTY1, PROPERTY2> notIn(
+    fun <PROPERTY1 : Any, PROPERTY2 : Any> notIn(
         left: Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>,
         right: SubSelectContext<Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>>>,
     ) {
@@ -84,7 +84,7 @@ class KWhereDeclaration(declaration: WhereDeclaration) : org.seasar.doma.kotlin.
         declaration.notExists(subSelectContext)
     }
 
-    fun <ENTITY> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
+    fun <ENTITY : Any> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
         val declaration = SubSelectFromDeclaration<ENTITY>(entityMetamodel)
         return KSubSelectFromDeclaration(declaration)
     }

--- a/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/expression/KSelectExpression.kt
+++ b/doma-kotlin/src/main/kotlin/org/seasar/doma/kotlin/jdbc/criteria/expression/KSelectExpression.kt
@@ -7,7 +7,7 @@ import org.seasar.doma.kotlin.jdbc.criteria.declaration.KSubSelectFromDeclaratio
 class KSelectExpression {
 
     class Declaration {
-        fun <ENTITY> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
+        fun <ENTITY : Any> from(entityMetamodel: EntityMetamodel<ENTITY>): KSubSelectFromDeclaration<ENTITY> {
             val declaration = SubSelectFromDeclaration<ENTITY>(entityMetamodel)
             return KSubSelectFromDeclaration(declaration)
         }

--- a/integration-test-kotlin/src/test/kotlin/org/seasar/doma/it/criteria/KEntityqlBatchInsertTest.kt
+++ b/integration-test-kotlin/src/test/kotlin/org/seasar/doma/it/criteria/KEntityqlBatchInsertTest.kt
@@ -32,7 +32,7 @@ class KEntityqlBatchInsertTest(config: Config) {
         val result = entityql.insert(d, departments).execute()
         assertEquals(departments, result.entities)
 
-        val ids = departments.map { it.departmentId }
+        val ids = departments.mapNotNull { it.departmentId }
         val departments2 = entityql
             .from(d)
             .where { `in`(d.departmentId, ids) }


### PR DESCRIPTION
Prevent unintentionally nullable values.

example1

```kotlin
.innerJoin(d) {
    le(e.id, null as Int?) // compile error by this PR
}
```

example2

```kotlin
.where {
    `in`(e.id, listOf(1, 2, null)) // compile error by this PR
}
```
