### PR TITLE
Add java.lang.Iterable support for IN and NOT IN clauses in DSL

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
@@ -477,6 +477,36 @@ public abstract class ComparisonDeclaration {
    */
   public <PROPERTY1, PROPERTY2> void in(
       Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
+      Iterable<Tuple2<PROPERTY1, PROPERTY2>> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      List<Tuple2<Operand.Param, Operand.Param>> params =
+          StreamSupport.stream(right.spliterator(), false)
+              .map(
+                  pair -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
+                    return new Tuple2<>(param1, param2);
+                  })
+              .collect(toList());
+      add(new Criterion.InTuple2(new Tuple2<>(prop1, prop2), params));
+    }
+  }
+
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY1, PROPERTY2> void in(
+      Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
       List<Tuple2<PROPERTY1, PROPERTY2>> right) {
     Objects.requireNonNull(left);
     if (right != null) {
@@ -492,6 +522,36 @@ public abstract class ComparisonDeclaration {
                   })
               .collect(toList());
       add(new Criterion.InTuple2(new Tuple2<>(prop1, prop2), params));
+    }
+  }
+
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY1, PROPERTY2> void notIn(
+      Tuple2<PropertyMetamodel<PROPERTY1>, PropertyMetamodel<PROPERTY2>> left,
+      Iterable<Tuple2<PROPERTY1, PROPERTY2>> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      List<Tuple2<Operand.Param, Operand.Param>> params =
+          StreamSupport.stream(right.spliterator(), false)
+              .map(
+                  pair -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), pair.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), pair.getItem2());
+                    return new Tuple2<>(param1, param2);
+                  })
+              .collect(toList());
+      add(new Criterion.NotInTuple2(new Tuple2<>(prop1, prop2), params));
     }
   }
 
@@ -580,6 +640,43 @@ public abstract class ComparisonDeclaration {
               PropertyMetamodel<PROPERTY2>,
               PropertyMetamodel<PROPERTY3>>
           left,
+      Iterable<Tuple3<PROPERTY1, PROPERTY2, PROPERTY3>> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      Operand.Prop prop3 = new Operand.Prop(left.getItem3());
+      List<Tuple3<Operand.Param, Operand.Param, Operand.Param>> params =
+          StreamSupport.stream(right.spliterator(), false)
+              .map(
+                  triple -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), triple.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), triple.getItem2());
+                    Operand.Param param3 = new Operand.Param(left.getItem3(), triple.getItem3());
+                    return new Tuple3<>(param1, param2, param3);
+                  })
+              .collect(toList());
+      add(new Criterion.InTuple3(new Tuple3<>(prop1, prop2, prop3), params));
+    }
+  }
+
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @param <PROPERTY3> the third property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY1, PROPERTY2, PROPERTY3> void in(
+      Tuple3<
+              PropertyMetamodel<PROPERTY1>,
+              PropertyMetamodel<PROPERTY2>,
+              PropertyMetamodel<PROPERTY3>>
+          left,
       List<Tuple3<PROPERTY1, PROPERTY2, PROPERTY3>> right) {
     Objects.requireNonNull(left);
     if (right != null) {
@@ -597,6 +694,43 @@ public abstract class ComparisonDeclaration {
                   })
               .collect(toList());
       add(new Criterion.InTuple3(new Tuple3<>(prop1, prop2, prop3), params));
+    }
+  }
+
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY1> the first property type
+   * @param <PROPERTY2> the second property type
+   * @param <PROPERTY3> the third property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY1, PROPERTY2, PROPERTY3> void notIn(
+      Tuple3<
+              PropertyMetamodel<PROPERTY1>,
+              PropertyMetamodel<PROPERTY2>,
+              PropertyMetamodel<PROPERTY3>>
+          left,
+      Iterable<Tuple3<PROPERTY1, PROPERTY2, PROPERTY3>> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      Operand.Prop prop1 = new Operand.Prop(left.getItem1());
+      Operand.Prop prop2 = new Operand.Prop(left.getItem2());
+      Operand.Prop prop3 = new Operand.Prop(left.getItem3());
+      List<Tuple3<Operand.Param, Operand.Param, Operand.Param>> params =
+          StreamSupport.stream(right.spliterator(), false)
+              .map(
+                  triple -> {
+                    Operand.Param param1 = new Operand.Param(left.getItem1(), triple.getItem1());
+                    Operand.Param param2 = new Operand.Param(left.getItem2(), triple.getItem2());
+                    Operand.Param param3 = new Operand.Param(left.getItem3(), triple.getItem3());
+                    return new Tuple3<>(param1, param2, param3);
+                  })
+              .collect(toList());
+      add(new Criterion.NotInTuple3(new Tuple3<>(prop1, prop2, prop3), params));
     }
   }
 

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/declaration/ComparisonDeclaration.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 import org.seasar.doma.jdbc.criteria.context.Criterion;
 import org.seasar.doma.jdbc.criteria.context.Operand;
 import org.seasar.doma.jdbc.criteria.context.SubSelectContext;
