### PR TITLE
Fix issue causing error when using classes annotated with `DataType` in Criteria API

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/scalar/Scalars.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/scalar/Scalars.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.function.Supplier;
+import org.seasar.doma.DataType;
 import org.seasar.doma.Domain;
 import org.seasar.doma.jdbc.ClassHelper;
 import org.seasar.doma.jdbc.domain.DomainType;
@@ -255,7 +256,8 @@ public final class Scalars {
   protected static <BASIC, DOMAIN> Supplier<Scalar<?, ?>> wrapDomainObject(
       Object value, Class<DOMAIN> valueClass, boolean optional, ClassHelper classHelper) {
     DomainType<BASIC, DOMAIN> domainType;
-    if (valueClass.isAnnotationPresent(Domain.class)) {
+    if (valueClass.isAnnotationPresent(Domain.class)
+        || valueClass.isAnnotationPresent(DataType.class)) {
       domainType = DomainTypeFactory.getDomainType(valueClass, classHelper);
     } else {
       domainType = DomainTypeFactory.getExternalDomainType(valueClass, classHelper);

--- a/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Avenue.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Avenue.java
@@ -1,0 +1,6 @@
+package org.seasar.doma.it.criteria;
+
+import org.seasar.doma.DataType;
+
+@DataType
+public record Avenue(String value) {}

--- a/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Place.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Place.java
@@ -1,0 +1,22 @@
+package org.seasar.doma.it.criteria;
+
+import org.seasar.doma.Entity;
+import org.seasar.doma.Id;
+import org.seasar.doma.Metamodel;
+import org.seasar.doma.Table;
+
+@Entity(metamodel = @Metamodel)
+@Table(name = "address")
+public class Place {
+  @Id private Integer addressId;
+  private Avenue street;
+  private Integer version;
+
+  public Integer getAddressId() {
+    return addressId;
+  }
+
+  public void setAddressId(Integer addressId) {
+    this.addressId = addressId;
+  }
+}

--- a/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Place.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/criteria/Place.java
@@ -6,7 +6,7 @@ import org.seasar.doma.Metamodel;
 import org.seasar.doma.Table;
 
 @Entity(metamodel = @Metamodel)
-@Table(name = "address")
+@Table(name = "ADDRESS")
 public class Place {
   @Id private Integer addressId;
   private Avenue street;

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/QueryDslEntityqlSelectTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/QueryDslEntityqlSelectTest.java
@@ -420,6 +420,14 @@ public class QueryDslEntityqlSelectTest {
   }
 
   @Test
+  void where_eq_dataType() {
+    Place_ p = new Place_();
+
+    List<Place> list = dsl.from(p).where(c -> c.eq(p.street, new Avenue("STREET 10"))).fetch();
+    assertEquals(1, list.size());
+  }
+
+  @Test
   void innerJoin() {
     Employee_ e = new Employee_();
     Department_ d = new Department_();


### PR DESCRIPTION
This pull request prevents the issue causing the DOMA1007 error.

Close #1216.
