### PR TITLE
Use `leadingTabsToSpaces` instead of `indentWithSpaces`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ allprojects {
         format("misc") {
             target("**/*.gitignore", "docs/**/*.rst", "**/*.md")
             targetExclude("**/bin/**", "**/build/**")
-            indentWithSpaces()
+            leadingTabsToSpaces()
             trimTrailingWhitespace()
             endWithNewline()
         }


### PR DESCRIPTION
Update the code formatting to replace `indentWithSpaces` with `leadingTabsToSpaces` as `indentWithSpaces` has been deprecated since Spotless 7.0.0.