### PR TITLE
Fix: Correct @Suppress annotation placement guidance in DOMA4220

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -697,7 +697,7 @@ public enum Message implements MessageResource {
   DOMA4220(
       "The SQL template \"{0}\" that is not mapped to any methods was found. "
           + "Check the method names or the sqlFile elements of annotations. "
-          + "To suppress this warning, annotate the DAO method with @Suppress(messages = '{ Message.DOMA4220 }')."),
+          + "To suppress this warning, annotate the DAO interface with @Suppress(messages = '{ Message.DOMA4220 }')."),
   DOMA4221("A non-private constructor is required for the immutable entity class."),
   DOMA4222(
       "When the immutable entity class is a parameter type for the method annotated with @Insert, @Update, or @Delete, "


### PR DESCRIPTION
## Summary
- Fixed the DOMA4220 error message to correctly indicate that `@Suppress` should be placed on the DAO interface, not on individual methods

## Test plan
- [x] Verify the error message text is grammatically correct
- [x] Confirm that placing `@Suppress` on the DAO interface actually suppresses the warning (existing behavior, just documentation fix)

🤖 Generated with [Claude Code](https://claude.ai/code)