### PR TITLE
Update SQL Server docker image to 2019-CU28-ubuntu-20.04

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ mysql.url=jdbc:tc:mysql:5.7:///test?TC_DAEMON=true&allowMultiQueries=true
 mysql8.url=jdbc:tc:mysql:8.0.36:///test?TC_MY_CNF=mysql_conf_override&TC_DAEMON=true&allowMultiQueries=true
 oracle.url=jdbc:tc:oracle:21-slim-faststart:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true
-sqlserver.url=jdbc:tc:sqlserver:2019-CU12-ubuntu-20.04:///test?TC_DAEMON=true
+sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true

--- a/integration-test-java/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-java/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04

--- a/integration-test-kotlin/src/test/resources/container-license-acceptance.txt
+++ b/integration-test-kotlin/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CU12-ubuntu-20.04
+mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04


### PR DESCRIPTION
It seems that the Docker image of Microsoft SQL Server 2019-CU12-ubuntu-20.04 does not work on Ubuntu 22.04.5. Therefore, we have upgraded the version to 2019-CU28-ubuntu-20.04.