### PR TITLE
Remove unnecessary `@EntityField` annotation from `@Delete` annotation

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/Delete.java
+++ b/doma-core/src/main/java/org/seasar/doma/Delete.java
@@ -59,7 +59,6 @@ import org.seasar.doma.jdbc.SqlLogType;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @DaoMethod
-@EntityField
 public @interface Delete {
 
   /**


### PR DESCRIPTION
Simplifies the `@Delete` annotation by removing an unused `@EntityField` annotation. No functional changes are introduced, ensuring cleaner and more maintainable code.