### PR TITLE
Restrict Spotless line endings to LF

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,10 @@ allprojects {
         mavenCentral()
     }
 
+    spotless {
+        lineEndings = com.diffplug.spotless.LineEnding.UNIX
+    }
+
     tasks {
         build {
             dependsOn(spotlessApply)


### PR DESCRIPTION
The default value for Spotless' `lineEndings` property is `PLATFORM_NATIVE`. 
As a result, when building in a Windows environment, all line endings are converted from the currently used LF to CRLF. 
This causes a large number of change diffs to appear, significantly reducing work efficiency. 
To address this issue, we've fixed the line endings to LF even in Windows environments.

This change ensures consistent line endings across different operating systems, preventing unnecessary diffs and maintaining productivity when working on Windows machines.