### PR TITLE
Enable Eclipse Compiler for building integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,6 @@ jobs:
           -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           assemble check
 
-      - name: Test annotation processors with Eclipse Compiler
-        run: >
-          ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
-          -Pcompiler=ecj
-          :doma-processor:test
-
       - name: Upload reports
         if: failure()
         uses: actions/upload-artifact@v4
@@ -57,9 +50,8 @@ jobs:
             ./**/build/reports
             /home/runner/work/doma/doma/.gradle
 
-
-  test:
-    name: Test (${{ matrix.driver }})
+  integration-test:
+    name: Integration Test (${{ matrix.driver }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -116,11 +108,49 @@ jobs:
             ./**/build/reports
             /home/runner/work/doma/doma/.gradle
 
+  ecj:
+    name: Build and Integration Test with Eclipse Compiler for Java (ECJ)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Set up JDKs
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+          java-version: |
+            ${{ env.JDK_VERSION_OLDEST }}
+            ${{ env.JDK_VERSION_LATEST }}
+            ${{ env.JDK_VERSION_LATEST_LTS }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4.2.2
+
+      - name: Test with ECJ
+        run: >
+          ./gradlew
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Pcompiler=ecj
+          :doma-processor:build
+          :integration-test-java:build
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-${{ matrix.driver }}
+          path: |
+            ./**/build/reports
+            /home/runner/work/doma/doma/.gradle
+
   publish:
     if: github.event_name == 'push'
     name: Publish
     runs-on: ubuntu-latest
-    needs: [ build, test ]
+    needs: [ build, integration-test, ecj ]
     timeout-minutes: 30
 
     steps:

--- a/doma-processor/gradle.properties
+++ b/doma-processor/gradle.properties
@@ -1,1 +1,0 @@
-compiler=javac

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptException.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptException.java
@@ -1,5 +1,6 @@
 package org.seasar.doma.internal.apt;
 
+import java.io.Serial;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -9,7 +10,7 @@ import org.seasar.doma.message.MessageResource;
 
 public class AptException extends DomaException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   protected final Kind kind;
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptIllegalOptionException.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptIllegalOptionException.java
@@ -1,8 +1,10 @@
 package org.seasar.doma.internal.apt;
 
+import java.io.Serial;
+
 public class AptIllegalOptionException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   public AptIllegalOptionException(String message) {
     super(message);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptIllegalStateException.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/AptIllegalStateException.java
@@ -1,8 +1,10 @@
 package org.seasar.doma.internal.apt;
 
+import java.io.Serial;
+
 public class AptIllegalStateException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  @Serial private static final long serialVersionUID = 1L;
 
   public AptIllegalStateException(String message) {
     super(message);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Context.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Context.java
@@ -37,15 +37,15 @@ public class Context {
     if (initialized) {
       throw new AptIllegalStateException("already initialized");
     }
-    moreElements = new MoreElements(this, env);
-    moreTypes = new MoreTypes(this, env);
-    options = new Options(this, env);
-    reporter = new Reporter(env);
-    resources = new Resources(this, env);
+    moreElements = new MoreElements(this, env.getElementUtils());
+    moreTypes = new MoreTypes(this, env.getTypeUtils());
+    reporter = new Reporter(env.getMessager());
     annotations = new Annotations(this);
     declarations = new Declarations(this);
     ctTypes = new CtTypes(this);
     names = new Names(this);
+    resources = new Resources(env.getFiler(), env.getOptions().get(Options.RESOURCES_DIR));
+    options = new Options(env.getOptions(), resources);
     initialized = true;
   }
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
@@ -27,11 +28,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleElementVisitor14;
 import org.seasar.doma.ParameterName;
 import org.seasar.doma.internal.apt.def.TypeParametersDef;
 import org.seasar.doma.internal.util.Pair;
@@ -164,40 +164,12 @@ public class MoreElements implements Elements {
 
   public TypeElement toTypeElement(Element element) {
     assertNotNull(element);
-    return element.accept(
-        new SimpleElementVisitor8<TypeElement, Void>() {
-
-          // delegate to elementUtils
-          public TypeElement visitType(TypeElement e, Void p) {
-            return e;
-          }
-        },
-        null);
+    return element.accept(Visitors.toTypeElement, null);
   }
 
   public TypeParameterElement toTypeParameterElement(Element element) {
     assertNotNull(element);
-    return element.accept(
-        new SimpleElementVisitor8<TypeParameterElement, Void>() {
-
-          @Override
-          public TypeParameterElement visitTypeParameter(TypeParameterElement e, Void aVoid) {
-            return e;
-          }
-        },
-        null);
-  }
-
-  public ExecutableType toExecutableType(Element element) {
-    assertNotNull(element);
-    return element.accept(
-        new SimpleElementVisitor8<ExecutableType, Void>() {
-
-          public ExecutableType visitExecutableType(ExecutableType e, Void p) {
-            return e;
-          }
-        },
-        null);
+    return element.accept(Visitors.toTypeParameterElement, null);
   }
 
   public TypeElement getTypeElementFromBinaryName(String binaryName) {
@@ -364,5 +336,23 @@ public class MoreElements implements Elements {
                               .map(pair -> new Pair<>(pair.fst.asType(), pair.snd.asType()))
                               .allMatch(p -> ctx.getMoreTypes().isSameType(p.fst, p.snd));
                         }));
+  }
+
+  private static final class Visitors {
+    static final ElementVisitor<TypeElement, Void> toTypeElement =
+        new SimpleElementVisitor14<>() {
+          @Override
+          public TypeElement visitType(TypeElement e, Void p) {
+            return e;
+          }
+        };
+
+    static final ElementVisitor<TypeParameterElement, Void> toTypeParameterElement =
+        new SimpleElementVisitor14<>() {
+          @Override
+          public TypeParameterElement visitTypeParameter(TypeParameterElement e, Void aVoid) {
+            return e;
+          }
+        };
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -46,10 +45,10 @@ public class MoreElements implements Elements {
 
   private final Map<String, TypeElement> typeElementCache = new HashMap<>(64);
 
-  public MoreElements(Context ctx, ProcessingEnvironment env) {
-    assertNotNull(ctx, env);
+  public MoreElements(Context ctx, Elements elementUtils) {
+    assertNotNull(ctx, elementUtils);
     this.ctx = ctx;
-    this.elementUtils = env.getElementUtils();
+    this.elementUtils = elementUtils;
   }
 
   // delegate to elementUtils

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -33,10 +32,10 @@ public class MoreTypes implements Types {
 
   private final Types typeUtils;
 
-  public MoreTypes(Context ctx, ProcessingEnvironment env) {
-    assertNotNull(ctx, env);
+  public MoreTypes(Context ctx, Types typeUtils) {
+    assertNotNull(ctx, typeUtils);
     this.ctx = ctx;
-    this.typeUtils = env.getTypeUtils();
+    this.typeUtils = typeUtils;
   }
 
   // delegate to typeUtils
@@ -453,7 +452,7 @@ public class MoreTypes implements Types {
       }
       Iterator<? extends TypeMirror> it = bounds.iterator();
       TypeMirror first = it.next();
-      if (bounds.size() == 1 && ctx.getMoreTypes().isSameTypeWithErasure(first, Object.class)) {
+      if (bounds.size() == 1 && isSameTypeWithErasure(first, Object.class)) {
         return null;
       }
       p.append(" extends ");

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
@@ -20,10 +20,10 @@ import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.SimpleTypeVisitor14;
-import javax.lang.model.util.SimpleTypeVisitor8;
-import javax.lang.model.util.TypeKindVisitor8;
+import javax.lang.model.util.TypeKindVisitor14;
 import javax.lang.model.util.Types;
 
 public class MoreTypes implements Types {
@@ -164,38 +164,17 @@ public class MoreTypes implements Types {
 
   public DeclaredType toDeclaredType(TypeMirror typeMirror) {
     assertNotNull(typeMirror);
-    return typeMirror.accept(
-        new SimpleTypeVisitor8<DeclaredType, Void>() {
-
-          public DeclaredType visitDeclared(DeclaredType t, Void p) {
-            return t;
-          }
-        },
-        null);
+    return typeMirror.accept(Visitors.toDeclaredType, null);
   }
 
   public TypeVariable toTypeVariable(TypeMirror typeMirror) {
     assertNotNull(typeMirror);
-    return typeMirror.accept(
-        new SimpleTypeVisitor8<TypeVariable, Void>() {
-
-          public TypeVariable visitTypeVariable(TypeVariable t, Void p) {
-            return t;
-          }
-        },
-        null);
+    return typeMirror.accept(Visitors.toTypeVariable, null);
   }
 
   public ArrayType toArrayType(TypeMirror typeMirror) {
     assertNotNull(typeMirror);
-    return typeMirror.accept(
-        new SimpleTypeVisitor14<ArrayType, Void>() {
-
-          public ArrayType visitArray(ArrayType t, Void p) {
-            return t;
-          }
-        },
-        null);
+    return typeMirror.accept(Visitors.toArrayType, null);
   }
 
   public boolean isAssignableWithErasure(TypeMirror lhs, Class<?> rhs) {
@@ -298,14 +277,14 @@ public class MoreTypes implements Types {
   public TypeMirror boxIfPrimitive(TypeMirror typeMirror) {
     assertNotNull(typeMirror);
     return typeMirror.accept(
-        new TypeKindVisitor8<TypeMirror, Void>() {
+        new TypeKindVisitor14<TypeMirror, Void>() {
 
           public TypeMirror visitPrimitive(PrimitiveType t, Void p) {
             return typeUtils.boxedClass(t).asType();
           }
 
-          protected TypeMirror defaultAction(TypeMirror e, Void p) {
-            return e;
+          protected TypeMirror defaultAction(TypeMirror t, Void p) {
+            return t;
           }
         },
         null);
@@ -351,7 +330,7 @@ public class MoreTypes implements Types {
     return typeElement.asType();
   }
 
-  private class TypeNameBuilder extends TypeKindVisitor8<Void, StringBuilder> {
+  private class TypeNameBuilder extends TypeKindVisitor14<Void, StringBuilder> {
 
     public Void visitNoTypeAsVoid(NoType t, StringBuilder p) {
       p.append("void");
@@ -476,5 +455,32 @@ public class MoreTypes implements Types {
       }
       return null;
     }
+  }
+
+  private static final class Visitors {
+
+    static final TypeVisitor<DeclaredType, Void> toDeclaredType =
+        new SimpleTypeVisitor14<>() {
+          @Override
+          public DeclaredType visitDeclared(DeclaredType t, Void p) {
+            return t;
+          }
+        };
+
+    static final TypeVisitor<TypeVariable, Void> toTypeVariable =
+        new SimpleTypeVisitor14<>() {
+          @Override
+          public TypeVariable visitTypeVariable(TypeVariable t, Void p) {
+            return t;
+          }
+        };
+
+    static final TypeVisitor<ArrayType, Void> toArrayType =
+        new SimpleTypeVisitor14<>() {
+          @Override
+          public ArrayType visitArray(ArrayType t, Void p) {
+            return t;
+          }
+        };
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -51,10 +51,6 @@ public final class Options {
 
   public static final String LOMBOK_VALUE = "doma.lombok.Value";
 
-  public static final String CDI_APPLICATION_SCOPED = "doma.cdi.ApplicationScoped";
-
-  public static final String CDI_DEPENDENT = "doma.cdi.Dependent";
-
   private final Map<String, String> options;
 
   Options(Map<String, String> options, Resources resources) {
@@ -181,11 +177,6 @@ public final class Options {
     return name != null ? name : Constants.DEFAULT_LOMBOK_VALUE;
   }
 
-  public String getCdiApplicationScoped() {
-    String name = getOption(CDI_APPLICATION_SCOPED);
-    return name != null ? name : Constants.DEFAULT_CDI_APPLICATION_SCOPED;
-  }
-
   private String getOption(String key) {
     return options.get(key);
   }
@@ -205,8 +196,5 @@ public final class Options {
     public static final String DEFAULT_LOMBOK_ALL_ARGS_CONSTRUCTOR = "lombok.AllArgsConstructor";
 
     public static final String DEFAULT_LOMBOK_VALUE = "lombok.Value";
-
-    public static final String DEFAULT_CDI_APPLICATION_SCOPED =
-        "javax.enterprise.context.ApplicationScoped";
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Reporter.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Reporter.java
@@ -3,7 +3,6 @@ package org.seasar.doma.internal.apt;
 import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import javax.annotation.processing.Messager;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic.Kind;
 import org.seasar.doma.message.MessageResource;
@@ -12,9 +11,9 @@ public final class Reporter {
 
   private final Messager messager;
 
-  Reporter(ProcessingEnvironment env) {
-    assertNotNull(env);
-    this.messager = env.getMessager();
+  Reporter(Messager messager) {
+    assertNotNull(messager);
+    this.messager = messager;
   }
 
   public void debug(MessageResource messageResource, Object[] args) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
@@ -20,10 +19,10 @@ public class Resources {
 
   private final String resourcesDir;
 
-  Resources(Context ctx, ProcessingEnvironment env) {
-    assertNotNull(ctx, env);
-    this.filer = env.getFiler();
-    this.resourcesDir = env.getOptions().get(Options.RESOURCES_DIR);
+  Resources(Filer filer, String resourcesDir) {
+    assertNotNull(filer);
+    this.filer = filer;
+    this.resourcesDir = resourcesDir;
   }
 
   public JavaFileObject createSourceFile(CharSequence name, Element... originatingElements)

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -31,7 +31,6 @@ import java.util.OptionalLong;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -259,7 +258,7 @@ public class CtTypes {
         ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
             .filter(c -> !c.getModifiers().contains(Modifier.PRIVATE))
             .filter(c -> c.getParameters().size() == 1)
-            .collect(Collectors.toList());
+            .toList();
     if (constructors.size() != 1) {
       throw new AptIllegalStateException(
           String.format("%s : %d", typeElement.getQualifiedName(), constructors.size()));
@@ -704,26 +703,17 @@ public class CtTypes {
 
     @Override
     public Class<?> visitPrimitive(PrimitiveType t, Void p) {
-      switch (t.getKind()) {
-        case BOOLEAN:
-          return PrimitiveBooleanWrapper.class;
-        case BYTE:
-          return PrimitiveByteWrapper.class;
-        case SHORT:
-          return PrimitiveShortWrapper.class;
-        case INT:
-          return PrimitiveIntWrapper.class;
-        case LONG:
-          return PrimitiveLongWrapper.class;
-        case FLOAT:
-          return PrimitiveFloatWrapper.class;
-        case DOUBLE:
-          return PrimitiveDoubleWrapper.class;
-        case CHAR:
-          return null;
-        default:
-          return assertUnreachable();
-      }
+      return switch (t.getKind()) {
+        case BOOLEAN -> PrimitiveBooleanWrapper.class;
+        case BYTE -> PrimitiveByteWrapper.class;
+        case SHORT -> PrimitiveShortWrapper.class;
+        case INT -> PrimitiveIntWrapper.class;
+        case LONG -> PrimitiveLongWrapper.class;
+        case FLOAT -> PrimitiveFloatWrapper.class;
+        case DOUBLE -> PrimitiveDoubleWrapper.class;
+        case CHAR -> null;
+        default -> assertUnreachable();
+      };
     }
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -46,7 +46,7 @@ import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
-import javax.lang.model.util.SimpleTypeVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor14;
 import org.seasar.doma.DataType;
 import org.seasar.doma.Domain;
 import org.seasar.doma.Embeddable;
@@ -610,7 +610,7 @@ public class CtTypes {
     return null;
   }
 
-  private class WrapperClassResolver extends SimpleTypeVisitor8<Class<?>, Void> {
+  private class WrapperClassResolver extends SimpleTypeVisitor14<Class<?>, Void> {
 
     @Override
     public Class<?> visitArray(ArrayType t, Void p) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/decl/Declarations.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/decl/Declarations.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
@@ -154,9 +153,13 @@ public class Declarations {
                           .filter(declaration -> arg.equals(declaration.getFormalType()))
                           .map(TypeParameterDeclaration::getActualType)
                           .findFirst())
-              .collect(Collectors.toList());
+              .toList();
       if (optTypeArgs.stream().allMatch(Optional::isPresent)) {
-        TypeMirror[] typeArgs = optTypeArgs.stream().map(Optional::get).toArray(TypeMirror[]::new);
+        TypeMirror[] typeArgs =
+            optTypeArgs.stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toArray(TypeMirror[]::new);
         TypeElement typeElement = ctx.getMoreElements().toTypeElement(declaredType.asElement());
         if (typeElement == null) {
           continue;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/def/TypeParametersDef.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/def/TypeParametersDef.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,6 @@ public class TypeParametersDef {
   }
 
   public List<String> getTypeParameters() {
-    return Collections.unmodifiableList(new ArrayList<>(typeParameterNameMap.values()));
+    return List.copyOf(typeParameterNameMap.values());
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/EntityTypeGenerator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/EntityTypeGenerator.java
@@ -517,7 +517,6 @@ public class EntityTypeGenerator extends AbstractGenerator {
       EntityPropertyMeta pm = entityMeta.getGeneratedIdPropertyMeta();
       idName = pm.getName();
     }
-    iprint("@SuppressWarnings(\"unchecked\")%n");
     iprint("@Override%n");
     iprint(
         "public %1$s<%2$s, ?, ?> getGeneratedIdPropertyType() {%n",
@@ -535,7 +534,6 @@ public class EntityTypeGenerator extends AbstractGenerator {
       EntityPropertyMeta pm = entityMeta.getVersionPropertyMeta();
       versionName = pm.getName();
     }
-    iprint("@SuppressWarnings(\"unchecked\")%n");
     iprint("@Override%n");
     iprint(
         "public %1$s<%2$s, ?, ?> getVersionPropertyType() {%n",
@@ -553,7 +551,6 @@ public class EntityTypeGenerator extends AbstractGenerator {
       EntityPropertyMeta pm = entityMeta.getTenantIdPropertyMeta();
       tenantIdName = pm.getName();
     }
-    iprint("@SuppressWarnings(\"unchecked\")%n");
     iprint("@Override%n");
     iprint(
         "public %1$s<%2$s, ?, ?> getTenantIdPropertyType() {%n",

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/dao/DaoMetaFactory.java
@@ -163,7 +163,7 @@ public class DaoMetaFactory implements TypeElementMetaFactory<DaoMeta> {
                     throw new AptIllegalStateException("failed to convert to TypeElement.");
                   }
                 })
-            .collect(toList());
+            .toList();
     for (TypeElement typeElement : interfaces) {
       DaoAnnot daoAnnot = ctx.getAnnotations().newDaoAnnot(typeElement);
       if (daoAnnot == null) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/DataTypeMetaFactory.java
@@ -5,7 +5,6 @@ import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -96,7 +95,7 @@ public class DataTypeMetaFactory implements TypeElementMetaFactory<DataTypeMeta>
         ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
             .filter(c -> !c.getModifiers().contains(Modifier.PRIVATE))
             .filter(c -> c.getParameters().size() == 1)
-            .collect(Collectors.toList());
+            .toList();
     if (constructors.isEmpty()) {
       throw new AptException(Message.DOMA4453, typeElement, new Object[] {});
     }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/domain/InternalDomainMetaFactory.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -390,7 +389,7 @@ public class InternalDomainMetaFactory implements TypeElementMetaFactory<Interna
       List<VariableElement> fields =
           ElementFilter.fieldsIn(classElement.getEnclosedElements()).stream()
               .filter(field -> !field.getModifiers().contains(Modifier.STATIC))
-              .collect(Collectors.toList());
+              .toList();
       if (fields.size() == 0) {
         throw new AptException(Message.DOMA4430, classElement, new Object[] {});
       }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EmbeddableConstructorMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EmbeddableConstructorMeta.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.ExecutableElement;
 
-class EmbeddableConstructorMeta {
+public class EmbeddableConstructorMeta {
 
   private final ExecutableElement constructorElement;
   private final List<EmbeddablePropertyMeta> embeddablePropertyMetas;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EntityConstructorMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EntityConstructorMeta.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.ExecutableElement;
 
-class EntityConstructorMeta {
+public class EntityConstructorMeta {
 
   private final ExecutableElement constructorElement;
   private final List<EntityPropertyMeta> entityPropertyMetas;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/ScopeParameterMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/ScopeParameterMeta.java
@@ -53,6 +53,7 @@ public class ScopeParameterMeta implements CharSequence {
     return typeAndName.charAt(index);
   }
 
+  @SuppressWarnings("NullableProblems")
   @Override
   public CharSequence subSequence(int start, int end) {
     return typeAndName.subSequence(start, end);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/ScopeParameterMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/ScopeParameterMeta.java
@@ -5,7 +5,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleTypeVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor14;
 
 public class ScopeParameterMeta implements CharSequence {
 
@@ -26,7 +26,7 @@ public class ScopeParameterMeta implements CharSequence {
 
   private TypeMirror getComponentType(TypeMirror type) {
     return type.accept(
-        new SimpleTypeVisitor8<TypeMirror, Void>() {
+        new SimpleTypeVisitor14<TypeMirror, Void>() {
           @Override
           public TypeMirror visitArray(ArrayType t, Void unused) {
             return t.getComponentType();

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/QueryReturnMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/query/QueryReturnMeta.java
@@ -5,7 +5,7 @@ import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.TypeKindVisitor8;
+import javax.lang.model.util.TypeKindVisitor14;
 import org.seasar.doma.internal.apt.cttype.*;
 
 public class QueryReturnMeta {
@@ -43,7 +43,7 @@ public class QueryReturnMeta {
     return ctType
         .getType()
         .accept(
-            new TypeKindVisitor8<Boolean, Void>(false) {
+            new TypeKindVisitor14<Boolean, Void>(false) {
 
               @Override
               public Boolean visitArray(ArrayType t, Void p) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
@@ -33,7 +33,6 @@ import org.seasar.doma.internal.util.ClassUtil;
   Options.VERSION_VALIDATION,
   Options.RESOURCES_DIR,
   Options.CONFIG_PATH,
-  Options.CDI_APPLICATION_SCOPED
 })
 public class DaoProcessor extends AbstractGeneratingProcessor<DaoMeta> {
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/util/AnnotationValueUtil.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/util/AnnotationValueUtil.java
@@ -4,9 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleAnnotationValueVisitor8;
+import javax.lang.model.util.SimpleAnnotationValueVisitor14;
 
 public final class AnnotationValueUtil {
 
@@ -15,24 +16,7 @@ public final class AnnotationValueUtil {
       return null;
     }
     final List<String> results = new ArrayList<>();
-    value.accept(
-        new SimpleAnnotationValueVisitor8<Void, Void>() {
-
-          @Override
-          public Void visitArray(List<? extends AnnotationValue> values, Void p) {
-            for (AnnotationValue value : values) {
-              value.accept(this, p);
-            }
-            return null;
-          }
-
-          @Override
-          public Void visitString(String s, Void p) {
-            results.add(s);
-            return null;
-          }
-        },
-        null);
+    value.accept(Visitors.fillStringList, results);
     return results;
   }
 
@@ -41,24 +25,7 @@ public final class AnnotationValueUtil {
       return null;
     }
     final List<TypeMirror> results = new ArrayList<>();
-    value.accept(
-        new SimpleAnnotationValueVisitor8<Void, Void>() {
-
-          @Override
-          public Void visitArray(List<? extends AnnotationValue> values, Void p) {
-            for (AnnotationValue value : values) {
-              value.accept(this, p);
-            }
-            return null;
-          }
-
-          @Override
-          public Void visitType(TypeMirror t, Void p) {
-            results.add(t);
-            return null;
-          }
-        },
-        null);
+    value.accept(Visitors.fillTypeList, results);
     return results;
   }
 
@@ -67,24 +34,7 @@ public final class AnnotationValueUtil {
       return null;
     }
     final List<AnnotationMirror> results = new ArrayList<>();
-    value.accept(
-        new SimpleAnnotationValueVisitor8<Void, Void>() {
-
-          @Override
-          public Void visitArray(List<? extends AnnotationValue> values, Void p) {
-            for (AnnotationValue value : values) {
-              value.accept(this, p);
-            }
-            return null;
-          }
-
-          @Override
-          public Void visitAnnotation(AnnotationMirror a, Void p) {
-            results.add(a);
-            return null;
-          }
-        },
-        null);
+    value.accept(Visitors.fillAnnotationList, results);
     return results;
   }
 
@@ -92,103 +42,158 @@ public final class AnnotationValueUtil {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<Boolean, Void>() {
-
-          @Override
-          public Boolean visitBoolean(boolean b, Void p) {
-            return b;
-          }
-        },
-        null);
+    return value.accept(Visitors.toBoolean, null);
   }
 
   public static Integer toInteger(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<Integer, Void>() {
-
-          @Override
-          public Integer visitInt(int i, Void p) {
-            return i;
-          }
-        },
-        null);
+    return value.accept(Visitors.toInteger, null);
   }
 
   public static Long toLong(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<Long, Void>() {
-
-          @Override
-          public Long visitLong(long l, Void p) {
-            return l;
-          }
-        },
-        null);
+    return value.accept(Visitors.toLong, null);
   }
 
   public static String toString(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<String, Void>() {
-
-          @Override
-          public String visitString(String s, Void p) {
-            return s;
-          }
-        },
-        null);
+    return value.accept(Visitors.toString, null);
   }
 
   public static TypeMirror toType(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<TypeMirror, Void>() {
-
-          @Override
-          public TypeMirror visitType(TypeMirror t, Void p) {
-            return t;
-          }
-        },
-        null);
+    return value.accept(Visitors.toType, null);
   }
 
   public static VariableElement toEnumConstant(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<VariableElement, Void>() {
-
-          @Override
-          public VariableElement visitEnumConstant(VariableElement c, Void p) {
-            return c;
-          }
-        },
-        null);
+    return value.accept(Visitors.toEnumConstant, null);
   }
 
   public static AnnotationMirror toAnnotation(AnnotationValue value) {
     if (value == null) {
       return null;
     }
-    return value.accept(
-        new SimpleAnnotationValueVisitor8<AnnotationMirror, Void>() {
+    return value.accept(Visitors.toAnnotation, null);
+  }
+
+  private static final class Visitors {
+
+    static final AnnotationValueVisitor<Void, List<String>> fillStringList =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Void visitArray(List<? extends AnnotationValue> values, List<String> p) {
+            for (AnnotationValue value : values) {
+              value.accept(this, p);
+            }
+            return null;
+          }
+
+          @Override
+          public Void visitString(String s, List<String> p) {
+            p.add(s);
+            return null;
+          }
+        };
+
+    static final AnnotationValueVisitor<Void, List<TypeMirror>> fillTypeList =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Void visitArray(List<? extends AnnotationValue> values, List<TypeMirror> p) {
+            for (AnnotationValue value : values) {
+              value.accept(this, p);
+            }
+            return null;
+          }
+
+          @Override
+          public Void visitType(TypeMirror t, List<TypeMirror> p) {
+            p.add(t);
+            return null;
+          }
+        };
+
+    static final AnnotationValueVisitor<Void, List<AnnotationMirror>> fillAnnotationList =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Void visitArray(List<? extends AnnotationValue> values, List<AnnotationMirror> p) {
+            for (AnnotationValue value : values) {
+              value.accept(this, p);
+            }
+            return null;
+          }
+
+          @Override
+          public Void visitAnnotation(AnnotationMirror a, List<AnnotationMirror> p) {
+            p.add(a);
+            return null;
+          }
+        };
+
+    static final AnnotationValueVisitor<Boolean, Void> toBoolean =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Boolean visitBoolean(boolean b, Void p) {
+            return b;
+          }
+        };
+
+    static final AnnotationValueVisitor<Integer, Void> toInteger =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Integer visitInt(int i, Void p) {
+            return i;
+          }
+        };
+
+    static final AnnotationValueVisitor<Long, Void> toLong =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public Long visitLong(long l, Void p) {
+            return l;
+          }
+        };
+
+    static final AnnotationValueVisitor<String, Void> toString =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public String visitString(String s, Void p) {
+            return s;
+          }
+        };
+
+    static final AnnotationValueVisitor<TypeMirror, Void> toType =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public TypeMirror visitType(TypeMirror t, Void p) {
+            return t;
+          }
+        };
+
+    static final AnnotationValueVisitor<VariableElement, Void> toEnumConstant =
+        new SimpleAnnotationValueVisitor14<>() {
+          @Override
+          public VariableElement visitEnumConstant(VariableElement c, Void p) {
+            return c;
+          }
+        };
+
+    static final AnnotationValueVisitor<AnnotationMirror, Void> toAnnotation =
+        new SimpleAnnotationValueVisitor14<>() {
           @Override
           public AnnotationMirror visitAnnotation(AnnotationMirror a, Void p) {
             return a;
           }
-        },
-        null);
+        };
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/validator/ExpressionValidator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/validator/ExpressionValidator.java
@@ -371,7 +371,7 @@ public class ExpressionValidator implements ExpressionNodeVisitor<TypeDeclaratio
     TypeDeclaration typeDeclaration = ctx.getDeclarations().newTypeDeclaration(typeElement);
     Optional<ConstructorDeclaration> constructorDeclaration =
         typeDeclaration.getConstructorDeclaration(parameterTypeDeclarations);
-    if (!constructorDeclaration.isPresent()) {
+    if (constructorDeclaration.isEmpty()) {
       ExpressionLocation location = node.getLocation();
       String signature = createConstructorSignature(className, parameterTypeDeclarations);
       throw new AptException(

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
@@ -19,6 +19,8 @@ public abstract class TestProcessor extends AbstractProcessor {
 
   protected Context ctx;
 
+  private boolean handled;
+
   protected TestProcessor() {}
 
   @Override
@@ -46,10 +48,11 @@ public abstract class TestProcessor extends AbstractProcessor {
   @Override
   public boolean process(
       final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
-    if (roundEnv.processingOver()) {
+    if (roundEnv.processingOver() || handled) {
       return true;
     }
     run();
+    handled = true;
     return false;
   }
 

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_AbstractEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_AbstractEntity.txt
@@ -170,19 +170,16 @@ public final class _AbstractEntity extends org.seasar.doma.jdbc.entity.AbstractE
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.AbstractEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_BytesPropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_BytesPropertyEntity.txt
@@ -169,19 +169,16 @@ public final class _BytesPropertyEntity extends org.seasar.doma.jdbc.entity.Abst
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.BytesPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Child2InheritingEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Child2InheritingEntity.txt
@@ -171,19 +171,16 @@ public final class _Child2InheritingEntity extends org.seasar.doma.jdbc.entity.A
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2InheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Child2NoInheritingEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Child2NoInheritingEntity.txt
@@ -170,19 +170,16 @@ public final class _Child2NoInheritingEntity extends org.seasar.doma.jdbc.entity
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Child2NoInheritingEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ChildEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ChildEntity.txt
@@ -171,19 +171,16 @@ public final class _ChildEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_CommonChild.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_CommonChild.txt
@@ -168,19 +168,16 @@ public final class _CommonChild extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.CommonChild, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Dept.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Dept.txt
@@ -171,19 +171,16 @@ public final class _Dept extends org.seasar.doma.jdbc.entity.AbstractEntityType<
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Dept, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_DomainPropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_DomainPropertyEntity.txt
@@ -181,19 +181,16 @@ public final class _DomainPropertyEntity extends org.seasar.doma.jdbc.entity.Abs
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("id");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("ver");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.DomainPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Emp.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Emp.txt
@@ -184,19 +184,16 @@ public final class _Emp extends org.seasar.doma.jdbc.entity.AbstractEntityType<o
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?>)__entityPropertyTypeMap.get("id");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Emp, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_EnumPropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_EnumPropertyEntity.txt
@@ -171,19 +171,16 @@ public final class _EnumPropertyEntity extends org.seasar.doma.jdbc.entity.Abstr
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.EnumPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener1Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener1Entity.txt
@@ -168,19 +168,16 @@ public final class _GenericListener1Entity extends org.seasar.doma.jdbc.entity.A
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener1Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener3Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener3Entity.txt
@@ -168,19 +168,16 @@ public final class _GenericListener3Entity extends org.seasar.doma.jdbc.entity.A
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener3Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener6Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_GenericListener6Entity.txt
@@ -168,19 +168,16 @@ public final class _GenericListener6Entity extends org.seasar.doma.jdbc.entity.A
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.GenericListener6Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableChildEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableChildEntity.txt
@@ -171,19 +171,16 @@ public final class _ImmutableChildEntity extends org.seasar.doma.jdbc.entity.Abs
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableEntity.txt
@@ -171,19 +171,16 @@ public final class _ImmutableEntity extends org.seasar.doma.jdbc.entity.Abstract
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableUser.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ImmutableUser.txt
@@ -172,19 +172,16 @@ public final class _ImmutableUser extends org.seasar.doma.jdbc.entity.AbstractEn
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ImmutableUser, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_LombokAllArgsConstructor.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_LombokAllArgsConstructor.txt
@@ -170,19 +170,16 @@ public final class _LombokAllArgsConstructor extends org.seasar.doma.jdbc.entity
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokAllArgsConstructor, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_LombokValue.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_LombokValue.txt
@@ -170,19 +170,16 @@ public final class _LombokValue extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.LombokValue, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType1Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType1Entity.txt
@@ -168,19 +168,16 @@ public final class _NamingType1Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType1Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType2Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType2Entity.txt
@@ -168,19 +168,16 @@ public final class _NamingType2Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType2Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType3Entity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NamingType3Entity.txt
@@ -168,19 +168,16 @@ public final class _NamingType3Entity extends org.seasar.doma.jdbc.entity.Abstra
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NamingType3Entity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NotTopLevelEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NotTopLevelEntity.txt
@@ -168,19 +168,16 @@ public final class _NotTopLevelEntity__Hoge extends org.seasar.doma.jdbc.entity.
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NotTopLevelImmutableEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_NotTopLevelImmutableEntity.txt
@@ -169,19 +169,16 @@ public final class _NotTopLevelImmutableEntity__Hoge extends org.seasar.doma.jdb
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.NotTopLevelImmutableEntity.Hoge, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalDoubleEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalDoubleEntity.txt
@@ -172,19 +172,16 @@ public final class _OptionalDoubleEntity extends org.seasar.doma.jdbc.entity.Abs
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalDoubleEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalEntity.txt
@@ -175,19 +175,16 @@ public final class _OptionalEntity extends org.seasar.doma.jdbc.entity.AbstractE
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalIntEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalIntEntity.txt
@@ -172,19 +172,16 @@ public final class _OptionalIntEntity extends org.seasar.doma.jdbc.entity.Abstra
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalIntEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalLongEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OptionalLongEntity.txt
@@ -172,19 +172,16 @@ public final class _OptionalLongEntity extends org.seasar.doma.jdbc.entity.Abstr
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OptionalLongEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OriginalStatesChildEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_OriginalStatesChildEntity.txt
@@ -173,19 +173,16 @@ public final class _OriginalStatesChildEntity extends org.seasar.doma.jdbc.entit
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.OriginalStatesChildEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PackagePrivateEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PackagePrivateEntity.txt
@@ -181,19 +181,16 @@ public final class _PackagePrivateEntity extends org.seasar.doma.jdbc.entity.Abs
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?>)__entityPropertyTypeMap.get("id");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PackagePrivateEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ParameterizedPropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_ParameterizedPropertyEntity.txt
@@ -169,19 +169,16 @@ public final class _ParameterizedPropertyEntity extends org.seasar.doma.jdbc.ent
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.ParameterizedPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrimitivePropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrimitivePropertyEntity.txt
@@ -172,19 +172,16 @@ public final class _PrimitivePropertyEntity extends org.seasar.doma.jdbc.entity.
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("version");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrimitivePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrivateOriginalStatesEntity.txt
@@ -171,19 +171,16 @@ public final class _PrivateOriginalStatesEntity extends org.seasar.doma.jdbc.ent
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivateOriginalStatesEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrivatePropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_PrivatePropertyEntity.txt
@@ -169,19 +169,16 @@ public final class _PrivatePropertyEntity extends org.seasar.doma.jdbc.entity.Ab
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.PrivatePropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_QuoteEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_QuoteEntity.txt
@@ -172,19 +172,16 @@ public final class _QuoteEntity extends org.seasar.doma.jdbc.entity.AbstractEnti
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.QuoteEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Room.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_Room.txt
@@ -169,19 +169,16 @@ public final class _Room extends org.seasar.doma.jdbc.entity.AbstractEntityType<
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.Room, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_TenantIdEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_TenantIdEntity.txt
@@ -169,19 +169,16 @@ public final class _TenantIdEntity extends org.seasar.doma.jdbc.entity.AbstractE
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TenantIdEntity, ?, ?>)__entityPropertyTypeMap.get("tenantDiscriminator");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_TransientPropertyEntity.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_TransientPropertyEntity.txt
@@ -169,19 +169,16 @@ public final class _TransientPropertyEntity extends org.seasar.doma.jdbc.entity.
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("id");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.TransientPropertyEntity, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_User.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest_User.txt
@@ -171,19 +171,16 @@ public final class _User extends org.seasar.doma.jdbc.entity.AbstractEntityType<
         return __idPropertyTypes;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?> getGeneratedIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.GeneratedIdPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?> getVersionPropertyType() {
         return (org.seasar.doma.jdbc.entity.VersionPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?>)__entityPropertyTypeMap.get("null");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?> getTenantIdPropertyType() {
         return (org.seasar.doma.jdbc.entity.TenantIdPropertyType<org.seasar.doma.internal.apt.processor.entity.User, ?, ?>)__entityPropertyTypeMap.get("null");

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,5 @@ postgresql.url=jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true
 sqlite.url=jdbc:sqlite:test.db?date_class=text
 sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true
 
+# javac or ecj
 compiler=javac

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,5 @@ oracle.url=jdbc:tc:oracle:21-slim-faststart:thin:@test?TC_DAEMON=true
 postgresql.url=jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true
 sqlite.url=jdbc:sqlite:test.db?date_class=text
 sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true
+
+compiler=javac

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,3 +36,4 @@ publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 release = { id = "net.researchgate.release", version = "3.1.0" }
 doma-compile = { id = "org.domaframework.doma.compile", version = "3.0.1" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+themrmilchmann-ecj = { id = "io.github.themrmilchmann.ecj", version = "0.2.0" }

--- a/integration-test-java/build.gradle.kts
+++ b/integration-test-java/build.gradle.kts
@@ -1,15 +1,62 @@
 plugins {
     java
+    alias(libs.plugins.themrmilchmann.ecj) apply false
 }
+
+val compiler: String by project
 
 dependencies {
     annotationProcessor(project(":doma-processor"))
     implementation(project(":doma-core"))
     testImplementation(project(":integration-test-common"))
+    if (compiler == "ecj") {
+        implementation(libs.ecj)
+        // See https://github.com/TheMrMilchmann/gradle-ecj/issues/30
+        compileOnly(project(":doma-processor"))
+    }
 }
 
-tasks {
-    compileJava {
-        options.compilerArgs.addAll(listOf("-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider"))
+when(compiler) {
+    "javac" -> {
+        tasks {
+            compileJava {
+                options.compilerArgs.addAll(
+                    listOf(
+                        "-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider",
+                        "-Adoma.stats=true",
+                    )
+                )
+            }
+        }
     }
+    "ecj" -> {
+        apply(plugin = libs.plugins.themrmilchmann.ecj.get().pluginId)
+        val processors = listOf(
+            "org.seasar.doma.internal.apt.processor.DomainProcessor",
+            "org.seasar.doma.internal.apt.processor.DataTypeProcessor",
+            "org.seasar.doma.internal.apt.processor.ExternalDomainProcessor",
+            "org.seasar.doma.internal.apt.processor.DomainConvertersProcessor",
+            "org.seasar.doma.internal.apt.processor.EmbeddableProcessor",
+            "org.seasar.doma.internal.apt.processor.EntityProcessor",
+            "org.seasar.doma.internal.apt.processor.DaoProcessor",
+            "org.seasar.doma.internal.apt.processor.ScopeProcessor",
+        )
+        tasks {
+            compileJava {
+                @Suppress("UnstableApiUsage")
+                options.forkOptions.jvmArgumentProviders.add(
+                    CommandLineArgumentProvider {
+                        listOf(
+                            // The processors are not automatically detected, so it must be explicitly specified.
+                            "-processor",
+                            processors.joinToString(","),
+                            "-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider",
+                            "-Adoma.stats=true",
+                        )
+                    }
+                )
+            }
+        }
+    }
+    else -> error("Unknown compiler: $compiler")
 }

--- a/integration-test-java/build.gradle.kts
+++ b/integration-test-java/build.gradle.kts
@@ -16,47 +16,45 @@ dependencies {
     }
 }
 
-when(compiler) {
+val commonArgs = listOf(
+    "-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider",
+)
+
+// The processors are not automatically detected, so it must be explicitly specified.
+val ecjArgs = listOf(
+    "-processor",
+    listOf(
+        "org.seasar.doma.internal.apt.processor.DomainProcessor",
+        "org.seasar.doma.internal.apt.processor.DataTypeProcessor",
+        "org.seasar.doma.internal.apt.processor.ExternalDomainProcessor",
+        "org.seasar.doma.internal.apt.processor.DomainConvertersProcessor",
+        "org.seasar.doma.internal.apt.processor.EmbeddableProcessor",
+        "org.seasar.doma.internal.apt.processor.EntityProcessor",
+        "org.seasar.doma.internal.apt.processor.DaoProcessor",
+        "org.seasar.doma.internal.apt.processor.ScopeProcessor",
+    ).joinToString(","),
+)
+
+when (compiler) {
     "javac" -> {
         tasks {
             compileJava {
-                options.compilerArgs.addAll(
-                    listOf(
-                        "-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider",
-                        "-Adoma.stats=true",
-                    )
-                )
+                options.compilerArgs.addAll(commonArgs)
             }
         }
     }
+
     "ecj" -> {
         apply(plugin = libs.plugins.themrmilchmann.ecj.get().pluginId)
-        val processors = listOf(
-            "org.seasar.doma.internal.apt.processor.DomainProcessor",
-            "org.seasar.doma.internal.apt.processor.DataTypeProcessor",
-            "org.seasar.doma.internal.apt.processor.ExternalDomainProcessor",
-            "org.seasar.doma.internal.apt.processor.DomainConvertersProcessor",
-            "org.seasar.doma.internal.apt.processor.EmbeddableProcessor",
-            "org.seasar.doma.internal.apt.processor.EntityProcessor",
-            "org.seasar.doma.internal.apt.processor.DaoProcessor",
-            "org.seasar.doma.internal.apt.processor.ScopeProcessor",
-        )
         tasks {
             compileJava {
                 @Suppress("UnstableApiUsage")
                 options.forkOptions.jvmArgumentProviders.add(
-                    CommandLineArgumentProvider {
-                        listOf(
-                            // The processors are not automatically detected, so it must be explicitly specified.
-                            "-processor",
-                            processors.joinToString(","),
-                            "-Adoma.domain.converters=org.seasar.doma.it.domain.DomainConverterProvider",
-                            "-Adoma.stats=true",
-                        )
-                    }
+                    CommandLineArgumentProvider { commonArgs + ecjArgs }
                 )
             }
         }
     }
+
     else -> error("Unknown compiler: $compiler")
 }


### PR DESCRIPTION
To make the doma-processor module easier to refactor, we added support for building integration tests with both `javac` and `ecj` (Eclipse Compiler for Java).

You can build the integration tests with `ecj` using the following command:
```
$  ./gradlew clean :integration-test-java:build -Pcompiler=ecj
```