### PR TITLE
feat: add doma.resources.dir.test annotation processor option

### DIFF
--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
@@ -74,6 +74,7 @@ import org.seasar.doma.internal.apt.processor.ScopeProcessor;
   Options.METAMODEL_PREFIX,
   Options.METAMODEL_SUFFIX,
   Options.RESOURCES_DIR,
+  Options.RESOURCES_DIR_TEST,
   Options.SQL_VALIDATION,
   Options.TEST_INTEGRATION,
   Options.TEST_UNIT,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -66,6 +66,8 @@ public final class Options {
 
   public static final String RESOURCES_DIR = "doma.resources.dir";
 
+  public static final String RESOURCES_DIR_TEST = "doma.resources.dir.test";
+
   public static final String LOMBOK_ALL_ARGS_CONSTRUCTOR = "doma.lombok.AllArgsConstructor";
 
   public static final String LOMBOK_VALUE = "doma.lombok.Value";

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
@@ -43,13 +43,20 @@ public class ProcessingContext {
     var envClassName = env.getClass().getName();
     var isRunningOnEcj = envClassName.startsWith("org.eclipse.");
     var resourceDir = env.getOptions().get(Options.RESOURCES_DIR);
+    var resourceDirTest = env.getOptions().get(Options.RESOURCES_DIR_TEST);
     var canAcceptDirectoryPath = isRunningOnEcj || resourceDir != null;
     var location = determineLocation(isRunningOnEcj);
 
     reporter = new Reporter(env.getMessager());
     resources =
         new Resources(
-            env.getFiler(), reporter, resourceDir, canAcceptDirectoryPath, location, isDebug(env));
+            env.getFiler(),
+            reporter,
+            resourceDir,
+            resourceDirTest,
+            canAcceptDirectoryPath,
+            location,
+            isDebug(env));
     options = new Options(env.getOptions(), resources);
     initialized = true;
   }

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
 import javax.tools.FileObject;
