### PR TITLE
Improve the efficiency of type management in annotation processing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -300,7 +300,7 @@ configure(integrationTestProjects) {
         }
 
         register("testAll") {
-            dependsOn(h2, mysql, oracle, postgresql, sqlserver)
+            dependsOn(h2, mysql, oracle, postgresql, sqlite, sqlserver)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,10 +213,6 @@ configure(modularProjects) {
             useJUnitPlatform()
         }
 
-        build {
-            dependsOn("publishToMavenLocal")
-        }
-
         withType<Sign>().configureEach {
             onlyIf { isReleaseVersion }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,6 +246,13 @@ configure(integrationTestProjects) {
             options.encoding = encoding
         }
 
+        compileJava {
+            val ap: String by project
+            ap.split(",").map { it.trim() }.filter { it.isNotEmpty() }.map { "-A$it" }.forEach {
+                options.compilerArgs.add(it)
+            }
+        }
+
         compileTestJava {
             options.compilerArgs.addAll(listOf("-proc:none"))
         }

--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -472,8 +472,8 @@ public enum Message implements MessageResource {
   DOMA4089(
       "When you annotate the field with @Id or @Version, "
           + "you must not annotate the field with @Column(updatable=false) to the same field."),
-  DOMA4090("The annotation processor \"{0}\" starts processing for the element \"{1}\"."),
-  DOMA4091("The annotation processor \"{0}\" ends processing for the element \"{1}\"."),
+  DOMA4090("Starting processing of annotation \"{0}\" on element \"{1}\"."),
+  DOMA4091("Finished processing of annotation \"{0}\" on element \"{1}\"."),
   DOMA4092(
       "Failed to verify the SQL template \"{0}\" on line {2} at column {3}. The cause is as follows: {4} SQL=[{1}]."),
   DOMA4093("The field annotated with @Version must be numeric."),

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
@@ -109,7 +109,7 @@ public class DomaProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    if (roundEnv.processingOver()) {
+    if (roundEnv.processingOver() || annotations.isEmpty()) {
       return true;
     }
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -60,7 +60,7 @@ public class MoreElements implements Elements {
 
   private final Map<String, TypeElement> typeElementCache = new HashMap<>(64);
 
-  public MoreElements(ProcessingContext ctx, Elements elementUtils) {
+  public MoreElements(RoundContext ctx, Elements elementUtils) {
     assertNotNull(ctx, elementUtils);
     this.ctx = ctx;
     this.elementUtils = elementUtils;
@@ -72,7 +72,6 @@ public class MoreElements implements Elements {
     return elementUtils.getPackageElement(name);
   }
 
-  // delegate to elementUtils
   @Override
   public TypeElement getTypeElement(CharSequence canonicalName) {
     assertNotNull(canonicalName);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -58,11 +58,13 @@ import org.seasar.doma.internal.util.Zip;
 
 public class MoreElements implements Elements {
 
-  private final ProcessingContext ctx;
+  private static final Object NOT_FOUND = new Object();
+
+  private final RoundContext ctx;
 
   private final Elements elementUtils;
 
-  private final Map<String, TypeElement> typeElementCache = new HashMap<>(64);
+  private final Map<String, Object> typeElementCache = new HashMap<>(256);
 
   public MoreElements(RoundContext ctx, Elements elementUtils) {
     assertNotNull(ctx, elementUtils);
@@ -88,7 +90,14 @@ public class MoreElements implements Elements {
   }
 
   private TypeElement getTypeElementInternal(String canonicalName) {
-    return typeElementCache.computeIfAbsent(canonicalName, elementUtils::getTypeElement);
+    var typeElement =
+        typeElementCache.computeIfAbsent(
+            canonicalName,
+            it -> {
+              var result = elementUtils.getTypeElement(it);
+              return result == null ? NOT_FOUND : result;
+            });
+    return typeElement == NOT_FOUND ? null : (TypeElement) typeElement;
   }
 
   // delegate to elementUtils

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreElements.java
@@ -28,17 +28,21 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import javax.lang.model.AnnotatedConstruct;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.Parameterizable;
+import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
@@ -165,6 +169,84 @@ public class MoreElements implements Elements {
   @Override
   public boolean isFunctionalInterface(TypeElement type) {
     return elementUtils.isFunctionalInterface(type);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public PackageElement getPackageElement(ModuleElement module, CharSequence name) {
+    return elementUtils.getPackageElement(module, name);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Set<? extends PackageElement> getAllPackageElements(CharSequence name) {
+    return elementUtils.getAllPackageElements(name);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public TypeElement getTypeElement(ModuleElement module, CharSequence name) {
+    return elementUtils.getTypeElement(module, name);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Set<? extends TypeElement> getAllTypeElements(CharSequence name) {
+    return elementUtils.getAllTypeElements(name);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public ModuleElement getModuleElement(CharSequence name) {
+    return elementUtils.getModuleElement(name);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Set<? extends ModuleElement> getAllModuleElements() {
+    return elementUtils.getAllModuleElements();
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Origin getOrigin(Element e) {
+    return elementUtils.getOrigin(e);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Origin getOrigin(AnnotatedConstruct c, AnnotationMirror a) {
+    return elementUtils.getOrigin(c, a);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public Origin getOrigin(ModuleElement m, ModuleElement.Directive directive) {
+    return elementUtils.getOrigin(m, directive);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public boolean isBridge(ExecutableElement e) {
+    return elementUtils.isBridge(e);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public ModuleElement getModuleOf(Element e) {
+    return elementUtils.getModuleOf(e);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public boolean isAutomaticModule(ModuleElement module) {
+    return elementUtils.isAutomaticModule(module);
+  }
+
+  // delegate to elementUtils
+  @Override
+  public RecordComponentElement recordComponentFor(ExecutableElement accessor) {
+    return elementUtils.recordComponentFor(accessor);
   }
 
   public String getParameterName(VariableElement variableElement) {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/MoreTypes.java
@@ -43,11 +43,11 @@ import javax.lang.model.util.Types;
 
 public class MoreTypes implements Types {
 
-  private final ProcessingContext ctx;
+  private final RoundContext ctx;
 
   private final Types typeUtils;
 
-  public MoreTypes(ProcessingContext ctx, Types typeUtils) {
+  public MoreTypes(RoundContext ctx, Types typeUtils) {
     assertNotNull(ctx, typeUtils);
     this.ctx = ctx;
     this.typeUtils = typeUtils;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
@@ -18,14 +18,14 @@ package org.seasar.doma.internal.apt;
 import java.util.Objects;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 
 public class ProcessingContext {
 
   private final ProcessingEnvironment env;
 
   private boolean initialized;
-  private MoreElements moreElements;
-  private MoreTypes moreTypes;
   private Options options;
   private Reporter reporter;
   private Resources resources;
@@ -38,8 +38,6 @@ public class ProcessingContext {
     if (initialized) {
       throw new AptIllegalStateException("already initialized");
     }
-    moreElements = new MoreElements(this, env.getElementUtils());
-    moreTypes = new MoreTypes(this, env.getTypeUtils());
     reporter = new Reporter(env.getMessager());
     resources =
         new Resources(
@@ -73,16 +71,6 @@ public class ProcessingContext {
     return roundContext;
   }
 
-  public MoreElements getMoreElements() {
-    assertInitialized();
-    return moreElements;
-  }
-
-  public MoreTypes getMoreTypes() {
-    assertInitialized();
-    return moreTypes;
-  }
-
   public Options getOptions() {
     assertInitialized();
     return options;
@@ -96,6 +84,16 @@ public class ProcessingContext {
   public Resources getResources() {
     assertInitialized();
     return resources;
+  }
+
+  public Elements getElements() {
+    assertInitialized();
+    return env.getElementUtils();
+  }
+
+  public Types getTypes() {
+    assertInitialized();
+    return env.getTypeUtils();
   }
 
   private void assertInitialized() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/RoundContext.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/RoundContext.java
@@ -33,6 +33,8 @@ public class RoundContext {
   private final RoundEnvironment roundEnvironment;
   private final List<ExternalDomainMeta> externalDomainMetaList = new ArrayList<>();
   private boolean initialized;
+  private MoreElements moreElements;
+  private MoreTypes moreTypes;
   private Annotations annotations;
   private Declarations declarations;
   private CtTypes ctTypes;
@@ -47,6 +49,8 @@ public class RoundContext {
     if (initialized) {
       throw new AptIllegalStateException("already initialized");
     }
+    moreElements = new MoreElements(this, processingContext.getElements());
+    moreTypes = new MoreTypes(this, processingContext.getTypes());
     annotations = new Annotations(this);
     declarations = new Declarations(this);
     ctTypes = new CtTypes(this);
@@ -61,12 +65,12 @@ public class RoundContext {
 
   public MoreElements getMoreElements() {
     assertInitialized();
-    return processingContext.getMoreElements();
+    return moreElements;
   }
 
   public MoreTypes getMoreTypes() {
     assertInitialized();
-    return processingContext.getMoreTypes();
+    return moreTypes;
   }
 
   public Options getOptions() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtType.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtType.java
@@ -23,7 +23,6 @@ import org.seasar.doma.internal.apt.RoundContext;
 import org.seasar.doma.internal.apt.generator.Code;
 import org.seasar.doma.internal.jdbc.scalar.BasicScalarSuppliers;
 import org.seasar.doma.internal.jdbc.scalar.OptionalBasicScalarSuppliers;
-import org.seasar.doma.internal.util.Pair;
 import org.seasar.doma.internal.wrapper.WrapperSuppliers;
 
 public class BasicCtType extends AbstractCtType {
@@ -32,12 +31,11 @@ public class BasicCtType extends AbstractCtType {
 
   private final TypeElement wrapperTypeElement;
 
-  BasicCtType(
-      RoundContext ctx, TypeMirror type, Pair<TypeElement, TypeMirror> wrapperElementAndType) {
+  BasicCtType(RoundContext ctx, TypeMirror type, TypeElement wrapperTypeElement) {
     super(ctx, type);
-    assertNotNull(wrapperElementAndType);
+    assertNotNull(wrapperTypeElement);
     this.boxedType = ctx.getMoreTypes().boxIfPrimitive(type);
-    this.wrapperTypeElement = wrapperElementAndType.fst;
+    this.wrapperTypeElement = wrapperTypeElement;
   }
 
   public TypeMirror getBoxedType() {

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtTypeFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtTypeFactory.java
@@ -225,7 +225,7 @@ class BasicCtTypeFactory {
     return new BasicCtType(ctx, type, wrapperTypeElement);
   }
 
-  BasicCtType newCtType(TypeMirror type) {
+  BasicCtType newBasicCtType(TypeMirror type) {
     return type.accept(new BasicCtTypeResolver(), null);
   }
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtTypeFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/BasicCtTypeFactory.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.cttype;
+
+import static org.seasar.doma.internal.util.AssertionUtil.assertTrue;
+import static org.seasar.doma.internal.util.AssertionUtil.assertUnreachable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Objects;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleTypeVisitor14;
+import org.seasar.doma.internal.apt.RoundContext;
+import org.seasar.doma.wrapper.ArrayWrapper;
+import org.seasar.doma.wrapper.BigDecimalWrapper;
+import org.seasar.doma.wrapper.BigIntegerWrapper;
+import org.seasar.doma.wrapper.BlobWrapper;
+import org.seasar.doma.wrapper.BooleanWrapper;
+import org.seasar.doma.wrapper.ByteWrapper;
+import org.seasar.doma.wrapper.BytesWrapper;
+import org.seasar.doma.wrapper.ClobWrapper;
+import org.seasar.doma.wrapper.DateWrapper;
+import org.seasar.doma.wrapper.DoubleWrapper;
+import org.seasar.doma.wrapper.EnumWrapper;
+import org.seasar.doma.wrapper.FloatWrapper;
+import org.seasar.doma.wrapper.IntegerWrapper;
+import org.seasar.doma.wrapper.LocalDateTimeWrapper;
+import org.seasar.doma.wrapper.LocalDateWrapper;
+import org.seasar.doma.wrapper.LocalTimeWrapper;
+import org.seasar.doma.wrapper.LongWrapper;
+import org.seasar.doma.wrapper.NClobWrapper;
+import org.seasar.doma.wrapper.ObjectWrapper;
+import org.seasar.doma.wrapper.PrimitiveBooleanWrapper;
+import org.seasar.doma.wrapper.PrimitiveByteWrapper;
+import org.seasar.doma.wrapper.PrimitiveDoubleWrapper;
+import org.seasar.doma.wrapper.PrimitiveFloatWrapper;
+import org.seasar.doma.wrapper.PrimitiveIntWrapper;
+import org.seasar.doma.wrapper.PrimitiveLongWrapper;
+import org.seasar.doma.wrapper.PrimitiveShortWrapper;
+import org.seasar.doma.wrapper.SQLXMLWrapper;
+import org.seasar.doma.wrapper.ShortWrapper;
+import org.seasar.doma.wrapper.StringWrapper;
+import org.seasar.doma.wrapper.TimeWrapper;
+import org.seasar.doma.wrapper.TimestampWrapper;
+import org.seasar.doma.wrapper.UtilDateWrapper;
+
+class BasicCtTypeFactory {
+
+  private final RoundContext ctx;
+
+  BasicCtTypeFactory(RoundContext ctx) {
+    this.ctx = Objects.requireNonNull(ctx);
+  }
+
+  BasicCtType newPrimitiveBooleanCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.BOOLEAN);
+    return newBasicCtType(type, PrimitiveBooleanWrapper.class);
+  }
+
+  BasicCtType newPrimitiveByteCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.BYTE);
+    return newBasicCtType(type, PrimitiveByteWrapper.class);
+  }
+
+  BasicCtType newPrimitiveDoubleCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.DOUBLE);
+    return newBasicCtType(type, PrimitiveDoubleWrapper.class);
+  }
+
+  BasicCtType newPrimitiveFloatCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.FLOAT);
+    return newBasicCtType(type, PrimitiveFloatWrapper.class);
+  }
+
+  BasicCtType newPrimitiveIntCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.INT);
+    return newBasicCtType(type, PrimitiveIntWrapper.class);
+  }
+
+  BasicCtType newPrimitiveLongCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.LONG);
+    return newBasicCtType(type, PrimitiveLongWrapper.class);
+  }
+
+  BasicCtType newPrimitiveShortCtType(TypeMirror type) {
+    assertTrue(type.getKind() == TypeKind.SHORT);
+    return newBasicCtType(type, PrimitiveShortWrapper.class);
+  }
+
+  BasicCtType newArrayCtType(TypeMirror type) {
+    return newBasicCtType(type, ArrayWrapper.class);
+  }
+
+  BasicCtType newBigDecimalCtType(TypeMirror type) {
+    return newBasicCtType(type, BigDecimalWrapper.class);
+  }
+
+  BasicCtType newBigIntegerCtType(TypeMirror type) {
+    return newBasicCtType(type, BigIntegerWrapper.class);
+  }
+
+  BasicCtType newBlobCtType(TypeMirror type) {
+    return newBasicCtType(type, BlobWrapper.class);
+  }
+
+  BasicCtType newBooleanCtType(TypeMirror type) {
+    return newBasicCtType(type, BooleanWrapper.class);
+  }
+
+  BasicCtType newByteCtType(TypeMirror type) {
+    return newBasicCtType(type, ByteWrapper.class);
+  }
+
+  BasicCtType newBytesCtType(TypeMirror type) {
+    return newBasicCtType(type, BytesWrapper.class);
+  }
+
+  BasicCtType newClobCtType(TypeMirror type) {
+    return newBasicCtType(type, ClobWrapper.class);
+  }
+
+  BasicCtType newDateCtType(TypeMirror type) {
+    return newBasicCtType(type, DateWrapper.class);
+  }
+
+  BasicCtType newDoubleCtType(TypeMirror type) {
+    return newBasicCtType(type, DoubleWrapper.class);
+  }
+
+  BasicCtType newEnumCtType(TypeMirror type) {
+    return newBasicCtType(type, EnumWrapper.class);
+  }
+
+  BasicCtType newFloatCtType(TypeMirror type) {
+    return newBasicCtType(type, FloatWrapper.class);
+  }
+
+  BasicCtType newIntegerCtType(TypeMirror type) {
+    return newBasicCtType(type, IntegerWrapper.class);
+  }
+
+  BasicCtType newLocalDateCtType(TypeMirror type) {
+    return newBasicCtType(type, LocalDateWrapper.class);
+  }
+
+  BasicCtType newLocalDateTimeCtType(TypeMirror type) {
+    return newBasicCtType(type, LocalDateTimeWrapper.class);
+  }
+
+  BasicCtType newLocalTimeCtType(TypeMirror type) {
+    return newBasicCtType(type, LocalTimeWrapper.class);
+  }
+
+  BasicCtType newLongCtType(TypeMirror type) {
+    return newBasicCtType(type, LongWrapper.class);
+  }
+
+  BasicCtType newNClobCtType(TypeMirror type) {
+    return newBasicCtType(type, NClobWrapper.class);
+  }
+
+  BasicCtType newObjectCtType(TypeMirror type) {
+    return newBasicCtType(type, ObjectWrapper.class);
+  }
+
+  BasicCtType newShortCtType(TypeMirror type) {
+    return newBasicCtType(type, ShortWrapper.class);
+  }
+
+  BasicCtType newStringCtType(TypeMirror type) {
+    return newBasicCtType(type, StringWrapper.class);
+  }
+
+  BasicCtType newSQLXMLCtType(TypeMirror type) {
+    return newBasicCtType(type, SQLXMLWrapper.class);
+  }
+
+  BasicCtType newTimeCtType(TypeMirror type) {
+    return newBasicCtType(type, TimeWrapper.class);
+  }
+
+  BasicCtType newTimestampCtType(TypeMirror type) {
+    return newBasicCtType(type, TimestampWrapper.class);
+  }
+
+  BasicCtType newUtilDateCtType(TypeMirror type) {
+    return newBasicCtType(type, UtilDateWrapper.class);
+  }
+
+  private BasicCtType newBasicCtType(TypeMirror type, Class<?> wrapperType) {
+    var wrapperTypeElement = ctx.getMoreElements().getTypeElement(wrapperType);
+    if (wrapperTypeElement == null) {
+      return null;
+    }
+    return new BasicCtType(ctx, type, wrapperTypeElement);
+  }
+
+  BasicCtType newCtType(TypeMirror type) {
+    return type.accept(new BasicCtTypeResolver(), null);
+  }
+
+  private class BasicCtTypeResolver extends SimpleTypeVisitor14<BasicCtType, Void> {
+
+    @Override
+    public BasicCtType visitArray(ArrayType t, Void p) {
+      if (t.getComponentType().getKind() == TypeKind.BYTE) {
+        return newBytesCtType(t);
+      }
+      return null;
+    }
+
+    @Override
+    public BasicCtType visitDeclared(DeclaredType t, Void p) {
+      TypeElement typeElement = ctx.getMoreTypes().toTypeElement(t);
+      if (typeElement == null) {
+        return null;
+      }
+      if (typeElement.getKind() == ElementKind.ENUM) {
+        return newEnumCtType(t);
+      }
+      String name = typeElement.getQualifiedName().toString();
+      if (String.class.getName().equals(name)) {
+        return newStringCtType(t);
+      }
+      if (Boolean.class.getName().equals(name)) {
+        return newBooleanCtType(t);
+      }
+      if (Byte.class.getName().equals(name)) {
+        return newByteCtType(t);
+      }
+      if (Short.class.getName().equals(name)) {
+        return newShortCtType(t);
+      }
+      if (Integer.class.getName().equals(name)) {
+        return newIntegerCtType(t);
+      }
+      if (Long.class.getName().equals(name)) {
+        return newLongCtType(t);
+      }
+      if (Float.class.getName().equals(name)) {
+        return newFloatCtType(t);
+      }
+      if (Double.class.getName().equals(name)) {
+        return newDoubleCtType(t);
+      }
+      if (Object.class.getName().equals(name)) {
+        return newObjectCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, BigDecimal.class)) {
+        return newBigDecimalCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, BigInteger.class)) {
+        return newBigIntegerCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Time.class)) {
+        return newTimeCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Timestamp.class)) {
+        return newTimestampCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Date.class)) {
+        return newDateCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, java.util.Date.class)) {
+        return newUtilDateCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, LocalTime.class)) {
+        return newLocalTimeCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, LocalDateTime.class)) {
+        return newLocalDateTimeCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, LocalDate.class)) {
+        return newLocalDateCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Array.class)) {
+        return newArrayCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Blob.class)) {
+        return newBlobCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, NClob.class)) {
+        return newNClobCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, Clob.class)) {
+        return newClobCtType(t);
+      }
+      if (ctx.getMoreTypes().isAssignableWithErasure(t, SQLXML.class)) {
+        return newSQLXMLCtType(t);
+      }
+      return null;
+    }
+
+    @Override
+    public BasicCtType visitPrimitive(PrimitiveType t, Void p) {
+      return switch (t.getKind()) {
+        case BOOLEAN -> newPrimitiveBooleanCtType(t);
+        case BYTE -> newPrimitiveByteCtType(t);
+        case SHORT -> newPrimitiveShortCtType(t);
+        case INT -> newPrimitiveIntCtType(t);
+        case LONG -> newPrimitiveLongCtType(t);
+        case FLOAT -> newPrimitiveFloatCtType(t);
+        case DOUBLE -> newPrimitiveDoubleCtType(t);
+        case CHAR -> null;
+        default -> assertUnreachable();
+      };
+    }
+  }
+}

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -138,7 +138,6 @@ public class CtTypes {
           this::newCollectorCtType,
           this::newReferenceCtType,
           this::newBiFunctionCtType,
-          this::newBiConsumerCtType,
           this::newPreparedSqlCtType,
           this::newConfigCtType,
           this::newResultCtType,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/CtTypes.java
@@ -255,7 +255,7 @@ public class CtTypes {
     return new ConfigCtType(ctx, type);
   }
 
-  public DomainCtType newDomainCtType(TypeMirror type) {
+  private DomainCtType newDomainCtType(TypeMirror type) {
     assertNotNull(type);
 
     if (type.getKind() == TypeKind.ARRAY) {
@@ -524,7 +524,7 @@ public class CtTypes {
     return new FunctionCtType(ctx, type, targetCtType, returnCtType);
   }
 
-  public IterableCtType newIterableCtType(TypeMirror type) {
+  private IterableCtType newIterableCtType(TypeMirror type) {
     assertNotNull(type);
     DeclaredType declaredType = getSuperDeclaredType(type, Iterable.class);
     if (declaredType == null) {
@@ -535,7 +535,7 @@ public class CtTypes {
     return new IterableCtType(ctx, type, elementCtType);
   }
 
-  public ArrayCtType newArrayCtType(TypeMirror type) {
+  private ArrayCtType newArrayCtType(TypeMirror type) {
     assertNotNull(type);
     if (type.getKind() != TypeKind.ARRAY) {
       return null;

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/ExternalDomainCtTypeFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/ExternalDomainCtTypeFactory.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.cttype;
+
+import static java.util.stream.Collectors.toList;
+import static org.seasar.doma.internal.util.AssertionUtil.assertEquals;
+import static org.seasar.doma.internal.util.AssertionUtil.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.seasar.doma.internal.ClassNames;
+import org.seasar.doma.internal.apt.AptIllegalOptionException;
+import org.seasar.doma.internal.apt.RoundContext;
+import org.seasar.doma.internal.apt.meta.domain.ExternalDomainMeta;
+import org.seasar.doma.jdbc.domain.DomainConverter;
+import org.seasar.doma.jdbc.domain.DomainType;
+import org.seasar.doma.message.Message;
+
+public class ExternalDomainCtTypeFactory {
+  private final RoundContext ctx;
+
+  public ExternalDomainCtTypeFactory(RoundContext ctx) {
+    this.ctx = Objects.requireNonNull(ctx);
+  }
+
+  DomainCtType newDomainCtType(TypeMirror type) {
+    var valueType = getValueType(type);
+    if (valueType == null) {
+      return null;
+    }
+    var basicCtType = ctx.getCtTypes().newBasicCtType(valueType);
+    if (basicCtType == null) {
+      return null;
+    }
+    if (type.getKind() == TypeKind.ARRAY) {
+      return newDomainCtType(type, basicCtType, Collections.emptyList());
+    } else {
+      var typeArgCtTypes = getTypeArgCtTypes(type);
+      if (typeArgCtTypes == null) {
+        return null;
+      }
+      return newDomainCtType(type, basicCtType, typeArgCtTypes);
+    }
+  }
+
+  private TypeMirror getValueType(TypeMirror domainType) {
+    var valueType = getValueTypeFromOptions(domainType);
+    if (valueType != null) {
+      return valueType;
+    }
+    valueType = getValueTypeFromRoundContext(domainType);
+    if (valueType != null) {
+      return valueType;
+    }
+    return getValueTypeFromCompiledMetadata(domainType);
+  }
+
+  private TypeMirror getValueTypeFromOptions(TypeMirror domainType) {
+    var csv = ctx.getOptions().getDomainConverters();
+    if (csv != null) {
+      for (String value : csv.split(",")) {
+        var className = value.trim();
+        if (className.isEmpty()) {
+          continue;
+        }
+        var convertersProviderElement =
+            ctx.getMoreElements().getTypeElementFromBinaryName(className);
+        if (convertersProviderElement == null) {
+          throw new AptIllegalOptionException(Message.DOMA4200.getMessage(className));
+        }
+        var convertersMirror =
+            ctx.getAnnotations().newDomainConvertersAnnot(convertersProviderElement);
+        if (convertersMirror == null) {
+          throw new AptIllegalOptionException(Message.DOMA4201.getMessage(className));
+        }
+        for (var converterType : convertersMirror.getValueValue()) {
+          // converterType does not contain adequate information in
+          // eclipse incremental compile, so reload type
+          converterType = reloadTypeMirror(converterType);
+          if (converterType == null) {
+            continue;
+          }
+          var argTypes = getConverterArgTypes(converterType);
+          if (argTypes == null
+              || !ctx.getMoreTypes().isSameTypeWithErasure(domainType, argTypes[0])) {
+            continue;
+          }
+          return argTypes[1];
+        }
+      }
+    }
+    return null;
+  }
+
+  private TypeMirror reloadTypeMirror(TypeMirror typeMirror) {
+    var typeElement = ctx.getMoreTypes().toTypeElement(typeMirror);
+    if (typeElement == null) {
+      return null;
+    }
+    typeElement = ctx.getMoreElements().getTypeElement(typeElement.getQualifiedName());
+    if (typeElement == null) {
+      return null;
+    }
+    return typeElement.asType();
+  }
+
+  private TypeMirror[] getConverterArgTypes(TypeMirror typeMirror) {
+    for (var supertype : ctx.getMoreTypes().directSupertypes(typeMirror)) {
+      if (!ctx.getMoreTypes().isAssignableWithErasure(supertype, DomainConverter.class)) {
+        continue;
+      }
+      if (ctx.getMoreTypes().isSameTypeWithErasure(supertype, DomainConverter.class)) {
+        var declaredType = ctx.getMoreTypes().toDeclaredType(supertype);
+        assertNotNull(declaredType);
+        var args = declaredType.getTypeArguments();
+        assertEquals(2, args.size());
+        return new TypeMirror[] {args.get(0), args.get(1)};
+      }
+      var argTypes = getConverterArgTypes(supertype);
+      if (argTypes != null) {
+        return argTypes;
+      }
+    }
+    return null;
+  }
+
+  private TypeMirror getValueTypeFromRoundContext(TypeMirror domainType) {
+    return ctx.getExternalDomainMetaList().stream()
+        .filter(it -> ctx.getMoreTypes().isSameTypeWithErasure(it.asType(), domainType))
+        .findFirst()
+        .map(ExternalDomainMeta::getValueType)
+        .orElse(null);
+  }
+
+  private TypeMirror getValueTypeFromCompiledMetadata(TypeMirror domainType) {
+    var domainTypeElement = ctx.getMoreTypes().toTypeElement(domainType);
+    if (domainTypeElement == null) {
+      return null;
+    }
+    var className = ClassNames.newExternalDomainTypeClassName(domainTypeElement.getQualifiedName());
+    var externalDomainMetadataElement = ctx.getMoreElements().getTypeElement(className);
+    if (externalDomainMetadataElement == null) {
+      return null;
+    }
+    var argTypes = getDomainTypeArgTypes(externalDomainMetadataElement.asType());
+    if (argTypes == null) {
+      return null;
+    }
+    return argTypes[0];
+  }
+
+  private TypeMirror[] getDomainTypeArgTypes(TypeMirror typeMirror) {
+    for (var supertype : ctx.getMoreTypes().directSupertypes(typeMirror)) {
+      if (!ctx.getMoreTypes().isAssignableWithErasure(supertype, DomainType.class)) {
+        continue;
+      }
+      if (ctx.getMoreTypes().isSameTypeWithErasure(supertype, DomainType.class)) {
+        var declaredType = ctx.getMoreTypes().toDeclaredType(supertype);
+        assertNotNull(declaredType);
+        var args = declaredType.getTypeArguments();
+        assertEquals(2, args.size());
+        return new TypeMirror[] {args.get(0), args.get(1)};
+      }
+      var argTypes = getDomainTypeArgTypes(supertype);
+      if (argTypes != null) {
+        return argTypes;
+      }
+    }
+    return null;
+  }
+
+  private List<CtType> getTypeArgCtTypes(TypeMirror type) {
+    var typeElement = ctx.getMoreTypes().toTypeElement(type);
+    if (typeElement == null) {
+      return null;
+    }
+    var declaredType = ctx.getMoreTypes().toDeclaredType(type);
+    if (declaredType == null) {
+      return null;
+    }
+    var typeArgs = declaredType.getTypeArguments().iterator();
+    return typeElement.getTypeParameters().stream()
+        .map(
+            __ ->
+                typeArgs.hasNext()
+                    ? ctx.getCtTypes().newCtType(typeArgs.next())
+                    : ctx.getCtTypes().newNoneCtType())
+        .collect(toList());
+  }
+
+  private DomainCtType newDomainCtType(
+      TypeMirror type, BasicCtType typeElement, List<CtType> typeArgCtTypes) {
+    var name = ctx.getNames().createExternalDomainName(type);
+    var typeClassName = ClassNames.newExternalDomainTypeClassName(name);
+    return new DomainCtType(ctx, type, typeElement, typeArgCtTypes, typeClassName);
+  }
+}

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/InternalDomainCtTypeFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/InternalDomainCtTypeFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.cttype;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Objects;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.seasar.doma.DataType;
+import org.seasar.doma.Domain;
+import org.seasar.doma.internal.ClassNames;
+import org.seasar.doma.internal.apt.AptIllegalStateException;
+import org.seasar.doma.internal.apt.RoundContext;
+
+class InternalDomainCtTypeFactory {
+  private final RoundContext ctx;
+
+  InternalDomainCtTypeFactory(RoundContext ctx) {
+    this.ctx = Objects.requireNonNull(ctx);
+  }
+
+  DomainCtType newDomainCtType(TypeMirror type, TypeElement typeElement, Domain domain) {
+    var valueType = getValueType(domain);
+    return newDomainCtType(type, typeElement, valueType);
+  }
+
+  private TypeMirror getValueType(Domain domain) {
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      domain.valueType();
+    } catch (MirroredTypeException e) {
+      return e.getTypeMirror();
+    }
+    throw new AptIllegalStateException("unreachable.");
+  }
+
+  DomainCtType newDataTypeCtType(TypeMirror type, TypeElement typeElement, DataType dataType) {
+    var valueType = getValueType(typeElement, dataType);
+    return newDomainCtType(type, typeElement, valueType);
+  }
+
+  private TypeMirror getValueType(TypeElement typeElement, DataType dataType) {
+    var constructors =
+        ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
+            .filter(c -> !c.getModifiers().contains(Modifier.PRIVATE))
+            .filter(c -> c.getParameters().size() == 1)
+            .toList();
+    if (constructors.size() != 1) {
+      throw new AptIllegalStateException(
+          String.format("%s : %d", typeElement.getQualifiedName(), constructors.size()));
+    }
+    var constructor = constructors.iterator().next();
+    var param = constructor.getParameters().iterator().next();
+    if (param == null) {
+      throw new AptIllegalStateException("param is null");
+    }
+    return param.asType();
+  }
+
+  private DomainCtType newDomainCtType(
+      TypeMirror type, TypeElement typeElement, TypeMirror valueType) {
+    if (valueType == null) {
+      return null;
+    }
+    var basicCtType = ctx.getCtTypes().newBasicCtType(valueType);
+    if (basicCtType == null) {
+      return null;
+    }
+    var declaredType = ctx.getMoreTypes().toDeclaredType(type);
+    if (declaredType == null) {
+      return null;
+    }
+    var typeArgs = declaredType.getTypeArguments().iterator();
+    var typeArgCtTypes =
+        typeElement.getTypeParameters().stream()
+            .map(
+                __ ->
+                    typeArgs.hasNext()
+                        ? ctx.getCtTypes().newCtType(typeArgs.next())
+                        : ctx.getCtTypes().newNoneCtType())
+            .collect(toList());
+    var binaryName = ctx.getMoreElements().getBinaryName(typeElement);
+    var typeClassName = ClassNames.newDomainTypeClassName(binaryName);
+    return new DomainCtType(ctx, type, basicCtType, typeArgCtTypes, typeClassName);
+  }
+}

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/InternalDomainCtTypeFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/cttype/InternalDomainCtTypeFactory.java
@@ -15,8 +15,6 @@
  */
 package org.seasar.doma.internal.apt.cttype;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.Objects;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -87,15 +85,7 @@ class InternalDomainCtTypeFactory {
     if (declaredType == null) {
       return null;
     }
-    var typeArgs = declaredType.getTypeArguments().iterator();
-    var typeArgCtTypes =
-        typeElement.getTypeParameters().stream()
-            .map(
-                __ ->
-                    typeArgs.hasNext()
-                        ? ctx.getCtTypes().newCtType(typeArgs.next())
-                        : ctx.getCtTypes().newNoneCtType())
-            .collect(toList());
+    var typeArgCtTypes = ctx.getCtTypes().getAllTypeArguments(typeElement, declaredType);
     var binaryName = ctx.getMoreElements().getBinaryName(typeElement);
     var typeClassName = ClassNames.newDomainTypeClassName(binaryName);
     return new DomainCtType(ctx, type, basicCtType, typeArgCtTypes, typeClassName);

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ElementProcessorSupport.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/processor/ElementProcessorSupport.java
@@ -83,7 +83,9 @@ class ElementProcessorSupport<M extends ElementMeta> {
     }
     if (ctx.getOptions().isDebugEnabled()) {
       ctx.getReporter()
-          .debug(Message.DOMA4090, new Object[] {getClass().getName(), elementNameSupplier.get()});
+          .debug(
+              Message.DOMA4090,
+              new Object[] {supportedAnnotationType.getName(), elementNameSupplier.get()});
     }
     M result = null;
     try {
@@ -117,7 +119,9 @@ class ElementProcessorSupport<M extends ElementMeta> {
     }
     if (ctx.getOptions().isDebugEnabled()) {
       ctx.getReporter()
-          .debug(Message.DOMA4091, new Object[] {getClass().getName(), elementNameSupplier.get()});
+          .debug(
+              Message.DOMA4091,
+              new Object[] {supportedAnnotationType.getName(), elementNameSupplier.get()});
     }
     return result;
   }

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/MoreElementsTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/MoreElementsTest.java
@@ -103,7 +103,7 @@ class MoreElementsTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement method =
-                createMethodElement(testClass, "test", String.class, String.class);
+                createMethodElement(ctx, testClass, "test", String.class, String.class);
             Iterator<? extends VariableElement> parameters = method.getParameters().iterator();
             VariableElement p1 = parameters.next();
             VariableElement p2 = parameters.next();
@@ -162,7 +162,7 @@ class MoreElementsTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement method = createMethodElement(testClass, "beforeEach");
+            ExecutableElement method = createMethodElement(ctx, testClass, "beforeEach");
             AnnotationMirror annotationMirror =
                 ctx.getMoreElements().getAnnotationMirror(method, BeforeEach.class);
             assertNotNull(annotationMirror);
@@ -174,7 +174,7 @@ class MoreElementsTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement method = createMethodElement(testClass, "beforeEach");
+            ExecutableElement method = createMethodElement(ctx, testClass, "beforeEach");
             AnnotationMirror annotationMirror =
                 ctx.getMoreElements()
                     .getAnnotationMirror(method, "org.junit.jupiter.api.BeforeEach");
@@ -294,11 +294,12 @@ class MoreElementsTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             TypeElement typeElement = ctx.getMoreElements().getTypeElement(MyDao.class);
-            ExecutableElement doIt = createMethodElement(MyDao.class, "doIt");
+            ExecutableElement doIt = createMethodElement(ctx, MyDao.class, "doIt");
             assertTrue(ctx.getMoreElements().isVirtualDefaultMethod(typeElement, doIt));
-            ExecutableElement execute = createMethodElement(MyDao.class, "execute", String.class);
+            ExecutableElement execute =
+                createMethodElement(ctx, MyDao.class, "execute", String.class);
             assertTrue(ctx.getMoreElements().isVirtualDefaultMethod(typeElement, execute));
-            ExecutableElement run = createMethodElement(MyDao.class, "run", String.class);
+            ExecutableElement run = createMethodElement(ctx, MyDao.class, "run", String.class);
             assertFalse(ctx.getMoreElements().isVirtualDefaultMethod(typeElement, run));
           }
         });

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
@@ -74,7 +74,7 @@ public abstract class TestProcessor extends AbstractProcessor {
   protected abstract void run(RoundContext roundContext);
 
   protected ExecutableElement createMethodElement(
-      Class<?> clazz, String methodName, Class<?>... parameterClasses) {
+      RoundContext ctx, Class<?> clazz, String methodName, Class<?>... parameterClasses) {
     TypeElement typeElement = ctx.getMoreElements().getTypeElement(clazz);
     for (TypeElement t = typeElement;
         t != null && t.asType().getKind() != TypeKind.NONE;

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/TestProcessor.java
@@ -56,7 +56,7 @@ public abstract class TestProcessor extends AbstractProcessor {
 
   @Override
   public Set<String> getSupportedOptions() {
-    return Set.of(Options.RESOURCES_DIR);
+    return Set.of(Options.RESOURCES_DIR, Options.TEST_UNIT);
   }
 
   @Override

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/MyAnnotationProcessor.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/MyAnnotationProcessor.java
@@ -23,6 +23,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
+import org.seasar.doma.internal.apt.Options;
 import org.seasar.doma.internal.apt.ProcessingContext;
 import org.seasar.doma.internal.apt.meta.NullElementMeta;
 
@@ -49,6 +50,11 @@ public class MyAnnotationProcessor extends AbstractProcessor {
   @Override
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latest();
+  }
+
+  @Override
+  public Set<String> getSupportedOptions() {
+    return Set.of(Options.TEST_UNIT);
   }
 
   @Override

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/scope/ScopeProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/scope/ScopeProcessorTest.java
@@ -34,6 +34,7 @@ import org.seasar.doma.internal.apt.AbstractCompilerTest;
 import org.seasar.doma.internal.apt.AnnotationTypes;
 import org.seasar.doma.internal.apt.CompilationUnitsParameterResolver;
 import org.seasar.doma.internal.apt.DomaProcessor;
+import org.seasar.doma.internal.apt.Options;
 import org.seasar.doma.internal.apt.SimpleParameterResolver;
 import org.seasar.doma.message.Message;
 
@@ -46,6 +47,11 @@ public class ScopeProcessorTest extends AbstractCompilerTest {
           @Override
           public Set<String> getSupportedAnnotationTypes() {
             return Set.of(AnnotationTypes.SCOPE);
+          }
+
+          @Override
+          public Set<String> getSupportedOptions() {
+            return Set.of(Options.TEST_UNIT);
           }
         });
   }

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/BatchSqlValidatorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/BatchSqlValidatorTest.java
@@ -42,7 +42,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testEmbeddedVariable", String.class);
+                createMethodElement(ctx, target, "testEmbeddedVariable", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -67,7 +67,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testEmbeddedVariableSuppressed", String.class);
+                createMethodElement(ctx, target, "testEmbeddedVariableSuppressed", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -91,7 +91,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testIf");
+            ExecutableElement methodElement = createMethodElement(ctx, target, "testIf");
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -116,7 +116,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testIfSuppressed");
+            ExecutableElement methodElement = createMethodElement(ctx, target, "testIfSuppressed");
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -142,7 +142,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testIfAndEmbeddedVariable", String.class);
+                createMethodElement(ctx, target, "testIfAndEmbeddedVariable", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -171,7 +171,8 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testIfAndEmbeddedVariableSuppressed", String.class);
+                createMethodElement(
+                    ctx, target, "testIfAndEmbeddedVariableSuppressed", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -198,7 +199,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPopulate", String.class);
+                createMethodElement(ctx, target, "testPopulate", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =
@@ -223,7 +224,7 @@ class BatchSqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPopulate", String.class);
+                createMethodElement(ctx, target, "testPopulate", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             BatchSqlValidator validator =

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/ExpressionValidatorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/ExpressionValidatorTest.java
@@ -44,7 +44,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -71,7 +72,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -93,7 +95,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -115,7 +118,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -141,7 +145,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -163,7 +168,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -186,7 +192,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -208,7 +215,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -231,7 +239,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -258,7 +267,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -286,7 +296,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -309,7 +320,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -336,7 +348,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -364,7 +377,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -386,7 +400,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -413,7 +428,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(
@@ -436,7 +452,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(
@@ -459,7 +476,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap, "nonExistent");
@@ -486,7 +504,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap, "java.lang.String");
@@ -513,7 +532,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(
@@ -541,7 +561,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -568,7 +589,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -591,7 +613,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -614,7 +636,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -637,7 +659,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -660,7 +682,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -683,7 +705,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -706,7 +728,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -728,7 +750,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -751,7 +774,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -774,7 +797,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -797,7 +820,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -820,7 +843,7 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPerson", Person.class);
+                createMethodElement(ctx, target, "testPerson", Person.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -842,7 +865,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -865,7 +889,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -888,7 +913,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -910,7 +936,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -932,7 +959,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -954,7 +982,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -976,7 +1005,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -1003,7 +1033,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);
@@ -1025,7 +1056,8 @@ class ExpressionValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testEmp", Emp.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testEmp", Emp.class);
             Map<String, TypeMirror> parameterTypeMap = createParameterTypeMap(methodElement);
             ExpressionValidator validator =
                 new ExpressionValidator(ctx, methodElement, parameterTypeMap);

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/SqlValidatorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/validator/SqlValidatorTest.java
@@ -44,7 +44,8 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testTypeParameterResolution", CriteriaHolder.class);
+                createMethodElement(
+                    ctx, target, "testTypeParameterResolution", CriteriaHolder.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
 
@@ -71,7 +72,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable", String.class);
+                createMethodElement(ctx, target, "testBindVariable", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -95,7 +96,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable_list", List.class);
+                createMethodElement(ctx, target, "testBindVariable_list", List.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -119,7 +120,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable_array", String[].class);
+                createMethodElement(ctx, target, "testBindVariable_array", String[].class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -143,7 +144,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable", String.class);
+                createMethodElement(ctx, target, "testBindVariable", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -167,7 +168,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable_list", List.class);
+                createMethodElement(ctx, target, "testBindVariable_list", List.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -191,7 +192,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testBindVariable_array", String[].class);
+                createMethodElement(ctx, target, "testBindVariable_array", String[].class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -215,7 +216,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testEmbeddedVariable", String.class);
+                createMethodElement(ctx, target, "testEmbeddedVariable", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -238,7 +239,8 @@ class SqlValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testFor", List.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testFor", List.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -264,7 +266,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testFor_array", String[].class);
+                createMethodElement(ctx, target, "testFor_array", String[].class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -289,7 +291,8 @@ class SqlValidatorTest extends AbstractCompilerTest {
         new TestProcessor() {
           @Override
           protected void run(RoundContext ctx) {
-            ExecutableElement methodElement = createMethodElement(target, "testFor", List.class);
+            ExecutableElement methodElement =
+                createMethodElement(ctx, target, "testFor", List.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -321,7 +324,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testFor_notIterable", Iterator.class);
+                createMethodElement(ctx, target, "testFor_notIterable", Iterator.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -353,7 +356,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testFor_noTypeArgument", List.class);
+                createMethodElement(ctx, target, "testFor_noTypeArgument", List.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -385,7 +388,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testExpand", String.class);
+                createMethodElement(ctx, target, "testExpand", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -410,7 +413,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testExpand", String.class);
+                createMethodElement(ctx, target, "testExpand", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -441,7 +444,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPopulate", String.class);
+                createMethodElement(ctx, target, "testPopulate", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =
@@ -465,7 +468,7 @@ class SqlValidatorTest extends AbstractCompilerTest {
           @Override
           protected void run(RoundContext ctx) {
             ExecutableElement methodElement =
-                createMethodElement(target, "testPopulate", String.class);
+                createMethodElement(ctx, target, "testPopulate", String.class);
             LinkedHashMap<String, TypeMirror> parameterTypeMap =
                 createParameterTypeMap(methodElement);
             SqlValidator validator =

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ sqlserver.url=jdbc:tc:sqlserver:2019-CU28-ubuntu-20.04:///test?TC_DAEMON=true
 
 # javac or ecj
 compiler=javac
+# annotation processing options (CSV format)
+ap=


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings focused on annotation processing:

- Refactored `CtTypes` for modern and cleaner implementation, including making factory methods private.
- Introduced `ExternalDomainCtTypeFactory`, `InternalDomainCtTypeFactory`, and `BasicCtTypeFactory` for better type handling.
- Improved efficiency of `TypeMirror` to `CtType` conversion.
- Enhanced `MoreElements` and `MoreTypes` with better caching mechanisms and the implementation of `RoundContext` for improved processing context.
- Refined debug messages related to annotation processing.

