### PR TITLE
Fix self-referential association duplication issue

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/CacheKey.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/CacheKey.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc.criteria.command;
+
+import java.util.List;
+import org.seasar.doma.jdbc.entity.EntityType;
+
+public record CacheKey(EntityType<?> entityType, List<?> items) {
+  static CacheKey of(EntityKey key) {
+    return new CacheKey(key.getEntityMetamodel().asType(), key.getItems());
+  }
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/EntityKey.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/EntityKey.java
@@ -34,6 +34,10 @@ public final class EntityKey {
     return entityMetamodel;
   }
 
+  public List<?> getItems() {
+    return items;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/EntityPoolIterationHandler.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/command/EntityPoolIterationHandler.java
@@ -18,6 +18,7 @@ package org.seasar.doma.jdbc.criteria.command;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.seasar.doma.internal.jdbc.command.AbstractIterationHandler;
 import org.seasar.doma.internal.jdbc.command.ResultListCallback;
 import org.seasar.doma.jdbc.ObjectProvider;
@@ -27,16 +28,23 @@ import org.seasar.doma.jdbc.query.SelectQuery;
 
 public class EntityPoolIterationHandler
     extends AbstractIterationHandler<EntityPool, List<EntityPool>> {
+  private final EntityMetamodel<?> rootEntityMetamodel;
+  private final Set<CacheKey> rootEntityKeys;
   private final Map<EntityMetamodel<?>, List<PropertyMetamodel<?>>> projectionEntityMetamodels;
 
   public EntityPoolIterationHandler(
+      EntityMetamodel<?> rootEntityMetamodel,
+      Set<CacheKey> rootEntityKeys,
       Map<EntityMetamodel<?>, List<PropertyMetamodel<?>>> projectionEntityMetamodels) {
     super(new ResultListCallback<>());
+    this.rootEntityMetamodel = Objects.requireNonNull(rootEntityMetamodel);
+    this.rootEntityKeys = Objects.requireNonNull(rootEntityKeys);
     this.projectionEntityMetamodels = Objects.requireNonNull(projectionEntityMetamodels);
   }
 
   @Override
   protected ObjectProvider<EntityPool> createObjectProvider(SelectQuery query) {
-    return new EntityPoolProvider(projectionEntityMetamodels, query);
+    return new EntityPoolProvider(
+        rootEntityMetamodel, rootEntityKeys, projectionEntityMetamodels, query);
   }
 }

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/metamodel/EntityTypeProxy.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/criteria/metamodel/EntityTypeProxy.java
@@ -182,4 +182,17 @@ public class EntityTypeProxy<ENTITY> implements EntityType<ENTITY> {
   public void postDelete(ENTITY entity, PostDeleteContext<ENTITY> context) {
     entityType.postDelete(entity, context);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityTypeProxy<?> that = (EntityTypeProxy<?>) o;
+    return Objects.equals(entityType, that.entityType)
+        && Objects.equals(qualifiedTableName, that.qualifiedTableName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entityType, qualifiedTableName);
+  }
 }

--- a/integration-test-java/src/test/java/org/seasar/doma/it/criteria/QueryDslEntitySelectTest.java
+++ b/integration-test-java/src/test/java/org/seasar/doma/it/criteria/QueryDslEntitySelectTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.seasar.doma.it.criteria.CustomExpressions.addOne;
@@ -949,5 +950,25 @@ public class QueryDslEntitySelectTest {
 
     assertEquals("TOKYO", iterator.next());
     assertEquals("KYOTO", iterator.next());
+  }
+
+  @Test
+  void selfJoin_association() {
+    Employee_ e = new Employee_();
+    Employee_ m = new Employee_();
+
+    QueryDsl queryDsl = new QueryDsl(config);
+    List<Employee> employees =
+        queryDsl
+            .from(e)
+            .leftJoin(m, on -> on.eq(e.managerId, m.employeeId))
+            .where(c -> c.in(e.employeeId, List.of(6, 9)))
+            .orderBy(c -> c.asc(e.employeeId))
+            .associate(e, m, (Employee::setManager))
+            .fetch();
+    assertEquals(2, employees.size());
+    Employee blake = employees.get(0);
+    Employee king = employees.get(1);
+    assertSame(king, blake.getManager());
   }
 }


### PR DESCRIPTION

This pull request addressed issue causing the same entity to be generated as multiple instances within a self-referential association.

This issue occurred when writing the following code using the Criteria API:

```java
Employee_ e = new Employee_();
Employee_ m = new Employee_();

QueryDsl queryDsl = new QueryDsl(config);
List<Employee> employees =
    queryDsl
        .from(e)
        .leftJoin(m, on -> on.eq(e.managerId, m.employeeId))
        .orderBy(c -> c.asc(e.employeeId))
        .associate(e, m, Employee::setManager)
        .fetch();

```