### PR TITLE
chore(deps): update shadow plugin to com.gradleup.shadow v9.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 release = { id = "net.researchgate.release", version = "3.1.0" }
 doma-compile = { id = "org.domaframework.doma.compile", version = "4.0.2" }
 doma-codegen = { id = "org.domaframework.doma.codegen", version = "3.2.1" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "9.0.0" }
 themrmilchmann-ecj = { id = "io.github.themrmilchmann.ecj", version = "0.2.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 eclipse-apt = { id = "com.diffplug.eclipse.apt", version = "4.3.0" }


### PR DESCRIPTION
## Summary
- Migrate from deprecated `com.github.johnrengelman.shadow` to the new `com.gradleup.shadow` plugin ID
- Update Shadow plugin version from 8.1.1 to 9.0.0

## Test plan
- [ ] Build passes with `./gradlew build`
- [ ] Shadow JAR creation works correctly
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)