### PR TITLE
Fix Gradle annotation processing configuration and update Doma plugin

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
@@ -74,7 +74,8 @@ import org.seasar.doma.internal.apt.processor.ScopeProcessor;
   Options.METAMODEL_SUFFIX,
   Options.RESOURCES_DIR,
   Options.SQL_VALIDATION,
-  Options.TEST,
+  Options.TEST_INTEGRATION,
+  Options.TEST_UNIT,
   Options.TRACE,
   Options.VERSION_VALIDATION,
 })

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -32,7 +32,9 @@ import org.seasar.doma.internal.Artifact;
 
 public final class Options {
 
-  public static final String TEST = "doma.test";
+  public static final String TEST_UNIT = "doma.test.unit";
+
+  public static final String TEST_INTEGRATION = "doma.test.integration";
 
   public static final String METAMODEL_ENABLED = "doma.metamodel.enabled";
 
@@ -106,7 +108,7 @@ public final class Options {
   }
 
   public boolean isTestEnabled() {
-    String test = getOption(TEST);
+    String test = getOption(TEST_UNIT);
     return Boolean.parseBoolean(test);
   }
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
@@ -43,9 +43,29 @@ public class ProcessingContext {
     moreElements = new MoreElements(this, env.getElementUtils());
     moreTypes = new MoreTypes(this, env.getTypeUtils());
     reporter = new Reporter(env.getMessager());
-    resources = new Resources(env.getFiler(), env.getOptions().get(Options.RESOURCES_DIR));
+    resources =
+        new Resources(
+            env.getFiler(),
+            reporter,
+            env.getOptions().get(Options.RESOURCES_DIR),
+            isRunningOnEclipse(env),
+            isDebug(env));
     options = new Options(env.getOptions(), resources);
     initialized = true;
+  }
+
+  private boolean isRunningOnEclipse(ProcessingEnvironment env) {
+    var envClassName = env.getClass().getName();
+    var unitTest = env.getOptions().get(Options.TEST_UNIT);
+    var integrationTest = env.getOptions().get(Options.TEST_INTEGRATION);
+    return envClassName.startsWith("org.eclipse.")
+        && !Boolean.parseBoolean(unitTest)
+        && !Boolean.parseBoolean(integrationTest);
+  }
+
+  private boolean isDebug(ProcessingEnvironment env) {
+    var debug = env.getOptions().get(Options.DEBUG);
+    return Boolean.parseBoolean(debug);
   }
 
   public RoundContext createRoundContext(

--- a/doma-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/doma-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,8 +1,1 @@
-org.seasar.doma.internal.apt.processor.DomainProcessor,isolating
-org.seasar.doma.internal.apt.processor.DataTypeProcessor,isolating
-org.seasar.doma.internal.apt.processor.ExternalDomainProcessor,isolating
-org.seasar.doma.internal.apt.processor.DomainConvertersProcessor,isolating
-org.seasar.doma.internal.apt.processor.EmbeddableProcessor,isolating
-org.seasar.doma.internal.apt.processor.EntityProcessor,isolating
-org.seasar.doma.internal.apt.processor.DaoProcessor,isolating
-org.seasar.doma.internal.apt.processor.ScopeProcessor,isolating
+org.seasar.doma.internal.apt.DomaProcessor,isolating

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/AptinaTestCase.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/AptinaTestCase.java
@@ -111,8 +111,9 @@ class AptinaTestCase
 
   @Override
   public void beforeEach(ExtensionContext context) {
+    addOption("-Adoma.test.unit=true");
     addSourcePath("src/test/java");
-    addOption("-Adoma.resources.dir=src/test/resources");
+    addSourcePath("src/test/resources");
     charset = StandardCharsets.UTF_8;
     locale = Locale.ENGLISH;
     TimeZone.setDefault(TimeZone.getTimeZone("GMT+9"));

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/aggregate/AggregateStrategyProcessorTest.java
@@ -40,8 +40,6 @@ class AggregateStrategyProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
-
     addProcessor(new DomaProcessor());
     addCompilationUnit(Emp.class);
     addCompilationUnit(Dept.class);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/DaoProcessorTest.java
@@ -48,8 +48,6 @@ class DaoProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
-
     addProcessor(new DomaProcessor());
 
     // Add the dependent entities

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/aggregate/AggregateStrategyTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/aggregate/AggregateStrategyTest.java
@@ -41,8 +41,6 @@ class AggregateStrategyTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
-
     addProcessor(new DomaProcessor());
 
     // Add the dependent entities

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/experimental/SqlTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/dao/experimental/SqlTest.java
@@ -40,7 +40,6 @@ class SqlTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
   }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/DomainConvertersProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/DomainConvertersProcessorTest.java
@@ -28,7 +28,6 @@ class DomainConvertersProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
   }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/DomainProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/DomainProcessorTest.java
@@ -41,7 +41,6 @@ class DomainProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
   }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/domain/ExternalDomainProcessorTest.java
