### PR TITLE
Enhance Gradle build configuration in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Build
         run: >
           ./gradlew
+          --no-daemon
+          --no-build-cache
           -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
-          assemble check -x :doma-processor:check
+          clean assemble check -x :doma-processor:check
 
       - name: Upload reports
         if: failure()


### PR DESCRIPTION
Added `--no-daemon` and `--no-build-cache` options to the Gradle command in the CodeQL workflow for a clean and isolated build environment, improving reliability and consistency during analysis.