@@ -35,7 +37,7 @@ public class Resources {
 
   private final Reporter reporter;
 
-  private final String resourcesDir;
+  private final String[] resourcesDirs;
 
   private final boolean canAcceptDirectoryPath;
 
@@ -49,13 +51,21 @@ public class Resources {
       Filer filer,
       Reporter reporter,
       String resourcesDir,
+      String resourcesDirTest,
       boolean canAcceptDirectoryPath,
       JavaFileManager.Location location,
       boolean isDebug) {
     assertNotNull(filer, reporter);
     this.filer = filer;
     this.reporter = reporter;
-    this.resourcesDir = resourcesDir;
+    List<String> dirs = new ArrayList<>();
+    if (resourcesDir != null && !resourcesDir.isEmpty()) {
+      dirs.add(resourcesDir);
+    }
+    if (resourcesDirTest != null && !resourcesDirTest.isEmpty()) {
+      dirs.add(resourcesDirTest);
+    }
+    this.resourcesDirs = dirs.isEmpty() ? null : dirs.toArray(new String[0]);
     this.canAcceptDirectoryPath = canAcceptDirectoryPath;
     this.location = location;
     this.isDebug = isDebug;
@@ -78,6 +88,11 @@ public class Resources {
   /**
    * Attempts to retrieve a resource file based on the specified relative path.
    *
+   * <p>When {@code doma.resources.dir} is set, it is searched first. If {@code
+   * doma.resources.dir.test} is also set, it is searched as a fallback. The first existing match is
+   * returned. If no match is found in any directory, a {@code FileObject} pointing to the first
+   * directory is returned so that error messages contain a meaningful path.
+   *
    * @param relativePath the relative path to the desired resource; must not be null
    * @return a {@code FileObject} representing the resource located at the given relative path
    * @throws IOException if an I/O error occurs during resource retrieval
@@ -86,10 +101,16 @@ public class Resources {
   public FileObject getResource(String relativePath) throws IOException {
     assertNotNull(relativePath);
 
-    // Prefer the directory specified by the annotation processor option.
-    if (resourcesDir != null) {
-      Path path = Paths.get(resourcesDir, relativePath);
-      return new FileObjectImpl(path);
+    // Prefer the directories specified by the annotation processor option.
+    if (resourcesDirs != null) {
+      for (String dir : resourcesDirs) {
+        Path path = Paths.get(dir, relativePath);
+        if (Files.exists(path)) {
+          return new FileObjectImpl(path);
+        }
+      }
+      // None found — return the first directory so error reporting shows a meaningful path.
+      return new FileObjectImpl(Paths.get(resourcesDirs[0], relativePath));
     }
 
     try {

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/ResourcesTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/ResourcesTest.java
@@ -16,13 +16,18 @@
 package org.seasar.doma.internal.apt;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ResourcesTest {
 
@@ -52,6 +57,115 @@ public class ResourcesTest {
     } finally {
       //noinspection ResultOfMethodCallIgnored
       file.delete();
+    }
+  }
+
+  @Test
+  public void testGetResource_multipleDirectories(@TempDir Path dir1, @TempDir Path dir2)
+      throws IOException {
+    // Place a file only in the second directory (simulating doma.resources.dir.test)
+    Path subDir = dir2.resolve("META-INF").resolve("test");
+    Files.createDirectories(subDir);
+    Path sqlFile = subDir.resolve("query.sql");
+    Files.writeString(sqlFile, "select 1");
+
+    // Configure two separate resource directories via doma.resources.dir and
+    // doma.resources.dir.test
+    Resources resources =
+        new Resources(
+            new NoopFiler(),
+            new Reporter(new NoopMessager()),
+            dir1.toAbsolutePath().toString(),
+            dir2.toAbsolutePath().toString(),
+            true,
+            StandardLocation.CLASS_OUTPUT,
+            false);
+
+    FileObject result = resources.getResource("META-INF/test/query.sql");
+    assertTrue(Files.exists(Path.of(result.toUri())), "Should find file in test directory");
+  }
+
+  @Test
+  public void testGetResource_firstDirectoryWins(@TempDir Path dir1, @TempDir Path dir2)
+      throws IOException {
+    // Place a file in both directories
+    for (Path dir : new Path[] {dir1, dir2}) {
+      Path subDir = dir.resolve("META-INF");
+      Files.createDirectories(subDir);
+      Files.writeString(subDir.resolve("test.sql"), "select from " + dir.getFileName());
+    }
+
+    Resources resources =
+        new Resources(
+            new NoopFiler(),
+            new Reporter(new NoopMessager()),
+            dir1.toAbsolutePath().toString(),
+            dir2.toAbsolutePath().toString(),
+            true,
+            StandardLocation.CLASS_OUTPUT,
+            false);
+
+    FileObject result = resources.getResource("META-INF/test.sql");
+    // Should resolve to dir1 (first match wins)
+    assertTrue(
+        result.toUri().getPath().contains(dir1.getFileName().toString()),
+        "Should return file from first matching directory");
+  }
+
+  /** Minimal Messager implementation for unit tests. */
+  private static class NoopMessager implements javax.annotation.processing.Messager {
+
+    @Override
+    public void printMessage(javax.tools.Diagnostic.Kind kind, CharSequence msg) {}
+
+    @Override
+    public void printMessage(
+        javax.tools.Diagnostic.Kind kind, CharSequence msg, javax.lang.model.element.Element e) {}
+
+    @Override
+    public void printMessage(
+        javax.tools.Diagnostic.Kind kind,
+        CharSequence msg,
+        javax.lang.model.element.Element e,
+        javax.lang.model.element.AnnotationMirror a) {}
+
+    @Override
+    public void printMessage(
+        javax.tools.Diagnostic.Kind kind,
+        CharSequence msg,
+        javax.lang.model.element.Element e,
+        javax.lang.model.element.AnnotationMirror a,
+        javax.lang.model.element.AnnotationValue v) {}
+  }
+
+  /** Minimal Filer implementation for unit tests that don't need Filer functionality. */
+  private static class NoopFiler implements javax.annotation.processing.Filer {
+
+    @Override
+    public javax.tools.JavaFileObject createSourceFile(
+        CharSequence n, javax.lang.model.element.Element... e) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public javax.tools.JavaFileObject createClassFile(
+        CharSequence n, javax.lang.model.element.Element... e) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public javax.tools.FileObject createResource(
+        javax.tools.JavaFileManager.Location l,
+        CharSequence m,
+        CharSequence r,
+        javax.lang.model.element.Element... e) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public javax.tools.FileObject getResource(
+        javax.tools.JavaFileManager.Location l, CharSequence m, CharSequence r) {
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a new annotation processor option `doma.resources.dir.test` that allows specifying an additional resource directory for SQL file resolution during compilation.

## Motivation

When using Doma with Eclipse (ECJ), the existing `doma.resources.dir` option only accepts a single directory path. Eclipse's strict annotation processor option validation prevents specifying multiple paths in a single option, and setting `doma.resources.dir` separately for main and test compilation phases is not supported since Eclipse maintains only one set of annotation processor options per project.

This makes it impossible to resolve SQL files located in test resource directories (e.g., `src/test/resources`) when `doma.resources.dir` is already pointing to the main resource directory (e.g., `src/main/resources`).

## Changes

- Options.java: Added `RESOURCES_DIR_TEST` constant (`doma.resources.dir.test`)
- DomaProcessor.java: Registered the new option in `@SupportedOptions`
- ProcessingContext.java: Reads the new option and passes it to `Resources`
- Resources.java: Changed resource lookup to search multiple directories. `doma.resources.dir` is checked first, then `doma.resources.dir.test` as a fallback. If a file exists in either directory, it is returned. If not found in any, a `FileObject` pointing to the first directory is returned for meaningful error messages.
- ResourcesTest.java: Added tests for multi-directory resolution and first-directory-wins behavior

## Usage

### Maven

```xml
<compilerArgs>
    <arg>-Adoma.resources.dir=${project.basedir}/src/main/resources</arg>
    <arg>-Adoma.resources.dir.test=${project.basedir}/src/test/resources</arg>
</compilerArgs>
```

## Backward Compatibility

Fully backward compatible. The new option is optional. Existing behavior is unchanged when `doma.resources.dir.test` is not specified.