@@ -363,6 +364,27 @@ public abstract class ComparisonDeclaration {
    * @param <PROPERTY> the property type
    * @throws NullPointerException if {@code left} is null
    */
+  public <PROPERTY> void in(PropertyMetamodel<PROPERTY> left, Iterable<PROPERTY> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      add(
+          new Criterion.In(
+              new Operand.Prop(left),
+              StreamSupport.stream(right.spliterator(), false)
+                  .map(p -> new Operand.Param(left, p))
+                  .collect(toList())));
+    }
+  }
+
+  /**
+   * Adds a {@code IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
   public <PROPERTY> void in(PropertyMetamodel<PROPERTY> left, List<PROPERTY> right) {
     Objects.requireNonNull(left);
     if (right != null) {
@@ -370,6 +392,27 @@ public abstract class ComparisonDeclaration {
           new Criterion.In(
               new Operand.Prop(left),
               right.stream().map(p -> new Operand.Param(left, p)).collect(toList())));
+    }
+  }
+
+  /**
+   * Adds a {@code NOT IN} operator.
+   *
+   * @param left the left hand operand
+   * @param right the right hand operand. If this value is null, the query condition doesn't include
+   *     the operator.
+   * @param <PROPERTY> the property type
+   * @throws NullPointerException if {@code left} is null
+   */
+  public <PROPERTY> void notIn(PropertyMetamodel<PROPERTY> left, Iterable<PROPERTY> right) {
+    Objects.requireNonNull(left);
+    if (right != null) {
+      add(
+          new Criterion.NotIn(
+              new Operand.Prop(left),
+              StreamSupport.stream(right.spliterator(), false)
+                  .map(p -> new Operand.Param(left, p))
+                  .collect(toList())));
     }
   }
 

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/QueryDslSqlSelectTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/QueryDslSqlSelectTest.java
@@ -26,6 +26,7 @@ import static org.seasar.doma.jdbc.criteria.expression.Expressions.when;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.seasar.doma.DomaException;
@@ -381,6 +382,22 @@ class QueryDslSqlSelectTest {
   }
 
   @Test
