### PR TITLE
Add the `doma.trace` option

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -930,6 +930,7 @@ public enum Message implements MessageResource {
       "If a method annotated with @MultiInsert targets immutable entities for insertion, the return type must be org.seasar.doma.jdbc.MultiResult."
           + "The type argument of org.seasar.doma.jdbc.MultiResult must be the immutable entity class."),
   DOMA4462("The property \"{0}\" is not found in the entity class \"{1}\"."),
+  DOMA4463("'{'\"execTimeMillis\": {0}, \"processor\": \"{1}\", \"element\": \"{2}\"'}'"),
 
   // other
   DOMA5001(

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -27,6 +27,8 @@ public final class Options {
 
   public static final String DEBUG = "doma.debug";
 
+  public static final String TRACE = "doma.trace";
+
   public static final String DAO_PACKAGE = "doma.dao.package";
 
   public static final String DAO_SUBPACKAGE = "doma.dao.subpackage";
@@ -120,6 +122,11 @@ public final class Options {
       return new Date(0L);
     }
     return new Date();
+  }
+
+  public boolean isTraceEnabled() {
+    String trace = getOption(TRACE);
+    return Boolean.parseBoolean(trace);
   }
 
   public boolean isDebugEnabled() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/AbstractProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/AbstractProcessor.java
@@ -4,6 +4,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -63,7 +64,18 @@ public abstract class AbstractProcessor extends javax.annotation.processing.Abst
           .debug(Message.DOMA4090, new Object[] {getClass().getName(), elementNameSupplier.get()});
     }
     try {
-      handler.accept(element);
+      if (ctx.getOptions().isTraceEnabled()) {
+        long startTime = System.nanoTime();
+        handler.accept(element);
+        long endTime = System.nanoTime();
+        long execTimeMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+        ctx.getReporter()
+            .debug(
+                Message.DOMA4463,
+                new Object[] {execTimeMillis, getClass().getName(), elementNameSupplier.get()});
+      } else {
+        handler.accept(element);
+      }
     } catch (AptException e) {
       ctx.getReporter().report(e);
     } catch (AptIllegalOptionException e) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DaoProcessor.java
@@ -24,6 +24,7 @@ import org.seasar.doma.internal.util.ClassUtil;
 @SupportedAnnotationTypes({"org.seasar.doma.Dao"})
 @SupportedOptions({
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.DAO_PACKAGE,
   Options.DAO_SUBPACKAGE,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DataTypeProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DataTypeProcessor.java
@@ -12,6 +12,7 @@ import org.seasar.doma.internal.apt.meta.domain.DataTypeMetaFactory;
   Options.VERSION_VALIDATION,
   Options.RESOURCES_DIR,
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.CONFIG_PATH
 })

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DomainConvertersProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DomainConvertersProcessor.java
@@ -19,7 +19,13 @@ import org.seasar.doma.message.Message;
  * @since 1.25.0
  */
 @SupportedAnnotationTypes({"org.seasar.doma.DomainConverters"})
-@SupportedOptions({Options.RESOURCES_DIR, Options.TEST, Options.DEBUG, Options.CONFIG_PATH})
+@SupportedOptions({
+  Options.RESOURCES_DIR,
+  Options.TEST,
+  Options.TRACE,
+  Options.DEBUG,
+  Options.CONFIG_PATH
+})
 public class DomainConvertersProcessor extends AbstractProcessor {
 
   public DomainConvertersProcessor() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DomainProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/DomainProcessor.java
@@ -13,6 +13,7 @@ import org.seasar.doma.internal.apt.meta.domain.InternalDomainMetaFactory;
   Options.RESOURCES_DIR,
   Options.LOMBOK_VALUE,
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.CONFIG_PATH
 })

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/EmbeddableProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/EmbeddableProcessor.java
@@ -24,6 +24,7 @@ import org.seasar.doma.internal.apt.meta.entity.EmbeddableMetaFactory;
   Options.LOMBOK_VALUE,
   Options.LOMBOK_ALL_ARGS_CONSTRUCTOR,
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.CONFIG_PATH,
   Options.METAMODEL_ENABLED,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/EntityProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/EntityProcessor.java
@@ -32,6 +32,7 @@ import org.seasar.doma.internal.apt.meta.entity.EntityMetaFactory;
   Options.LOMBOK_VALUE,
   Options.LOMBOK_ALL_ARGS_CONSTRUCTOR,
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.CONFIG_PATH,
   Options.METAMODEL_ENABLED,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ExternalDomainProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ExternalDomainProcessor.java
@@ -21,6 +21,7 @@ import org.seasar.doma.internal.apt.meta.domain.ExternalDomainMetaFactory;
   Options.VERSION_VALIDATION,
   Options.RESOURCES_DIR,
   Options.TEST,
+  Options.TRACE,
   Options.DEBUG,
   Options.CONFIG_PATH
 })

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ScopeProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ScopeProcessor.java
@@ -14,7 +14,13 @@ import org.seasar.doma.internal.apt.Options;
 import org.seasar.doma.message.Message;
 
 @SupportedAnnotationTypes({"org.seasar.doma.Scope"})
-@SupportedOptions({Options.RESOURCES_DIR, Options.TEST, Options.DEBUG, Options.CONFIG_PATH})
+@SupportedOptions({
+  Options.RESOURCES_DIR,
+  Options.TEST,
+  Options.TRACE,
+  Options.DEBUG,
+  Options.CONFIG_PATH
+})
 public class ScopeProcessor extends AbstractProcessor {
 
   public ScopeProcessor() {


### PR DESCRIPTION
This pull request introduces a new annotation processing option, `doma.trace`, to output the execution time of annotation processing.  

To enable the `doma.trace` option, configure your build script as follows:

**Gradle**
```kotlin
tasks {
    compileJava {
        options.compilerArgs.addAll(listOf("-Adoma.trace=true"))
    }
}
```

**Maven**
```xml
<compilerArgs>
    <arg>-Adoma.dao.trace=true</arg>
</compilerArgs>
```

When the option is enabled, you will get output similar to the following:

```
75. INFO: [DOMA4463] {"execTimeMillis": 114, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.dao.CompKeyDepartmentDao"}
76. INFO: [DOMA4463] {"execTimeMillis": 20, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.dao.CompKeyDeptDao"}
77. INFO: [DOMA4463] {"execTimeMillis": 7, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.dao.FulltimeEmployeeDao"}
78. INFO: [DOMA4463] {"execTimeMillis": 3, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.dao.VeryLongCharactersNamedTableDao"}
79. INFO: [DOMA4463] {"execTimeMillis": 6, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.dao.BranchDao"}
80. INFO: [DOMA4463] {"execTimeMillis": 8, "processor": "org.seasar.doma.internal.apt.processor.DaoProcessor", "element": "org.seasar.doma.it.jep355.TextBlockDao"}
```