### PR TITLE
Remove potential for NullPointerException

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/wrapper/BigDecimalWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/BigDecimalWrapper.java
@@ -18,7 +18,9 @@ public class BigDecimalWrapper extends AbstractWrapper<BigDecimal>
 
   @Override
   public void set(Number v) {
-    if (v instanceof BigDecimal) {
+    if (v == null) {
+      super.set(null);
+    } else if (v instanceof BigDecimal) {
       super.set((BigDecimal) v);
     } else if (v instanceof BigInteger) {
       super.set(new BigDecimal((BigInteger) v));

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/BigIntegerWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/BigIntegerWrapper.java
@@ -18,7 +18,9 @@ public class BigIntegerWrapper extends AbstractWrapper<BigInteger>
 
   @Override
   public void set(Number v) {
-    if (v instanceof BigInteger) {
+    if (v == null) {
+      super.set(null);
+    } else if (v instanceof BigInteger) {
       super.set((BigInteger) v);
     } else if (v instanceof BigDecimal) {
       super.set(((BigDecimal) v).toBigInteger());

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/ByteWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/ByteWrapper.java
@@ -15,7 +15,11 @@ public class ByteWrapper extends AbstractWrapper<Byte> implements NumberWrapper<
 
   @Override
   public void set(Number v) {
-    super.set(v.byteValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.byteValue());
+    }
   }
 
   @Override

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/DoubleWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/DoubleWrapper.java
@@ -15,7 +15,11 @@ public class DoubleWrapper extends AbstractWrapper<Double> implements NumberWrap
 
   @Override
   public void set(Number v) {
-    super.set(v.doubleValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.doubleValue());
+    }
   }
 
   @Override

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/FloatWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/FloatWrapper.java
@@ -15,7 +15,11 @@ public class FloatWrapper extends AbstractWrapper<Float> implements NumberWrappe
 
   @Override
   public void set(Number v) {
-    super.set(v.floatValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.floatValue());
+    }
   }
 
   @Override

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/IntegerWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/IntegerWrapper.java
@@ -15,7 +15,11 @@ public class IntegerWrapper extends AbstractWrapper<Integer> implements NumberWr
 
   @Override
   public void set(Number v) {
-    set(v.intValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.intValue());
+    }
   }
 
   @Override

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/LongWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/LongWrapper.java
@@ -15,7 +15,11 @@ public class LongWrapper extends AbstractWrapper<Long> implements NumberWrapper<
 
   @Override
   public void set(Number v) {
-    super.set(v.longValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.longValue());
+    }
   }
 
   @Override

--- a/doma-core/src/main/java/org/seasar/doma/wrapper/ShortWrapper.java
+++ b/doma-core/src/main/java/org/seasar/doma/wrapper/ShortWrapper.java
@@ -15,7 +15,11 @@ public class ShortWrapper extends AbstractWrapper<Short> implements NumberWrappe
 
   @Override
   public void set(Number v) {
-    super.set(v.shortValue());
+    if (v == null) {
+      super.set(null);
+    } else {
+      super.set(v.shortValue());
+    }
   }
 
   @Override

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/BigDecimalWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/BigDecimalWrapperTest.java
@@ -2,6 +2,7 @@ package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -27,6 +28,20 @@ public class BigDecimalWrapperTest {
     BigDecimalWrapper wrapper = new BigDecimalWrapper();
     wrapper.set(greaterThanLongMaxValue);
     assertEquals(new BigDecimal(greaterThanLongMaxValue), wrapper.get());
+  }
+
+  @Test
+  public void testSetNull() {
+    BigDecimalWrapper wrapper = new BigDecimalWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    BigDecimalWrapper wrapper = new BigDecimalWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
   }
 
   /** */

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/BigIntegerWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/BigIntegerWrapperTest.java
@@ -1,6 +1,7 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -25,6 +26,20 @@ public class BigIntegerWrapperTest {
     BigIntegerWrapper wrapper = new BigIntegerWrapper();
     wrapper.set(greaterThanLongMaxValue);
     assertEquals(greaterThanLongMaxValue.toBigInteger(), wrapper.get());
+  }
+
+  @Test
+  public void testSetNull() {
+    BigIntegerWrapper wrapper = new BigIntegerWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    BigIntegerWrapper wrapper = new BigIntegerWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
   }
 
   /** */

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/ByteWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/ByteWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class ByteWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    ByteWrapper wrapper = new ByteWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    ByteWrapper wrapper = new ByteWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/DoubleWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/DoubleWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class DoubleWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    DoubleWrapper wrapper = new DoubleWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    DoubleWrapper wrapper = new DoubleWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/FloatWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/FloatWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class FloatWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    FloatWrapper wrapper = new FloatWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    FloatWrapper wrapper = new FloatWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/IntegerWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/IntegerWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class IntegerWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    IntegerWrapper wrapper = new IntegerWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    IntegerWrapper wrapper = new IntegerWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/LongWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/LongWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class LongWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    LongWrapper wrapper = new LongWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    LongWrapper wrapper = new LongWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test

--- a/doma-core/src/test/java/org/seasar/doma/wrapper/ShortWrapperTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/wrapper/ShortWrapperTest.java
@@ -1,10 +1,25 @@
 package org.seasar.doma.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 public class ShortWrapperTest {
+
+  @Test
+  public void testSetNull() {
+    ShortWrapper wrapper = new ShortWrapper();
+    wrapper.set(null);
+    assertNull(wrapper.get());
+  }
+
+  @Test
+  public void testSetNullNumber() {
+    ShortWrapper wrapper = new ShortWrapper();
+    wrapper.set((Number) null);
+    assertNull(wrapper.get());
+  }
 
   /** */
   @Test


### PR DESCRIPTION
This pull request removes the potential for a NullPointerException when setting numeric types for entity properties. However, there is no actual logic in Doma's code that would cause a NullPointerException in this context.