### PR TITLE
ci: disable configuration cache for publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
           ./gradlew
           -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
           -Porg.gradle.parallel=false
+          --no-configuration-cache
           publishToSonatype closeAndReleaseSonatypeStagingRepository
 
       - name: Upload reports


### PR DESCRIPTION
## Summary
• Disable Gradle configuration cache for publishing steps in CI workflow
• Ensures compatibility with Sonatype publishing tasks

## Test plan
- [ ] Verify CI workflow runs successfully with publishing tasks
- [ ] Confirm configuration cache remains enabled for other build steps

🤖 Generated with [Claude Code](https://claude.ai/code)