+  void where_in_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.in(e.id, new TreeSet<Integer>(Arrays.asList(1, 2)));
+                  c.in(e.id, (List<Integer>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals("select t0_.ID from EMP t0_ where t0_.ID in (1, 2)", sql.getFormattedSql());
+  }
+
+  @Test
   void where_notIn() {
     Emp_ e = new Emp_();
     Buildable<?> stmt =
@@ -388,6 +405,22 @@ class QueryDslSqlSelectTest {
             .where(
                 c -> {
                   c.notIn(e.id, Arrays.asList(1, 2));
+                  c.notIn(e.id, (List<Integer>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals("select t0_.ID from EMP t0_ where t0_.ID not in (1, 2)", sql.getFormattedSql());
+  }
+
+  @Test
+  void where_notIn_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.notIn(e.id, new TreeSet<Integer>(Arrays.asList(1, 2)));
                   c.notIn(e.id, (List<Integer>) null);
                 })
             .select(e.id);

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/QueryDslSqlSelectTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/criteria/QueryDslSqlSelectTest.java
@@ -25,8 +25,8 @@ import static org.seasar.doma.jdbc.criteria.expression.Expressions.when;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.TreeSet;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.seasar.doma.DomaException;
@@ -388,7 +388,7 @@ class QueryDslSqlSelectTest {
         dsl.from(e)
             .where(
                 c -> {
-                  c.in(e.id, new TreeSet<Integer>(Arrays.asList(1, 2)));
+                  c.in(e.id, new LinkedHashSet<Integer>(Arrays.asList(1, 2)));
                   c.in(e.id, (List<Integer>) null);
                 })
             .select(e.id);
@@ -420,7 +420,7 @@ class QueryDslSqlSelectTest {
         dsl.from(e)
             .where(
                 c -> {
-                  c.notIn(e.id, new TreeSet<Integer>(Arrays.asList(1, 2)));
+                  c.notIn(e.id, new LinkedHashSet<Integer>(Arrays.asList(1, 2)));
                   c.notIn(e.id, (List<Integer>) null);
                 })
             .select(e.id);
@@ -450,6 +450,27 @@ class QueryDslSqlSelectTest {
   }
 
   @Test
+  void where_in_tuple2_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.in(
+                      new Tuple2<>(e.id, e.name),
+                      new LinkedHashSet<>(
+                          Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b"))));
+                  c.in(new Tuple2<>(e.id, e.name), (List<Tuple2<Integer, String>>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where (t0_.ID, t0_.NAME) in ((1, 'a'), (2, 'b'))",
+        sql.getFormattedSql());
+  }
+
+  @Test
   void where_notIn_tuple2() {
     Emp_ e = new Emp_();
     Buildable<?> stmt =
@@ -459,6 +480,27 @@ class QueryDslSqlSelectTest {
                   c.notIn(
                       new Tuple2<>(e.id, e.name),
                       Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b")));
+                  c.notIn(new Tuple2<>(e.id, e.name), (List<Tuple2<Integer, String>>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where (t0_.ID, t0_.NAME) not in ((1, 'a'), (2, 'b'))",
+        sql.getFormattedSql());
+  }
+
+  @Test
+  void where_notIn_tuple2_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.notIn(
+                      new Tuple2<>(e.id, e.name),
+                      new LinkedHashSet<>(
+                          Arrays.asList(new Tuple2<>(1, "a"), new Tuple2<>(2, "b"))));
                   c.notIn(new Tuple2<>(e.id, e.name), (List<Tuple2<Integer, String>>) null);
                 })
             .select(e.id);
@@ -494,6 +536,31 @@ class QueryDslSqlSelectTest {
   }
 
   @Test
+  void where_in_tuple3_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.in(
+                      new Tuple3<>(e.id, e.name, e.salary),
+                      new LinkedHashSet<>(
+                          Arrays.asList(
+                              new Tuple3<>(1, "a", BigDecimal.ONE),
+                              new Tuple3<>(2, "b", BigDecimal.TEN))));
+                  c.in(
+                      new Tuple3<>(e.id, e.name, e.salary),
+                      (List<Tuple3<Integer, String, BigDecimal>>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where (t0_.ID, t0_.NAME, t0_.SALARY) in ((1, 'a', 1), (2, 'b', 10))",
+        sql.getFormattedSql());
+  }
+
+  @Test
   void where_notIn_tuple3() {
     Emp_ e = new Emp_();
     Buildable<?> stmt =
@@ -505,6 +572,31 @@ class QueryDslSqlSelectTest {
                       Arrays.asList(
                           new Tuple3<>(1, "a", BigDecimal.ONE),
                           new Tuple3<>(2, "b", BigDecimal.TEN)));
+                  c.notIn(
+                      new Tuple3<>(e.id, e.name, e.salary),
+                      (List<Tuple3<Integer, String, BigDecimal>>) null);
+                })
+            .select(e.id);
+
+    Sql<?> sql = stmt.asSql();
+    assertEquals(
+        "select t0_.ID from EMP t0_ where (t0_.ID, t0_.NAME, t0_.SALARY) not in ((1, 'a', 1), (2, 'b', 10))",
+        sql.getFormattedSql());
+  }
+
+  @Test
+  void where_notIn_tuple3_iterable() {
+    Emp_ e = new Emp_();
+    Buildable<?> stmt =
+        dsl.from(e)
+            .where(
+                c -> {
+                  c.notIn(
+                      new Tuple3<>(e.id, e.name, e.salary),
+                      new LinkedHashSet<>(
+                          Arrays.asList(
+                              new Tuple3<>(1, "a", BigDecimal.ONE),
+                              new Tuple3<>(2, "b", BigDecimal.TEN))));
                   c.notIn(
                       new Tuple3<>(e.id, e.name, e.salary),
                       (List<Tuple3<Integer, String, BigDecimal>>) null);


### PR DESCRIPTION
This PR adds Iterable support for IN and NOT IN clauses in the Unified Criteria API's WHERE clause. 
For backward compatibility, existing List parameters have been kept as is.

Note: When using SQL files, Iterable parameters are already supported in Dao method arguments.