### PR TITLE
Fix missing validation for Optional type parameters in Embeddable properties

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EmbeddablePropertyMetaFactory.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/meta/entity/EmbeddablePropertyMetaFactory.java
@@ -85,7 +85,7 @@ class EmbeddablePropertyMetaFactory {
         throw new AptException(
             Message.DOMA4301, fieldElement, new Object[] {optionalCtType.getQualifiedName()});
       }
-      return null;
+      return optionalCtType.getElementCtType().accept(this, aVoid);
     }
 
     @Override

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/AptinaTestCase.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/AptinaTestCase.java
@@ -345,14 +345,16 @@ class AptinaTestCase
   @Override
   public void assertMessage(Message message) {
     assertCompiled();
+    var unmatchedMessages = new ArrayList<Message>();
     for (Diagnostic<? extends JavaFileObject> diagnostic : getDiagnostics()) {
       Message m = extractMessage(diagnostic);
       if (m == message) {
         // found
         return;
       }
+      unmatchedMessages.add(m);
     }
-    fail();
+    fail("unmatched messages: " + unmatchedMessages);
   }
 
   private Message extractMessage(Diagnostic<? extends JavaFileObject> diagnostic) {

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/EmbeddableProcessorTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/EmbeddableProcessorTest.java
@@ -154,7 +154,8 @@ class EmbeddableProcessorTest extends AbstractCompilerTest {
               LombokAllArgsConstructorAccess_none.class,
               Message.DOMA4427,
               "-Adoma.lombok.AllArgsConstructor=" + AllArgsConstructor.class.getName()),
-          invocationContext(Outer__illegalName.class, Message.DOMA4417));
+          invocationContext(Outer__illegalName.class, Message.DOMA4417),
+          invocationContext(IllegalOptionalProperty.class, Message.DOMA4298));
     }
 
     private TestTemplateInvocationContext invocationContext(

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/IllegalOptionalProperty.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/processor/embeddable/IllegalOptionalProperty.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Doma Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.seasar.doma.internal.apt.processor.embeddable;
+
+import java.net.URL;
+import java.util.Optional;
+import org.seasar.doma.Embeddable;
+
+@Embeddable
+public record IllegalOptionalProperty(Optional<URL> url) {}


### PR DESCRIPTION
## Summary
- Fixed a bug where validation logic for Optional type parameters in Embeddable properties was missing
- The processor now properly validates the wrapped type inside Optional instead of returning null
- Added comprehensive test case to verify the fix works correctly

## Test plan
- [x] Added new test case `IllegalOptionalProperty` to verify validation works
- [x] Updated `EmbeddableProcessorTest` to include the new test case
- [x] Enhanced error message reporting in `AptinaTestCase` for better debugging
- [x] All existing tests pass
- [x] Code formatting applied via Spotless

🤖 Generated with [Claude Code](https://claude.ai/code)