### PR TITLE
Add package-info.java for documentation clarity

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/node/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/node/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.expr.node;

--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.expr;

--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/util/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/util/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.expr.util;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/command/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/command/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.command;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dao/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dao/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.dao;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dialect/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/dialect/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.dialect;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/entity/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/entity/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.entity;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/scalar/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/scalar/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.scalar;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/node/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/node/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.sql.node;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/sql/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.sql;

--- a/doma-core/src/main/java/org/seasar/doma/internal/jdbc/util/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/jdbc/util/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.jdbc.util;

--- a/doma-core/src/main/java/org/seasar/doma/internal/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal;

--- a/doma-core/src/main/java/org/seasar/doma/internal/util/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/util/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.util;

--- a/doma-core/src/main/java/org/seasar/doma/internal/wrapper/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/wrapper/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal implementation details for the Doma framework.
+ *
+ * <p>The classes and interfaces in this package are intended solely for the internal implementation
+ * of the Doma framework. They are not part of the public API and may be changed or removed without
+ * notice in future releases. Do not use them directly from external code.
+ */
+package org.seasar.doma.internal.wrapper;

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/aggregate/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/aggregate/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides classes and interfaces for entity aggregation and association operations.
+ *
+ * <p>This package contains components for aggregating entities and establishing associations
+ * between them during database operations. Key components include:
+ *
+ * <ul>
+ *   <li>{@link org.seasar.doma.jdbc.aggregate.AggregateCommand} - A command for executing aggregate
+ *       operations on a stream of entities
+ *   <li>{@link org.seasar.doma.jdbc.aggregate.AggregateStrategyType} - A strategy for defining an
+ *       aggregate structure involving a root entity and its associated entities
+ *   <li>{@link org.seasar.doma.jdbc.aggregate.AssociationLinkerType} - Defines how entities are
+ *       linked in an association
+ *   <li>{@link org.seasar.doma.jdbc.aggregate.StreamReducer} - Reduces a stream of entities to a
+ *       result
+ * </ul>
+ */
+package org.seasar.doma.jdbc.aggregate;

--- a/doma-core/src/main/java/org/seasar/doma/jdbc/statistic/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/jdbc/statistic/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides classes and interfaces for collecting and managing SQL execution statistics.
+ *
+ * <p>This package contains components for monitoring and analyzing the performance of SQL
+ * statements executed through Doma. Key components include:
+ *
+ * <ul>
+ *   <li>{@link org.seasar.doma.jdbc.statistic.StatisticManager} - Interface for managing SQL
+ *       execution statistics
+ *   <li>{@link org.seasar.doma.jdbc.statistic.Statistic} - Record representing statistics for a
+ *       specific SQL statement
+ * </ul>
+ *
+ * <p>These classes can be used to monitor the performance of SQL statements in an application,
+ * helping to identify slow queries and optimize database access.
+ *
+ * @see org.seasar.doma.jdbc.Config#getStatisticManager()
+ */
+package org.seasar.doma.jdbc.statistic;

--- a/doma-core/src/main/java/org/seasar/doma/util/package-info.java
+++ b/doma-core/src/main/java/org/seasar/doma/util/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides utility classes and interfaces.
+ *
+ * <p>This package contains general-purpose utility components that can be used throughout the Doma
+ * framework.
+ */
+package org.seasar.doma.util;


### PR DESCRIPTION
This pull request adds `package-info.java` files across various packages to enhance clarity and provide documentation. These files serve as a central location for package-level JavaDoc, improving maintainability and understanding of the codebase.

No new functionality is introduced, and existing code behavior remains unchanged.