### PR TITLE
docs: Update dependency versions in documentation dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We are testing against the following databases:
 
 | Database           |  version | status |
 |--------------------|---------:|:------:|
-| H2 Database        |    2.3.x | stable |
+| H2 Database        |  2.3.232 | stable |
 | MySQL v5           |      5.7 | stable |
 | MySQL v8           |   8.0.36 | stable |
 | Oracle Database XE |      21c | stable |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 google-java-format = { module = "com.google.googlejavaformat:google-java-format", version = "1.28.0" }
 ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version = "1.6.0" }
 
+quarkus-doma = { module = "io.quarkiverse.doma:quarkus-doma", version = "1.0.4"}
+
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
@@ -40,6 +42,8 @@ spotless = { id = "com.diffplug.spotless", version = "7.1.0" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 release = { id = "net.researchgate.release", version = "3.1.0" }
 doma-compile = { id = "org.domaframework.doma.compile", version = "4.0.2" }
+doma-codegen = { id = "org.domaframework.doma.codegen", version = "3.2.1" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 themrmilchmann-ecj = { id = "io.github.themrmilchmann.ecj", version = "0.2.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
+eclipse-apt = { id = "com.diffplug.eclipse.apt", version = "4.3.0" }


### PR DESCRIPTION
## Summary
- Refactored version replacement logic in build.gradle.kts to dynamically update versions from the version catalog
- Added support for updating documentation versions in conf.py
- Ensures all dependency versions in README and documentation stay in sync with actual dependencies

## Changes
- Created a generic `replace()` function with `Replacement` data class for cleaner code organization
- Extended version updates to include:
  - Doma plugin versions (compile, codegen)
  - Database versions (H2, SQLite)
  - Related dependency versions (Eclipse APT, Logback, Quarkus Doma)
- Added new version entries to libs.versions.toml for documentation purposes

## Test plan
- [ ] Verify that running `./gradlew replaceVersionInDocs` correctly updates all versions in README.md
- [ ] Verify that conf.py versions are updated correctly
- [ ] Ensure the build passes with `./gradlew build`
- [ ] Check that documentation builds correctly with the new versions

🤖 Generated with [Claude Code](https://claude.ai/code)