### PR TITLE
docs: update Doma-related version numbers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,9 +179,9 @@ gettext_uuid = False
 gettext_compact = False
 
 html_context = {
-    'doma_version': '3.9.1',
-    'doma_compile_version': '4.0.0',
-    'doma_codegen_version': '3.2.0',
+    'doma_version': '3.10.0',
+    'doma_compile_version': '4.0.2',
+    'doma_codegen_version': '3.2.1',
     'eclipse_apt_version': '4.3.0',
     'logback_classic_version': '1.5.18',
     'quarkus_doma_version': '1.0.4'


### PR DESCRIPTION
## Summary
- Updated Doma-related version numbers in the documentation configuration
- doma_version: 3.9.1 → 3.10.0
- doma_compile_version: 4.0.0 → 4.0.2
- doma_codegen_version: 3.2.0 → 3.2.1

## Test plan
- [ ] Documentation builds successfully
- [ ] Version numbers are correctly displayed in the generated documentation

🤖 Generated with [Claude Code](https://claude.ai/code)