### PR TITLE
add convenient factory method to QueryDsl

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/QueryDsl.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/QueryDsl.java
@@ -38,6 +38,18 @@ public class QueryDsl {
   }
 
   /**
+   * Creates an instance.
+   *
+   * @param provider the instance of {@link ConfigProvider}
+   * @return a new QueryDsl instance
+   * @throws org.seasar.doma.DomaIllegalArgumentException if {@code provider} is not {@link
+   *     ConfigProvider}
+   */
+  public static QueryDsl of(Object provider) {
+    return new QueryDsl(Config.get(provider));
+  }
+
+  /**
    * Creates a WithQueryDsl.
    *
    * @param entityMetamodel the entity metamodel to use for the context of the common table


### PR DESCRIPTION
I added a convenient method that can be used when implementing default methods in a Dao interface using QueryDsl.

Currently, it is implemented as follows:

```java
default Employee select(Long id) {
    var emp = new Employee_();
    return new QueryDsl(Config.get(this)).from(emp ).where(c -> c.eq(emp.id, id)).fetchOne();
}
```

With the addition of this method, it can be simplified as follows:
```java
default Employee select(Long id) {
    var emp = new Employee_();
    return QueryDsl.of(this).from(emp).where(c -> c.eq(emp.id, id)).fetchOne();
}
```