@@ -43,7 +43,6 @@ class ExternalDomainProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
   }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/EmbeddableProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/EmbeddableProcessorTest.java
@@ -42,7 +42,6 @@ class EmbeddableProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
   }
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/EntityProcessorTest.java
@@ -43,7 +43,6 @@ class EntityProcessorTest extends AbstractCompilerTest {
   @BeforeEach
   void beforeEach() {
     addOption(
-        "-Adoma.test=true",
         "-Adoma.domain.converters=org.seasar.doma.internal.apt.processor.entity.DomainConvertersProvider");
     addProcessor(new DomaProcessor());
 

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/association/EntityProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/entity/association/EntityProcessorTest.java
@@ -40,7 +40,6 @@ class EntityProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
     addCompilationUnit(Emp.class);
     addCompilationUnit(Dept.class);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/MetamodelOptionTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/MetamodelOptionTest.java
@@ -41,7 +41,6 @@ class MetamodelOptionTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addOption("-Adoma.metamodel.enabled=true");
     addOption("-Adoma.metamodel.prefix=" + PREFIX);
     addOption("-Adoma.metamodel.suffix=" + SUFFIX);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/MetamodelTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/MetamodelTest.java
@@ -40,7 +40,6 @@ class MetamodelTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(new DomaProcessor());
 
     // Add the dependent domains

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/ScopeTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/metamodel/ScopeTest.java
@@ -41,7 +41,6 @@ public class ScopeTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addOption("-Adoma.metamodel.enabled=true");
     addProcessor(new DomaProcessor());
   }

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/scope/ScopeProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/scope/ScopeProcessorTest.java
@@ -41,7 +41,6 @@ public class ScopeProcessorTest extends AbstractCompilerTest {
 
   @BeforeEach
   void beforeEach() {
-    addOption("-Adoma.test=true");
     addProcessor(
         new DomaProcessor() {
           @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,6 @@ kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.3" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 release = { id = "net.researchgate.release", version = "3.1.0" }
-doma-compile = { id = "org.domaframework.doma.compile", version = "3.0.1" }
+doma-compile = { id = "org.domaframework.doma.compile", version = "4.0.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 themrmilchmann-ecj = { id = "io.github.themrmilchmann.ecj", version = "0.2.0" }

--- a/integration-test-java-common/build.gradle.kts
+++ b/integration-test-java-common/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     }
 }
 
-val commonArgs = listOf<String>()
+val commonArgs = listOf("-Adoma.test.integration=true")
 
 // The processors are not automatically detected, so it must be explicitly specified.
 val ecjArgs = listOf(

--- a/integration-test-java/build.gradle.kts
+++ b/integration-test-java/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     }
 }
 
-val commonArgs = listOf<String>()
+val commonArgs = listOf("-Adoma.test.integration=true")
 
 // The processors are not automatically detected, so it must be explicitly specified.
 val ecjArgs = listOf(


### PR DESCRIPTION
### Summary

- Fixed incorrect configuration for Gradle's incremental annotation processing.
- Updated Doma Compile plugin to version 4.0.0, including configuration to read resource files from SOURCE_PATH.
- Added an integration test option to the Doma processor.
