### PR TITLE
Revert "fix(deps): update dependency com.google.googlejavaformat:google-java-format to v1.29.0 (#1446)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ ecj = { module = "org.eclipse.jdt:ecj", version = "3.43.0" }
 
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 
-google-java-format = { module = "com.google.googlejavaformat:google-java-format", version = "1.29.0" }
+google-java-format = { module = "com.google.googlejavaformat:google-java-format", version = "1.28.0" }
 ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version = "1.7.1" }
 
 quarkus-doma = { module = "io.quarkiverse.doma:quarkus-doma", version = "1.0.6"}


### PR DESCRIPTION
This reverts commit fb96449d2c34105d46526604de539ba8085f35ed.

Since `google-java-format` v1.29.0 doesn’t support JDK 17, we’ll use v1.28.0 instead.
