### PR TITLE
Fix an issue where calling `peek` on `NativeSql` caused a `ClassCastException`

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyIgnoreSelectingKeys.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyIgnoreSelectingKeys.java
@@ -10,7 +10,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 public class NativeSqlUpsertOnDuplicateKeyIgnoreSelectingKeys
-    extends AbstractStatement<NativeSqlUpsertTerminal, Integer> {
+    extends AbstractStatement<NativeSqlUpsertOnDuplicateKeyIgnoreSelectingKeys, Integer> {
   private final Config config;
   private final InsertDeclaration declaration;
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyUpdateSelectingKeys.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyUpdateSelectingKeys.java
@@ -12,7 +12,7 @@ import org.seasar.doma.jdbc.criteria.metamodel.PropertyMetamodel;
 import org.seasar.doma.jdbc.query.DuplicateKeyType;
 
 public class NativeSqlUpsertOnDuplicateKeyUpdateSelectingKeys
-    extends AbstractStatement<NativeSqlUpsertTerminal, Integer> {
+    extends AbstractStatement<NativeSqlUpsertOnDuplicateKeyUpdateSelectingKeys, Integer> {
   private final Config config;
   private final InsertDeclaration declaration;
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyUpdateSelectingSet.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/statement/NativeSqlUpsertOnDuplicateKeyUpdateSelectingSet.java
@@ -8,7 +8,7 @@ import org.seasar.doma.jdbc.criteria.declaration.InsertDeclaration;
 import org.seasar.doma.jdbc.criteria.declaration.InsertOnDuplicateKeyUpdateSetValuesDeclaration;
 
 public class NativeSqlUpsertOnDuplicateKeyUpdateSelectingSet
-    extends AbstractStatement<NativeSqlUpsertTerminal, Integer> {
+    extends AbstractStatement<NativeSqlUpsertOnDuplicateKeyUpdateSelectingSet, Integer> {
   private final Config config;
   private final InsertDeclaration declaration;
 

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
@@ -629,7 +629,7 @@ public class NativeSqlInsertTest {
               c.value(d.version, 2);
             })
         .onDuplicateKeyUpdate()
-        .peek(System.out::println)
+        .peek(it -> invoked.set(true))
         .execute();
     assertTrue(invoked.get());
   }

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
@@ -1,8 +1,10 @@
 package org.seasar.doma.it.criteria;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.seasar.doma.it.Dbms;
@@ -590,5 +592,66 @@ public class NativeSqlInsertTest {
     int count = nativeSql.insert(da).select(c -> c.from(d)).execute();
 
     assertEquals(4, count);
+  }
+
+  @Test
+  void onDuplicateKeyIgnore_peek() {
+    Department_ d = new Department_();
+    final AtomicBoolean invoked = new AtomicBoolean(false);
+    nativeSql
+        .insert(d)
+        .values(
+            c -> {
+              c.value(d.departmentId, 1);
+              c.value(d.departmentNo, 60);
+              c.value(d.departmentName, "DEVELOPMENT");
+              c.value(d.location, "KYOTO");
+              c.value(d.version, 2);
+            })
+        .onDuplicateKeyIgnore()
+        .peek(it -> invoked.set(true))
+        .execute();
+    assertTrue(invoked.get());
+  }
+
+  @Test
+  void onDuplicateKeyUpdate_peek() {
+    Department_ d = new Department_();
+    final AtomicBoolean invoked = new AtomicBoolean(false);
+    nativeSql
+        .insert(d)
+        .values(
+            c -> {
+              c.value(d.departmentId, 1);
+              c.value(d.departmentNo, 60);
+              c.value(d.departmentName, "DEVELOPMENT");
+              c.value(d.location, "KYOTO");
+              c.value(d.version, 2);
+            })
+        .onDuplicateKeyUpdate()
+        .peek(it -> invoked.set(true))
+        .execute();
+    assertTrue(invoked.get());
+  }
+
+  @Test
+  void onDuplicateKeyUpdate_keys_peek() {
+    Department_ d = new Department_();
+    final AtomicBoolean invoked = new AtomicBoolean(false);
+    nativeSql
+        .insert(d)
+        .values(
+            c -> {
+              c.value(d.departmentId, 6);
+              c.value(d.departmentNo, 60);
+              c.value(d.departmentName, "DEVELOPMENT");
+              c.value(d.location, "KYOTO");
+              c.value(d.version, 2);
+            })
+        .onDuplicateKeyUpdate()
+        .keys(d.departmentName)
+        .peek(it -> invoked.set(true))
+        .execute();
+    assertTrue(invoked.get());
   }
 }

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/NativeSqlInsertTest.java
@@ -629,14 +629,14 @@ public class NativeSqlInsertTest {
               c.value(d.version, 2);
             })
         .onDuplicateKeyUpdate()
-        .peek(it -> invoked.set(true))
+        .peek(System.out::println)
         .execute();
     assertTrue(invoked.get());
   }
 
   @Test
   void onDuplicateKeyUpdate_keys_peek() {
-    Department_ d = new Department_();
+    var d = new Department_();
     final AtomicBoolean invoked = new AtomicBoolean(false);
     nativeSql
         .insert(d)
@@ -649,7 +649,7 @@ public class NativeSqlInsertTest {
               c.value(d.version, 2);
             })
         .onDuplicateKeyUpdate()
-        .keys(d.departmentName)
+        .keys(d.departmentId)
         .peek(it -> invoked.set(true))
         .execute();
     assertTrue(invoked.get());


### PR DESCRIPTION
The `ClassCastException` occurred when executing `peek` after calling `onDuplicateKeyUpdate` or `onDuplicateKeyIgnore`. For example, the `ClassCastException` occurred in the following code:

```java
var nativeSql = new NativeSql(config);
var d = new Department_();

nativeSql
    .insert(d)
    .values(
        c -> {
            c.value(d.departmentId, 1);
            c.value(d.departmentNo, 60);
            c.value(d.departmentName, "DEVELOPMENT");
            c.value(d.location, "KYOTO");
            c.value(d.version, 2);
        })
    .onDuplicateKeyUpdate()
    .peek(System.out::println)
    .execute();

```