### PR TITLE
docs: Enable edit source link in Sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,6 +186,14 @@ gettext_uuid = False
 gettext_compact = False
 
 html_context = {
+    # "Edit Source" link
+    'display_github': True,
+    'github_user': 'domaframework',
+    'github_repo': 'doma',
+    'github_version': 'master',
+    'conf_py_path': '/docs/',
+
+    # versions
     'doma_version': '3.10.0',
     'doma_compile_version': '4.0.2',
     'doma_codegen_version': '3.2.1',


### PR DESCRIPTION
## Summary
- Adds GitHub integration settings to Sphinx configuration to enable "Edit Source" links in documentation
- Configures repository details (domaframework/doma) and documentation path
- Improves contributor experience by providing direct links to edit documentation sources

## Test plan
- [ ] Verify documentation builds successfully
- [ ] Check that "Edit Source" links appear in generated documentation
- [ ] Confirm links point to correct GitHub repository and file paths

🤖 Generated with [Claude Code](https://claude.ai/code)