### PR TITLE
Add `SimpleConfig` to simplify the construction of `Config`

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/jdbc/SimpleConfig.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/SimpleConfig.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc;
+
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.statistic.StatisticManager;
+import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
+import org.seasar.doma.jdbc.tx.LocalTransactionManager;
+import org.seasar.doma.jdbc.tx.TransactionManager;
+
+/**
+ * Represents a simplified configuration interface that extends the base {@code Config} interface.
+ * It provides methods for accessing specific configuration components and constructing builder
+ * instances for creating configuration objects.
+ *
+ * <pre>
+ *     SimpleConfig config = SimpleConfig.builder("jdbc:h2:mem:test")
+ *       .naming(Naming.SNAKE_UPPER_CASE)
+ *       .queryTimeout(10)
+ *       .build();
+ * </pre>
+ *
+ * This configuration uses Doma's local transaction manager. If you're using Doma with Spring
+ * Framework or Quarkus, avoid using this class.
+ */
+public interface SimpleConfig extends Config {
+
+  /**
+   * Retrieves the {@code LocalTransactionDataSource} associated with this configuration.
+   *
+   * @return an instance of {@code LocalTransactionDataSource} for managing local database
+   *     connections and transactions
+   */
+  LocalTransactionDataSource getLocalTransactionDataSource();
+
+  /**
+   * Retrieves the {@code LocalTransactionManager} associated with this configuration.
+   *
+   * @return an instance of {@code LocalTransactionManager} for managing local transactions
+   */
+  LocalTransactionManager getLocalTransactionManager();
+
+  /**
+   * Creates a new instance of {@code SimpleConfigBuilder} with the specified URL.
+   *
+   * <p>You can use a specially modified JDBC URL for Testcontainers as follows:
+   *
+   * <pre>
+   *     jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true
+   * </pre>
+   *
+   * The {@link Dialect} is inferred from the URL information.
+   *
+   * @param url the database URL to be used for the configuration; must not be {@code null}
+   * @return an instance of {@code SimpleConfigBuilder} initialized with the given URL
+   * @throws NullPointerException if the URL is {@code null}
+   */
+  static SimpleConfigBuilder builder(String url) {
+    Objects.requireNonNull(url);
+    return SimpleConfigBuilderImpl.of(url);
+  }
+
+  /**
+   * Creates a new instance of {@code SimpleConfigBuilder} with the specified database URL,
+   * username, and password.
+   *
+   * <p>You can use a specially modified JDBC URL for Testcontainers as follows:
+   *
+   * <pre>
+   *     jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true
+   * </pre>
+   *
+   * The {@link Dialect} is inferred from the URL information.
+   *
+   * @param url the database URL to be used for the configuration; must not be {@code null}
+   * @param user the username to be used for the database connection; can be {@code null}
+   * @param password the password to be used for the database connection; can be {@code null}
+   * @return an instance of {@code SimpleConfigBuilder} initialized with the specified parameters
+   * @throws NullPointerException if the URL is {@code null}
+   */
+  static SimpleConfigBuilder builder(String url, String user, String password) {
+    Objects.requireNonNull(url);
+    return SimpleConfigBuilderImpl.of(url, user, password);
+  }
+
+  /**
+   * Creates a new instance of {@code SimpleConfigBuilder} with the specified {@code DataSource} and
+   * {@code Dialect}.
+   *
+   * @param dataSource the data source to be used for the configuration; must not be {@code null}
+   * @param dialect the dialect to be used for the configuration; must not be {@code null}
+   * @return an instance of {@code SimpleConfigBuilder} initialized with the provided {@code
+   *     DataSource} and {@code Dialect}
+   * @throws NullPointerException if the {@code dataSource} or {@code dialect} is {@code null}
+   */
+  static SimpleConfigBuilder builder(DataSource dataSource, Dialect dialect) {
+    Objects.requireNonNull(dataSource);
+    Objects.requireNonNull(dialect);
+    return SimpleConfigBuilderImpl.of(dataSource, dialect);
+  }
+}
+
+class SimpleConfigImpl implements Config, SimpleConfig {
+
+  private final LocalTransactionDataSource dataSource;
+  private final Dialect dialect;
+  private final SqlFileRepository sqlFileRepository;
+  private final ScriptFileLoader scriptFileLoader;
+  private final JdbcLogger jdbcLogger;
+  private final RequiresNewController requiresNewController;
+  private final ClassHelper classHelper;
+  private final CommandImplementors commandImplementors;
+  private final QueryImplementors queryImplementors;
+  private final SqlLogType exceptionSqlLogType;
+  private final UnknownColumnHandler unknownColumnHandler;
+  private final DuplicateColumnHandler duplicateColumnHandler;
+  private final Naming naming;
+  private final MapKeyNaming mapKeyNaming;
+  private final LocalTransactionManager transactionManager;
+  private final Commenter commenter;
+  private final EntityListenerProvider entityListenerProvider;
+  private final SqlBuilderSettings sqlBuilderSettings;
+  private final StatisticManager statisticManager;
+  private final int maxRows;
+  private final int fetchSize;
+  private final int queryTimeout;
+  private final int batchSize;
+
+  SimpleConfigImpl(
+      LocalTransactionDataSource dataSource,
+      Dialect dialect,
+      SqlFileRepository sqlFileRepository,
+      ScriptFileLoader scriptFileLoader,
+      JdbcLogger jdbcLogger,
+      RequiresNewController requiresNewController,
+      ClassHelper classHelper,
+      CommandImplementors commandImplementors,
+      QueryImplementors queryImplementors,
+      SqlLogType exceptionSqlLogType,
+      UnknownColumnHandler unknownColumnHandler,
+      DuplicateColumnHandler duplicateColumnHandler,
+      Naming naming,
+      MapKeyNaming mapKeyNaming,
+      LocalTransactionManager transactionManager,
+      Commenter commenter,
+      EntityListenerProvider entityListenerProvider,
+      SqlBuilderSettings sqlBuilderSettings,
+      StatisticManager statisticManager,
+      int maxRows,
+      int fetchSize,
+      int queryTimeout,
+      int batchSize) {
+    this.dataSource = Objects.requireNonNull(dataSource);
+    this.dialect = Objects.requireNonNull(dialect);
+    this.sqlFileRepository = Objects.requireNonNull(sqlFileRepository);
+    this.scriptFileLoader = Objects.requireNonNull(scriptFileLoader);
+    this.jdbcLogger = Objects.requireNonNull(jdbcLogger);
+    this.requiresNewController = Objects.requireNonNull(requiresNewController);
+    this.classHelper = Objects.requireNonNull(classHelper);
+    this.commandImplementors = Objects.requireNonNull(commandImplementors);
+    this.queryImplementors = Objects.requireNonNull(queryImplementors);
+    this.exceptionSqlLogType = Objects.requireNonNull(exceptionSqlLogType);
+    this.unknownColumnHandler = Objects.requireNonNull(unknownColumnHandler);
+    this.duplicateColumnHandler = Objects.requireNonNull(duplicateColumnHandler);
+    this.naming = Objects.requireNonNull(naming);
+    this.mapKeyNaming = Objects.requireNonNull(mapKeyNaming);
+    this.transactionManager = Objects.requireNonNull(transactionManager);
+    this.commenter = Objects.requireNonNull(commenter);
+    this.entityListenerProvider = Objects.requireNonNull(entityListenerProvider);
+    this.sqlBuilderSettings = Objects.requireNonNull(sqlBuilderSettings);
+    this.statisticManager = Objects.requireNonNull(statisticManager);
+    this.maxRows = maxRows;
+    this.fetchSize = fetchSize;
+    this.queryTimeout = queryTimeout;
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  @Override
+  public Dialect getDialect() {
+    return dialect;
+  }
+
+  @Override
+  public SqlFileRepository getSqlFileRepository() {
+    return sqlFileRepository;
+  }
+
+  @Override
+  public ScriptFileLoader getScriptFileLoader() {
+    return scriptFileLoader;
+  }
+
+  @Override
+  public JdbcLogger getJdbcLogger() {
+    return jdbcLogger;
+  }
+
+  @Override
+  public RequiresNewController getRequiresNewController() {
+    return requiresNewController;
+  }
+
+  @Override
+  public ClassHelper getClassHelper() {
+    return classHelper;
+  }
+
+  @Override
+  public CommandImplementors getCommandImplementors() {
+    return commandImplementors;
+  }
+
+  @Override
+  public QueryImplementors getQueryImplementors() {
+    return queryImplementors;
+  }
+
+  @Override
+  public SqlLogType getExceptionSqlLogType() {
+    return exceptionSqlLogType;
+  }
+
+  @Override
+  public UnknownColumnHandler getUnknownColumnHandler() {
+    return unknownColumnHandler;
+  }
+
+  @Override
+  public DuplicateColumnHandler getDuplicateColumnHandler() {
+    return duplicateColumnHandler;
+  }
+
+  @Override
+  public Naming getNaming() {
+    return naming;
+  }
+
+  @Override
+  public MapKeyNaming getMapKeyNaming() {
+    return mapKeyNaming;
+  }
+
+  @Override
+  public TransactionManager getTransactionManager() {
+    return transactionManager;
+  }
+
+  @Override
+  public Commenter getCommenter() {
+    return commenter;
+  }
+
+  @Override
+  public EntityListenerProvider getEntityListenerProvider() {
+    return entityListenerProvider;
+  }
+
+  @Override
+  public SqlBuilderSettings getSqlBuilderSettings() {
+    return sqlBuilderSettings;
+  }
+
+  @Override
+  public StatisticManager getStatisticManager() {
+    return statisticManager;
+  }
+
+  @Override
+  public int getMaxRows() {
+    return maxRows;
+  }
+
+  @Override
+  public int getFetchSize() {
+    return fetchSize;
+  }
+
+  @Override
+  public int getQueryTimeout() {
+    return queryTimeout;
+  }
+
+  @Override
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  @Override
+  public LocalTransactionDataSource getLocalTransactionDataSource() {
+    return dataSource;
+  }
+
+  @Override
+  public LocalTransactionManager getLocalTransactionManager() {
+    return transactionManager;
+  }
+}

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/SimpleConfigBuilder.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/SimpleConfigBuilder.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import org.seasar.doma.jdbc.dialect.Db2Dialect;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.H2Dialect;
+import org.seasar.doma.jdbc.dialect.HsqldbDialect;
+import org.seasar.doma.jdbc.dialect.MssqlDialect;
+import org.seasar.doma.jdbc.dialect.MysqlDialect;
+import org.seasar.doma.jdbc.dialect.OracleDialect;
+import org.seasar.doma.jdbc.dialect.PostgresDialect;
+import org.seasar.doma.jdbc.dialect.SqliteDialect;
+import org.seasar.doma.jdbc.statistic.StatisticManager;
+import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
+import org.seasar.doma.jdbc.tx.LocalTransactionManager;
+
+/**
+ * A builder interface for creating a {@link SimpleConfig} instance with custom configuration
+ * settings.
+ *
+ * <p>This builder provides a fluent API for specifying various settings required for database
+ * interaction such as dialect, logging behavior, transaction management, SQL behavior, entity
+ * listeners, and more. It allows customization of parameters such as fetch size, query timeout, and
+ * batch size, among others.
+ */
+public interface SimpleConfigBuilder {
+
+  SimpleConfigBuilder dialect(Dialect dialect);
+
+  SimpleConfigBuilder jdbcLogger(JdbcLogger jdbcLogger);
+
+  SimpleConfigBuilder sqlFileRepository(SqlFileRepository sqlFileRepository);
+
+  SimpleConfigBuilder scriptFileLoader(ScriptFileLoader scriptFileLoader);
+
+  SimpleConfigBuilder classHelper(ClassHelper classHelper);
+
+  SimpleConfigBuilder commandImplementors(CommandImplementors commandImplementors);
+
+  SimpleConfigBuilder queryImplementors(QueryImplementors queryImplementors);
+
+  SimpleConfigBuilder exceptionSqlLogType(SqlLogType exceptionSqlLogType);
+
+  SimpleConfigBuilder unknownColumnHandler(UnknownColumnHandler unknownColumnHandler);
+
+  SimpleConfigBuilder duplicateColumnHandler(DuplicateColumnHandler duplicateColumnHandler);
+
+  SimpleConfigBuilder naming(Naming naming);
+
+  SimpleConfigBuilder mapKeyNaming(MapKeyNaming mapKeyNaming);
+
+  SimpleConfigBuilder transactionManagerFactory(
+      BiFunction<LocalTransactionDataSource, JdbcLogger, LocalTransactionManager>
+          transactionManagerFactory);
+
+  SimpleConfigBuilder commenter(Commenter commenter);
+
+  SimpleConfigBuilder entityListenerProvider(EntityListenerProvider entityListenerProvider);
+
+  SimpleConfigBuilder sqlBuilderSettings(SqlBuilderSettings sqlBuilderSettings);
+
+  SimpleConfigBuilder statisticManager(StatisticManager statisticManager);
+
+  SimpleConfigBuilder maxRows(int maxRows);
+
+  SimpleConfigBuilder fetchSize(int fetchSize);
+
+  /**
+   * Sets the query timeout duration for SQL queries.
+   *
+   * @param queryTimeout the query timeout in seconds
+   * @return this builder instance for method chaining
+   */
+  SimpleConfigBuilder queryTimeout(int queryTimeout);
+
+  SimpleConfigBuilder batchSize(int batchSize);
+
+  /**
+   * Builds and returns an instance of {@code SimpleConfig} based on the current builder
+   * configuration.
+   *
+   * @return a new {@code SimpleConfig} instance configured with the specified settings
+   */
+  SimpleConfig build();
+}
+
+class SimpleConfigBuilderImpl implements SimpleConfigBuilder {
+  private static final Pattern jdbcUrlPattern = Pattern.compile("^jdbc:(tc:)?([^:]*):.*");
+
+  private final LocalTransactionDataSource dataSource;
+  private Dialect dialect;
+  private BiFunction<LocalTransactionDataSource, JdbcLogger, LocalTransactionManager>
+      transactionManagerFactory;
+  private SqlFileRepository sqlFileRepository = ConfigSupport.defaultSqlFileRepository;
+  private ScriptFileLoader scriptFileLoader = ConfigSupport.defaultScriptFileLoader;
+  private JdbcLogger jdbcLogger = ConfigSupport.defaultJdbcLogger;
+  private ClassHelper classHelper = ConfigSupport.defaultClassHelper;
+  private CommandImplementors commandImplementors = ConfigSupport.defaultCommandImplementors;
+  private QueryImplementors queryImplementors = ConfigSupport.defaultQueryImplementors;
+  private SqlLogType exceptionSqlLogType = SqlLogType.FORMATTED;
+  private UnknownColumnHandler unknownColumnHandler = ConfigSupport.defaultUnknownColumnHandler;
+  private DuplicateColumnHandler duplicateColumnHandler =
+      ConfigSupport.defaultDuplicateColumnHandler;
+  private Naming naming = ConfigSupport.defaultNaming;
+  private MapKeyNaming mapKeyNaming = ConfigSupport.defaultMapKeyNaming;
+  private Commenter commenter = ConfigSupport.defaultCommenter;
+  private EntityListenerProvider entityListenerProvider =
+      ConfigSupport.defaultEntityListenerProvider;
+  private SqlBuilderSettings sqlBuilderSettings = new SimpleSqlBuilderSettings();
+  private StatisticManager statisticManager = ConfigSupport.defaultStatisticManager;
+  int maxRows = 0;
+  int fetchSize = 0;
+  int queryTimeout = 0;
+  int batchSize = 0;
+
+  private SimpleConfigBuilderImpl(
+      LocalTransactionDataSource dataSource,
+      Dialect dialect,
+      BiFunction<LocalTransactionDataSource, JdbcLogger, LocalTransactionManager>
+          transactionManagerFactory) {
+    this.dataSource = Objects.requireNonNull(dataSource);
+    this.dialect = Objects.requireNonNull(dialect);
+    this.transactionManagerFactory = Objects.requireNonNull(transactionManagerFactory);
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl dialect(Dialect dialect) {
+    this.dialect = Objects.requireNonNull(dialect);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl jdbcLogger(JdbcLogger jdbcLogger) {
+    this.jdbcLogger = Objects.requireNonNull(jdbcLogger);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl sqlFileRepository(SqlFileRepository sqlFileRepository) {
+    this.sqlFileRepository = Objects.requireNonNull(sqlFileRepository);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl scriptFileLoader(ScriptFileLoader scriptFileLoader) {
+    this.scriptFileLoader = Objects.requireNonNull(scriptFileLoader);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl classHelper(ClassHelper classHelper) {
+    this.classHelper = Objects.requireNonNull(classHelper);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl commandImplementors(CommandImplementors commandImplementors) {
+    this.commandImplementors = Objects.requireNonNull(commandImplementors);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl queryImplementors(QueryImplementors queryImplementors) {
+    this.queryImplementors = Objects.requireNonNull(queryImplementors);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl exceptionSqlLogType(SqlLogType exceptionSqlLogType) {
+    this.exceptionSqlLogType = Objects.requireNonNull(exceptionSqlLogType);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl unknownColumnHandler(UnknownColumnHandler unknownColumnHandler) {
+    this.unknownColumnHandler = Objects.requireNonNull(unknownColumnHandler);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl duplicateColumnHandler(
+      DuplicateColumnHandler duplicateColumnHandler) {
+    this.duplicateColumnHandler = Objects.requireNonNull(duplicateColumnHandler);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl naming(Naming naming) {
+    this.naming = Objects.requireNonNull(naming);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl mapKeyNaming(MapKeyNaming mapKeyNaming) {
+    this.mapKeyNaming = Objects.requireNonNull(mapKeyNaming);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl transactionManagerFactory(
+      BiFunction<LocalTransactionDataSource, JdbcLogger, LocalTransactionManager>
+          transactionManagerFactory) {
+    this.transactionManagerFactory = Objects.requireNonNull(transactionManagerFactory);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl commenter(Commenter commenter) {
+    this.commenter = Objects.requireNonNull(commenter);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl entityListenerProvider(
+      EntityListenerProvider entityListenerProvider) {
+    this.entityListenerProvider = Objects.requireNonNull(entityListenerProvider);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl sqlBuilderSettings(SqlBuilderSettings sqlBuilderSettings) {
+    this.sqlBuilderSettings = Objects.requireNonNull(sqlBuilderSettings);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl statisticManager(StatisticManager statisticManager) {
+    this.statisticManager = Objects.requireNonNull(statisticManager);
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl maxRows(int maxRows) {
+    this.maxRows = maxRows;
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl fetchSize(int fetchSize) {
+    this.fetchSize = fetchSize;
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl queryTimeout(int queryTimeout) {
+    this.queryTimeout = queryTimeout;
+    return this;
+  }
+
+  @Override
+  public SimpleConfigBuilderImpl batchSize(int batchSize) {
+    this.batchSize = batchSize;
+    return this;
+  }
+
+  @Override
+  public SimpleConfig build() {
+    var transactionManager = transactionManagerFactory.apply(dataSource, jdbcLogger);
+    var requiresNewController =
+        new RequiresNewController() {
+          @Override
+          public <R> R requiresNew(Callback<R> callback) throws Throwable {
+            return transactionManager.requiresNew(callback::execute);
+          }
+        };
+    return new SimpleConfigImpl(
+        dataSource,
+        dialect,
+        sqlFileRepository,
+        scriptFileLoader,
+        jdbcLogger,
+        requiresNewController,
+        classHelper,
+        commandImplementors,
+        queryImplementors,
+        exceptionSqlLogType,
+        unknownColumnHandler,
+        duplicateColumnHandler,
+        naming,
+        mapKeyNaming,
+        transactionManager,
+        commenter,
+        entityListenerProvider,
+        sqlBuilderSettings,
+        statisticManager,
+        maxRows,
+        fetchSize,
+        queryTimeout,
+        batchSize);
+  }
+
+  static SimpleConfigBuilderImpl of(String url) {
+    Objects.requireNonNull(url);
+    return of(url, null, null);
+  }
+
+  static SimpleConfigBuilderImpl of(String url, String user, String password) {
+    Objects.requireNonNull(url);
+    var driver = extractJdbcDriver(url);
+    if (driver == null) {
+      throw new IllegalArgumentException(
+          "Cannot identify the JDBC driver from the URL. url=" + url);
+    }
+    var dialect = inferDialect(driver);
+    if (dialect == null) {
+      throw new IllegalArgumentException(
+          "Cannot infer the Dialect from the URL. url=" + url + ", driver=" + driver);
+    }
+    var dataSource = new LocalTransactionDataSource(url, user, password);
+    return of(dataSource, dialect);
+  }
+
+  static SimpleConfigBuilderImpl of(DataSource dataSource, Dialect dialect) {
+    Objects.requireNonNull(dataSource);
+    Objects.requireNonNull(dialect);
+    LocalTransactionDataSource localTransactionDataSource;
+    if (dataSource instanceof LocalTransactionDataSource ltd) {
+      localTransactionDataSource = ltd;
+    } else {
+      localTransactionDataSource = new LocalTransactionDataSource(dataSource);
+    }
+    return new SimpleConfigBuilderImpl(
+        localTransactionDataSource, dialect, LocalTransactionManager::new);
+  }
+
+  static String extractJdbcDriver(String url) {
+    var matcher = jdbcUrlPattern.matcher(url);
+    if (matcher.matches()) {
+      return matcher.group(2).toLowerCase();
+    }
+    return null;
+  }
+
+  static Dialect inferDialect(String driver) {
+    return switch (driver) {
+      case "db2" -> new Db2Dialect();
+      case "h2" -> new H2Dialect();
+      case "mysql" -> new MysqlDialect(MysqlDialect.MySqlVersion.V8);
+      case "oracle" -> new OracleDialect();
+      case "postgresql" -> new PostgresDialect();
+      case "sqlite" -> new SqliteDialect();
+      case "sqlserver" -> new MssqlDialect();
+      case "hsqldb" -> new HsqldbDialect();
+      default -> null;
+    };
+  }
+}
+
+class SimpleSqlBuilderSettings implements SqlBuilderSettings {
+  @Override
+  public boolean shouldRemoveBlankLines() {
+    return true;
+  }
+}

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigBuilderImplTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigBuilderImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.seasar.doma.internal.jdbc.mock.MockDataSource;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.H2Dialect;
+import org.seasar.doma.jdbc.dialect.PostgresDialect;
+import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
+
+class SimpleConfigBuilderImplTest {
+
+  @Test
+  void build_with_url() {
+    SimpleConfig config = SimpleConfigBuilderImpl.of("jdbc:h2:mem:test").build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotNull(config.getDialect());
+    assertNotNull(config.getLocalTransactionDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_url_user_password() {
+    SimpleConfig config = SimpleConfigBuilderImpl.of("jdbc:h2:mem:test", "sa", "sa").build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotNull(config.getDialect());
+    assertNotNull(config.getLocalTransactionDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_dataSource_dialect() {
+    DataSource dataSource = new MockDataSource();
+    Dialect dialect = new H2Dialect();
+
+    SimpleConfig config = SimpleConfigBuilderImpl.of(dataSource, dialect).build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotEquals(dataSource, config.getDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+    assertNotEquals(dataSource, config.getLocalTransactionDataSource());
+    assertEquals(dialect, config.getDialect());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_localTransactionDataSource_dialect() {
+    DataSource dataSource = new MockDataSource();
+    LocalTransactionDataSource localTransactionDataSource =
+        new LocalTransactionDataSource(dataSource);
+    Dialect dialect = new H2Dialect();
+
+    SimpleConfig config = SimpleConfigBuilderImpl.of(localTransactionDataSource, dialect).build();
+
+    assertNotNull(config);
+    assertEquals(localTransactionDataSource, config.getDataSource());
+    assertEquals(localTransactionDataSource, config.getLocalTransactionDataSource());
+    assertEquals(dialect, config.getDialect());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void extractJdbcDriver() {
+    assertEquals("h2", SimpleConfigBuilderImpl.extractJdbcDriver("jdbc:h2:mem:test"));
+    assertEquals("postgresql", SimpleConfigBuilderImpl.extractJdbcDriver("jdbc:postgresql:test"));
+    assertEquals(
+        "postgresql",
+        SimpleConfigBuilderImpl.extractJdbcDriver(
+            "jdbc:tc:postgresql:12.20:///test?TC_DAEMON=true"));
+    assertNull(SimpleConfigBuilderImpl.extractJdbcDriver("aaa:bbb:ccc"));
+  }
+
+  @Test
+  void inferDialect() {
+    assertInstanceOf(H2Dialect.class, SimpleConfigBuilderImpl.inferDialect("h2"));
+    assertInstanceOf(PostgresDialect.class, SimpleConfigBuilderImpl.inferDialect("postgresql"));
+    assertNull(SimpleConfigBuilderImpl.inferDialect("unknown"));
+  }
+}

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigImplTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigImplTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.seasar.doma.internal.jdbc.mock.MockDataSource;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.H2Dialect;
+import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
+import org.seasar.doma.jdbc.tx.LocalTransactionManager;
+
+public class SimpleConfigImplTest {
+
+  @Test
+  void testGetLocalTransactionManager() {
+    DataSource dataSource = new MockDataSource();
+    Dialect dialect = new H2Dialect();
+    JdbcLogger jdbcLogger = ConfigSupport.defaultJdbcLogger;
+    LocalTransactionDataSource localTransactionDataSource =
+        new LocalTransactionDataSource(dataSource);
+    LocalTransactionManager transactionManager =
+        new LocalTransactionManager(localTransactionDataSource, jdbcLogger);
+
+    SimpleConfig config =
+        new SimpleConfigImpl(
+            localTransactionDataSource,
+            dialect,
+            ConfigSupport.defaultSqlFileRepository,
+            ConfigSupport.defaultScriptFileLoader,
+            jdbcLogger,
+            ConfigSupport.defaultRequiresNewController,
+            ConfigSupport.defaultClassHelper,
+            ConfigSupport.defaultCommandImplementors,
+            ConfigSupport.defaultQueryImplementors,
+            SqlLogType.FORMATTED,
+            ConfigSupport.defaultUnknownColumnHandler,
+            ConfigSupport.defaultDuplicateColumnHandler,
+            ConfigSupport.defaultNaming,
+            ConfigSupport.defaultMapKeyNaming,
+            transactionManager,
+            ConfigSupport.defaultCommenter,
+            ConfigSupport.defaultEntityListenerProvider,
+            ConfigSupport.defaultSqlBuilderSettings,
+            ConfigSupport.defaultStatisticManager,
+            0,
+            0,
+            0,
+            0);
+
+    assertSame(localTransactionDataSource, config.getDataSource());
+    assertSame(localTransactionDataSource, config.getLocalTransactionDataSource());
+    assertSame(transactionManager, config.getTransactionManager());
+    assertSame(transactionManager, config.getLocalTransactionManager());
+  }
+}

--- a/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/jdbc/SimpleConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.seasar.doma.internal.jdbc.mock.MockDataSource;
+import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.H2Dialect;
+import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
+
+class SimpleConfigTest {
+
+  @Test
+  void build_with_url() {
+    SimpleConfig config = SimpleConfig.builder("jdbc:h2:mem:test").build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotNull(config.getDialect());
+    assertNotNull(config.getLocalTransactionDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_url_user_password() {
+    SimpleConfig config = SimpleConfig.builder("jdbc:h2:mem:test", "sa", "sa").build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotNull(config.getDialect());
+    assertNotNull(config.getLocalTransactionDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_dataSource_dialect() {
+    DataSource dataSource = new MockDataSource();
+    Dialect dialect = new H2Dialect();
+    SimpleConfig config = SimpleConfig.builder(dataSource, dialect).build();
+
+    assertNotNull(config);
+    assertNotNull(config.getDataSource());
+    assertNotEquals(dataSource, config.getDataSource());
+    assertNotNull(config.getLocalTransactionManager());
+    assertNotEquals(dataSource, config.getLocalTransactionDataSource());
+    assertEquals(dialect, config.getDialect());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+
+  @Test
+  void build_with_localTransactionDataSource_dialect() {
+    DataSource dataSource = new MockDataSource();
+    LocalTransactionDataSource localTransactionDataSource =
+        new LocalTransactionDataSource(dataSource);
+    Dialect dialect = new H2Dialect();
+
+    SimpleConfig config = SimpleConfig.builder(localTransactionDataSource, dialect).build();
+
+    assertNotNull(config);
+    assertEquals(localTransactionDataSource, config.getDataSource());
+    assertEquals(localTransactionDataSource, config.getLocalTransactionDataSource());
+    assertEquals(dialect, config.getDialect());
+    assertNotNull(config.getLocalTransactionManager());
+  }
+}


### PR DESCRIPTION
Introduce `SimpleConfig` to streamline the creation of `Config` instances.

Here is an example;

```java
Config config = SimpleConfig.builder("jdbc:h2:mem:tutorial;DB_CLOSE_DELAY=-1", "sa", null)
    .jdbcLogger(new Slf4jJdbcLogger())
    .naming(Naming.SNAKE_UPPER_CASE)
    .build();
```