### PR TITLE
Add BiConsumer support in AssociationLinker

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -955,9 +955,9 @@ public enum Message implements MessageResource {
   DOMA4462("The property \"{0}\" is not found in the entity class \"{1}\"."),
   DOMA4463("'{'\"execTimeMillis\": {0}, \"annotation\": \"{1}\", \"element\": \"{2}\"'}'"),
   DOMA4464("Fields annotated with AssociationLinker must be static."),
-  DOMA4465("Fields annotated with AssociationLinker must be java.util.function.BiFunction."),
+  DOMA4465("Fields annotated with AssociationLinker must be BiFunction or BiConsumer."),
   DOMA4466("The {0} type parameter of BiFunction must be an entity class."),
-  DOMA4467("The first and third type parameters of java.util.function.BiFunction must be the same"),
+  DOMA4467("The first and third type parameters of BiFunction must be the same"),
   DOMA4468("The tableAlias must not be blank."),
   DOMA4469("No field annotated with @AssociationLinker was found in the class \"{0}\"."),
   DOMA4470("Fields annotated with AssociationLinker must be public."),
@@ -971,9 +971,9 @@ public enum Message implements MessageResource {
           + "or a `List` of `Optional` containing elements of the entity class."),
   DOMA4474("The field \"{0}\" could not be found in the class \"{1}\"."),
   DOMA4475(
-      "The first type parameter of java.util.function.BiFunction differs from the type resolved by the propertyPath. type parameter=\"{0}\", resolved type=\"{1}\"."),
+      "The first type parameter of BiFunction or BiConsumer differs from the type resolved by the propertyPath. type parameter=\"{0}\", resolved type=\"{1}\"."),
   DOMA4476(
-      "The second type parameter of java.util.function.BiFunction differs from the type resolved by the propertyPath. type parameter=\"{0}\", resolved type=\"{1}\"."),
+      "The second type parameter of BiFunction or BiConsumer differs from the type resolved by the propertyPath. type parameter=\"{0}\", resolved type=\"{1}\"."),
   DOMA4477(
       "The type of field \"{0}\" in class \"{1}\" must be one of the following: "
           + "the entity class, "
@@ -1012,6 +1012,7 @@ public enum Message implements MessageResource {
       "When \"returning = @Returning\" is specified, the return type must be the same as the parameter type or an Optional whose element is the parameter type."),
   DOMA4496(
       "When \"returning = @Returning\" is specified, the return type must be a List of the entity class \"{0}\"."),
+  DOMA4497("The {0} type parameter of BiConsumer must be an entity class."),
 
   // other
   DOMA5001(

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BiConsumerCtType.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BiConsumerCtType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.cttype;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import javax.lang.model.type.TypeMirror;
+import org.seasar.doma.internal.apt.RoundContext;
+
+public class BiConsumerCtType extends AbstractCtType {
+
+  private final CtType firstArgCtType;
+
+  private final CtType secondArgCtType;
+
+  BiConsumerCtType(
+      RoundContext ctx, TypeMirror type, CtType firstArgCtType, CtType secondArgCtType) {
+    super(ctx, type);
+    assertNotNull(firstArgCtType, secondArgCtType);
+    this.firstArgCtType = firstArgCtType;
+    this.secondArgCtType = secondArgCtType;
+  }
+
+  public CtType getFirstArgCtType() {
+    return firstArgCtType;
+  }
+
+  public CtType getSecondArgCtType() {
+    return secondArgCtType;
+  }
+
+  public boolean isRaw() {
+    return firstArgCtType.isNone() || secondArgCtType.isNone();
+  }
+
+  public boolean hasWildcard() {
+    return firstArgCtType.isWildcard() || secondArgCtType.isWildcard();
+  }
+
+  @Override
+  public <R, P, TH extends Throwable> R accept(CtTypeVisitor<R, P, TH> visitor, P p) throws TH {
+    return visitor.visitBiConsumerCtType(this, p);
+  }
+}

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypeVisitor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypeVisitor.java
@@ -61,6 +61,8 @@ public interface CtTypeVisitor<R, P, TH extends Throwable> {
 
   R visitBiFunctionCtType(BiFunctionCtType ctType, P p) throws TH;
 
+  R visitBiConsumerCtType(BiConsumerCtType ctType, P p) throws TH;
+
   R visitConfigCtType(ConfigCtType ctType, P p) throws TH;
 
   R visitPreparedSqlCtType(PreparedSqlCtType ctType, P p) throws TH;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -195,6 +196,17 @@ public class CtTypes {
     CtType secondArgCtType = typeArgs.hasNext() ? newCtType(typeArgs.next()) : newNoneCtType();
     CtType resultCtType = typeArgs.hasNext() ? newCtType(typeArgs.next()) : newNoneCtType();
     return new BiFunctionCtType(ctx, type, firstArgCtType, secondArgCtType, resultCtType);
+  }
+
+  public BiConsumerCtType newBiConsumerCtType(TypeMirror type) {
+    DeclaredType declaredType = getSuperDeclaredType(type, BiConsumer.class);
+    if (declaredType == null) {
+      return null;
+    }
+    Iterator<? extends TypeMirror> typeArgs = declaredType.getTypeArguments().iterator();
+    CtType firstArgCtType = typeArgs.hasNext() ? newCtType(typeArgs.next()) : newNoneCtType();
+    CtType secondArgCtType = typeArgs.hasNext() ? newCtType(typeArgs.next()) : newNoneCtType();
+    return new BiConsumerCtType(ctx, type, firstArgCtType, secondArgCtType);
   }
 
   private CollectorCtType newCollectorCtType(TypeMirror type) {
@@ -670,6 +682,7 @@ public class CtTypes {
             this::newCollectorCtType,
             this::newReferenceCtType,
             this::newBiFunctionCtType,
+            this::newBiConsumerCtType,
             this::newPreparedSqlCtType,
             this::newConfigCtType,
             this::newResultCtType,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/SimpleCtTypeVisitor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/SimpleCtTypeVisitor.java
@@ -140,6 +140,11 @@ public class SimpleCtTypeVisitor<R, P, TH extends Throwable> implements CtTypeVi
   }
 
   @Override
+  public R visitBiConsumerCtType(BiConsumerCtType ctType, P p) throws TH {
+    return defaultAction(ctType, p);
+  }
+
+  @Override
   public R visitConfigCtType(ConfigCtType ctType, P p) throws TH {
     return defaultAction(ctType, p);
   }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/AggregateStrategyTypeGenerator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/AggregateStrategyTypeGenerator.java
@@ -85,9 +85,10 @@ public class AggregateStrategyTypeGenerator extends AbstractGenerator {
     indent();
     Iterator<AssociationLinkerMeta> iter = strategyMeta.associationLinkerMetas().iterator();
     while (iter.hasNext()) {
-      AssociationLinkerMeta linkerMeta = iter.next();
+      var linkerMeta = iter.next();
+      var linkerExpression = createLinkerExpression(linkerMeta);
       iprint(
-          "%1$s.of(\"%2$s\", \"%3$s\", %4$s, \"%5$s\", %6$s, %7$s, %8$s.%9$s)",
+          "%1$s.of(\"%2$s\", \"%3$s\", %4$s, \"%5$s\", %6$s, %7$s, %8$s)",
           /* 1 */ AssociationLinkerType.class,
           /* 2 */ linkerMeta.ancestorPath(),
           /* 3 */ linkerMeta.propertyPath(),
@@ -95,8 +96,7 @@ public class AggregateStrategyTypeGenerator extends AbstractGenerator {
           /* 5 */ linkerMeta.tableAlias(),
           /* 6 */ linkerMeta.source().getTypeCode(),
           /* 7 */ linkerMeta.target().getTypeCode(),
-          /* 8 */ linkerMeta.classElement(),
-          /* 9 */ linkerMeta.filedElement());
+          /* 8 */ linkerExpression);
       if (iter.hasNext()) {
         print(",");
       }
@@ -121,5 +121,15 @@ public class AggregateStrategyTypeGenerator extends AbstractGenerator {
     iprint("    return __singleton;%n");
     iprint("}%n");
     print("%n");
+  }
+
+  private String createLinkerExpression(AssociationLinkerMeta linkerMeta) {
+    var expression =
+        String.format("%1$s.%2$s", linkerMeta.classElement(), linkerMeta.filedElement());
+    return switch (linkerMeta.linkerKind()) {
+      case BI_FUNCTION -> expression;
+      case BI_CONSUMER ->
+          String.format("(a, b) -> { %1$s.accept(a, b); return null; }", expression);
+    };
   }
 }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplQueryMethodGenerator.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/generator/DaoImplQueryMethodGenerator.java
@@ -20,7 +20,6 @@ import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -46,8 +45,6 @@ import org.seasar.doma.internal.apt.cttype.OptionalIntCtType;
 import org.seasar.doma.internal.apt.cttype.OptionalLongCtType;
 import org.seasar.doma.internal.apt.cttype.SimpleCtTypeVisitor;
 import org.seasar.doma.internal.apt.cttype.StreamCtType;
-import org.seasar.doma.internal.apt.meta.aggregate.AggregateStrategyMeta;
-import org.seasar.doma.internal.apt.meta.aggregate.AssociationLinkerMeta;
 import org.seasar.doma.internal.apt.meta.dao.DaoMeta;
 import org.seasar.doma.internal.apt.meta.parameter.BasicInOutParameterMeta;
 import org.seasar.doma.internal.apt.meta.parameter.BasicInParameterMeta;
@@ -209,7 +206,6 @@ import org.seasar.doma.internal.jdbc.sql.OptionalLongOutParameter;
 import org.seasar.doma.internal.jdbc.sql.OptionalLongResultListParameter;
 import org.seasar.doma.internal.jdbc.sql.OptionalLongSingleResultParameter;
 import org.seasar.doma.jdbc.aggregate.AggregateCommand;
-import org.seasar.doma.jdbc.aggregate.AssociationLinkerType;
 import org.seasar.doma.jdbc.aggregate.ToListReducer;
 import org.seasar.doma.jdbc.aggregate.ToOptionalReducer;
 import org.seasar.doma.jdbc.aggregate.ToSingleReducer;
@@ -353,32 +349,6 @@ public class DaoImplQueryMethodGenerator extends AbstractGenerator
 
     printThrowingStatements(m);
     return null;
-  }
-
-  private void printAssociationLinkerTypes(AggregateStrategyMeta aggregateStrategyMeta) {
-    Objects.requireNonNull(aggregateStrategyMeta);
-    print("java.util.List.of(%n");
-    indent();
-    Iterator<AssociationLinkerMeta> iter =
-        aggregateStrategyMeta.associationLinkerMetas().iterator();
-    while (iter.hasNext()) {
-      AssociationLinkerMeta linkerMeta = iter.next();
-      iprint(
-          "%1$s.of(\"%2$s\", \"%3$s\", %4$s, %5$s, %6$s.%7$s)",
-          AssociationLinkerType.class,
-          linkerMeta.propertyPath(),
-          linkerMeta.tableAlias(),
-          linkerMeta.source().getTypeCode(),
-          linkerMeta.target().getTypeCode(),
-          linkerMeta.classElement(),
-          linkerMeta.filedElement());
-      if (iter.hasNext()) {
-        print(",");
-      }
-      print("%n");
-    }
-    unindent();
-    iprint(");%n");
   }
 
   @Override

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/aggregate/AssociationLinkerKind.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/aggregate/AssociationLinkerKind.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.meta.aggregate;
+
+public enum AssociationLinkerKind {
+  BI_FUNCTION,
+  BI_CONSUMER,
+}

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/aggregate/AssociationLinkerMeta.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/aggregate/AssociationLinkerMeta.java
@@ -29,6 +29,7 @@ public record AssociationLinkerMeta(
     List<String> propertyPathSegments,
     int propertyPathDepth,
     String tableAlias,
+    AssociationLinkerKind linkerKind,
     EntityCtType source,
     EntityCtType target,
     TypeElement classElement,
@@ -39,6 +40,7 @@ public record AssociationLinkerMeta(
     Objects.requireNonNull(propertyPath);
     Objects.requireNonNull(propertyPathSegments);
     Objects.requireNonNull(tableAlias);
+    Objects.requireNonNull(linkerKind);
     Objects.requireNonNull(source);
     Objects.requireNonNull(target);
     Objects.requireNonNull(classElement);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest.java
@@ -72,7 +72,8 @@ class AggregateStrategyProcessorTest extends AbstractCompilerTest {
       return Stream.of(
           invocationContext(EmpStrategy.class),
           invocationContext(DeptStrategy.class),
-          invocationContext(ChildEntityStrategy.class));
+          invocationContext(ChildEntityStrategy.class),
+          invocationContext(EmpStrategy_BiConsumer.class));
     }
 
     private TestTemplateInvocationContext invocationContext(
@@ -149,7 +150,9 @@ class AggregateStrategyProcessorTest extends AbstractCompilerTest {
           invocationContext(InvalidPropertyPath.class, Message.DOMA4474),
           invocationContext(Subtype.class, Message.DOMA4487),
           invocationContext(DuplicatePropertyPath.class, Message.DOMA4489),
-          invocationContext(UnreachableAssociation.class, Message.DOMA4488));
+          invocationContext(UnreachableAssociation.class, Message.DOMA4488),
+          invocationContext(Invalid1stParamTypeOfBiConsumer.class, Message.DOMA4497),
+          invocationContext(Invalid2ndParamTypeOfBiConsumer.class, Message.DOMA4497));
     }
 
     private TestTemplateInvocationContext invocationContext(

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/EmpStrategy_BiConsumer.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/EmpStrategy_BiConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.processor.aggregate;
+
+import java.util.function.BiConsumer;
+import org.seasar.doma.AggregateStrategy;
+import org.seasar.doma.AssociationLinker;
+
+@AggregateStrategy(root = Emp.class, tableAlias = "e")
+interface EmpStrategy_BiConsumer {
+  @AssociationLinker(propertyPath = "dept", tableAlias = "d")
+  BiConsumer<Emp, Dept> dept = (e, d) -> {};
+
+  @AssociationLinker(propertyPath = "address", tableAlias = "a")
+  BiConsumer<Emp, Address> address = (e, a) -> {};
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/Invalid1stParamTypeOfBiConsumer.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/Invalid1stParamTypeOfBiConsumer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.processor.aggregate;
+
+import java.util.function.BiConsumer;
+import org.seasar.doma.AggregateStrategy;
+import org.seasar.doma.AssociationLinker;
+
+@AggregateStrategy(root = Emp.class, tableAlias = "e")
+interface Invalid1stParamTypeOfBiConsumer {
+  @AssociationLinker(propertyPath = "dept", tableAlias = "d")
+  BiConsumer<String, Dept> dept = (e, d) -> {};
+}

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/Invalid2ndParamTypeOfBiConsumer.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/Invalid2ndParamTypeOfBiConsumer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.processor.aggregate;
+
+import java.util.function.BiConsumer;
+import org.seasar.doma.AggregateStrategy;
+import org.seasar.doma.AssociationLinker;
+
+@AggregateStrategy(root = Emp.class, tableAlias = "e")
+interface Invalid2ndParamTypeOfBiConsumer {
+  @AssociationLinker(propertyPath = "dept", tableAlias = "d")
+  BiConsumer<Emp, String> dept = (e, d) -> {};
+}

--- a/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest_EmpStrategy_BiConsumer.txt
+++ b/doma-processor/src/test/resources/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest_EmpStrategy_BiConsumer.txt
@@ -1,0 +1,27 @@
+package org.seasar.doma.internal.apt.processor.aggregate;
+
+/** */
+@javax.annotation.processing.Generated(value = { "Doma", "@VERSION@" }, date = "1970-01-01T09:00:00.000+0900")
+public final class _EmpStrategy_BiConsumer extends org.seasar.doma.jdbc.aggregate.AbstractAggregateStrategyType {
+
+    private static final _EmpStrategy_BiConsumer __singleton = new _EmpStrategy_BiConsumer();
+
+    static {
+        org.seasar.doma.internal.Artifact.validateVersion("@VERSION@");
+    }
+
+    private _EmpStrategy_BiConsumer() {
+        super("org.seasar.doma.internal.apt.processor.aggregate.EmpStrategy_BiConsumer", org.seasar.doma.internal.apt.processor.aggregate._Emp.getSingletonInternal(), "e", java.util.List.of(
+            org.seasar.doma.jdbc.aggregate.AssociationLinkerType.of("", "dept", 1, "d", org.seasar.doma.internal.apt.processor.aggregate._Emp.getSingletonInternal(), org.seasar.doma.internal.apt.processor.aggregate._Dept.getSingletonInternal(), (a, b) -> { org.seasar.doma.internal.apt.processor.aggregate.EmpStrategy_BiConsumer.dept.accept(a, b); return null; }),
+            org.seasar.doma.jdbc.aggregate.AssociationLinkerType.of("", "address", 1, "a", org.seasar.doma.internal.apt.processor.aggregate._Emp.getSingletonInternal(), org.seasar.doma.internal.apt.processor.aggregate._Address.getSingletonInternal(), (a, b) -> { org.seasar.doma.internal.apt.processor.aggregate.EmpStrategy_BiConsumer.address.accept(a, b); return null; })
+        ));
+    }
+
+    /**
+     * @return the singleton
+     */
+    public static _EmpStrategy_BiConsumer getSingletonInternal() {
+        return __singleton;
+    }
+
+}

--- a/integration-test-java/src/main/java/org/seasar/doma/it/dao/EmployeeDao.java
+++ b/integration-test-java/src/main/java/org/seasar/doma/it/dao/EmployeeDao.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -206,11 +207,7 @@ interface EmployeeStrategy {
       };
 
   @AssociationLinker(propertyPath = "address", tableAlias = "a")
-  BiFunction<Employee, Address, Employee> address =
-      (e, a) -> {
-        e.setAddress(a);
-        return e;
-      };
+  BiConsumer<Employee, Address> address = Employee::setAddress;
 }
 
 @AggregateStrategy(root = Employee.class, tableAlias = "e")


### PR DESCRIPTION
This pull request introduces support for the `BiConsumer` functional interface in the `AssociationLinker`, alongside the existing `BiFunction` support. This enhancement expands the flexibility of `AssociationLinker` to handle operations requiring `BiConsumer` types. No additional features or breaking changes are introduced.