### PR TITLE
Update Doma compile plugin to version 4.0.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ For Java projects:
 
 ```kotlin
 plugins {
-    id("org.domaframework.doma.compile") version "3.0.1"
+    id("org.domaframework.doma.compile") version "4.0.0"
 }
 
 dependencies {
@@ -153,7 +153,7 @@ For Kotlin projects, use doma-kotlin instead of doma-core and use kapt in place 
 
 ```kotlin
 plugins {
-  id("org.domaframework.doma.compile") version "3.0.1"
+  id("org.domaframework.doma.compile") version "4.0.0"
 }
 
 dependencies {


### PR DESCRIPTION
This pull request updates the Doma compile plugin to version 4.0.0.