### PR TITLE
docs: add doma.resources.dir.test option documentation

### DIFF
--- a/docs/annotation-processing.md
+++ b/docs/annotation-processing.md
@@ -78,6 +78,13 @@ The resource directory containing resource files such as doma.compile.config and
 Specify this option as an absolute path.
 If not specified, the resource directory defaults to the same directory where classes are generated.
 
+### doma.resources.dir.test
+
+The secondary resource directory for SQL files used during test compilation.
+Specify this option as an absolute path.
+When both `doma.resources.dir` and `doma.resources.dir.test` are specified,
+Doma first searches `doma.resources.dir`, and falls back to `doma.resources.dir.test` if the resource is not found.
+
 ### doma.sql.validation
 
 Controls whether to validate the existence of SQL files and the grammar of SQL directives.

--- a/docs/locale/ja/LC_MESSAGES/annotation-processing.po
+++ b/docs/locale/ja/LC_MESSAGES/annotation-processing.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  doma-docs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-12 00:57+0900\n"
+"POT-Creation-Date: 2026-04-04 23:19+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: ja_JP\n"
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../annotation-processing.md:1
 msgid "Annotation Processing"
@@ -113,8 +113,8 @@ msgid ""
 "Multiple names should be provided as a comma-separated list. This option "
 "is used to locate external domain classes."
 msgstr ""
-"`@DomainConverters` "
-"の注釈が付けられたクラスの完全修飾名。名前はカンマ区切りのリストとして記述されます。この値は、外部ドメイン クラスを検索するために使用されます。"
+"`@DomainConverters` の注釈が付けられたクラスの完全修飾名。名前はカンマ区切りのリストとして記述されます。この値は、外部ドメイン"
+" クラスを検索するために使用されます。"
 
 #: ../../annotation-processing.md:46
 msgid "doma.entity.field.prefix"
@@ -154,9 +154,8 @@ msgid ""
 "they are not explicitly configured with `metamodel = @Metamodel`. The "
 "default value is `false`."
 msgstr ""
-"Criteria API のメタクラスを生成するかどうか。値が `true` の場合、たとえ `metamodel = "
-"@Metamodel` で指定されていなくても、すべてのエンティティクラスに対してメタモデルが生成されます。デフォルト値は `false` "
-"です。"
+"Criteria API のメタクラスを生成するかどうか。値が `true` の場合、たとえ `metamodel = @Metamodel` "
+"で指定されていなくても、すべてのエンティティクラスに対してメタモデルが生成されます。デフォルト値は `false` です。"
 
 #: ../../annotation-processing.md:65
 msgid "doma.metamodel.prefix"
@@ -193,10 +192,28 @@ msgstr ""
 "このオプションを絶対パスとして指定します。 指定しない場合、リソース ディレクトリはクラスが生成されるのと同じディレクトリです。"
 
 #: ../../annotation-processing.md:81
+msgid "doma.resources.dir.test"
+msgstr "doma.resources.dir.test"
+
+#: ../../annotation-processing.md:83
+msgid ""
+"The secondary resource directory for SQL files used during test "
+"compilation. Specify this option as an absolute path. When both "
+"`doma.resources.dir` and `doma.resources.dir.test` are specified, Doma "
+"first searches `doma.resources.dir`, and falls back to "
+"`doma.resources.dir.test` if the resource is not found."
+msgstr ""
+"テストコンパイル時に使用される SQL ファイルのセカンダリリソースディレクトリです。"
+"このオプションを絶対パスとして指定します。"
+"`doma.resources.dir` と `doma.resources.dir.test` の両方が指定された場合、"
+"Doma はまず `doma.resources.dir` を検索し、リソースが見つからない場合は "
+"`doma.resources.dir.test` にフォールバックします。"
+
+#: ../../annotation-processing.md:88
 msgid "doma.sql.validation"
 msgstr "doma.sql.validation"
 
-#: ../../annotation-processing.md:83
+#: ../../annotation-processing.md:90
 msgid ""
 "Controls whether to validate the existence of SQL files and the grammar "
 "of SQL directives. When set to `true`, validations will run. To disable "
@@ -205,11 +222,11 @@ msgstr ""
 "SQL ファイルの存在と SQL ディレクティブの文法を検証するかどうかを制御します。`true` "
 "に設定すると、検証が実行されます。検証を無効にするには、`false` に設定します。 デフォルト値は `true` です。"
 
-#: ../../annotation-processing.md:88
+#: ../../annotation-processing.md:95
 msgid "doma.trace"
 msgstr "doma.trace"
 
-#: ../../annotation-processing.md:90
+#: ../../annotation-processing.md:97
 msgid ""
 "Controls whether trace logs are output during annotation processing. When"
 " set to `true`, the annotation processors will output trace logs, "
@@ -219,40 +236,40 @@ msgstr ""
 "アノテーション処理中にトレースログを出力するかどうかを制御します。`true` "
 "に設定すると、アノテーションプロセッサはトレースログを出力し、アノテーション処理の実行時間も含まれます。デフォルト値は `false` です。"
 
-#: ../../annotation-processing.md:94
+#: ../../annotation-processing.md:101
 msgid "doma.version.validation"
 msgstr "doma.version.validation"
 
-#: ../../annotation-processing.md:96
+#: ../../annotation-processing.md:103
 msgid ""
 "Controls whether to validate version compatibility between the runtime "
-"and compile-time. When set to `true`, version validation is performed. "
-"To disable validation, set it to `false`. The default value is `true`."
+"and compile-time. When set to `true`, version validation is performed. To"
+" disable validation, set it to `false`. The default value is `true`."
 msgstr ""
 "ランタイムとコンパイル時の間のバージョン互換性を検証するかどうかを制御します。`true` "
 "に設定すると、バージョン検証が実行されます。検証を無効にするには、`false` に設定します。デフォルト値は `true` です。"
 
-#: ../../annotation-processing.md:101
+#: ../../annotation-processing.md:108
 msgid "doma.config.path"
 msgstr "doma.config.path"
 
-#: ../../annotation-processing.md:103
+#: ../../annotation-processing.md:110
 msgid ""
 "The file path of the configuration file for Doma. The default value is "
 "`doma.compile.config`."
 msgstr "Doma の構成ファイルのファイル パス。デフォルト値は `doma.compile.config` です。"
 
-#: ../../annotation-processing.md:106
+#: ../../annotation-processing.md:113
 msgid "Setting Options in Gradle"
 msgstr "Gradle でのオプションの設定"
 
-#: ../../annotation-processing.md:108
+#: ../../annotation-processing.md:115
 msgid ""
 "Use [the compilerArgs "
 "property](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgs):"
 msgstr ""
-"[compilerArgs プロパティ]("
-"https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgs)"
+"[compilerArgs "
+"プロパティ](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgs)"
 " を使用します。"
 
 #: ../../annotation-processing.md
@@ -263,11 +280,11 @@ msgstr "オプション"
 msgid "Groovy"
 msgstr ""
 
-#: ../../annotation-processing.md:135
+#: ../../annotation-processing.md:142
 msgid "Setting Options in Maven"
 msgstr "Maven でのオプションの設定"
 
-#: ../../annotation-processing.md:137
+#: ../../annotation-processing.md:144
 msgid ""
 "Use [the compilerArgs parameter](https://maven.apache.org/plugins/maven-"
 "compiler-plugin/examples/pass-compiler-arguments.html):"
@@ -275,25 +292,25 @@ msgstr ""
 "[compilerArgs パラメータ](https://maven.apache.org/plugins/maven-compiler-"
 "plugin/examples/pass-compiler-arguments.html): を使用します。"
 
-#: ../../annotation-processing.md:167
+#: ../../annotation-processing.md:174
 msgid "Setting Options in Eclipse"
 msgstr "Eclipse でのオプションの設定"
 
-#: ../../annotation-processing.md:169 ../../annotation-processing.md:222
+#: ../../annotation-processing.md:176 ../../annotation-processing.md:229
 msgid "Gradle"
 msgstr "Gradle"
 
-#: ../../annotation-processing.md:171
+#: ../../annotation-processing.md:178
 msgid ""
 "Use the Gradle plugin "
 "[com.diffplug.eclipse.apt](https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt)"
 " and the `processorArgs` property:"
 msgstr ""
-"Gradle プラグイン [com.diffplug.eclipse.apt]"
-"(https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt) と "
-"`processorArgs` プロパティを使用します。"
+"Gradle プラグイン "
+"[com.diffplug.eclipse.apt](https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt)"
+" と `processorArgs` プロパティを使用します。"
 
-#: ../../annotation-processing.md:212
+#: ../../annotation-processing.md:219
 msgid ""
 "Right-click on the project in Eclipse and select Gradle > Refresh Gradle "
 "Project. This will apply the Gradle annotation processing options to "
@@ -302,11 +319,11 @@ msgstr ""
 "Eclipse でプロジェクトを右クリックし、Gradle > Refresh Gradle Project を選択します。これにより "
 "Gradle に指定したアノテーションプロセッサのオプションが Eclipse へ反映されます。"
 
-#: ../../annotation-processing.md:215 ../../annotation-processing.md:227
+#: ../../annotation-processing.md:222 ../../annotation-processing.md:234
 msgid "Maven"
 msgstr "Maven"
 
-#: ../../annotation-processing.md:217
+#: ../../annotation-processing.md:224
 msgid ""
 "Right-click on the project in Eclipse and select Maven > Update "
 "Project.... This will apply the Maven annotation processing options to "
@@ -315,46 +332,45 @@ msgstr ""
 "Eclipseでプロジェクトを右クリックし、Maven > Update "
 "Project...を選択します。これにより、Mavenのアノテーション処理オプションがEclipseに適用されます。"
 
-#: ../../annotation-processing.md:220
+#: ../../annotation-processing.md:227
 msgid "Setting Options in IntelliJ IDEA"
 msgstr "IntelliJ IDEA でのオプションの設定"
 
-#: ../../annotation-processing.md:224
+#: ../../annotation-processing.md:231
 msgid ""
 "Import your project as a Gradle project. In this case, the options "
 "defined in build.gradle(.kts) will be used."
 msgstr "Gradle プロジェクトとしてプロジェクトをインポートします。この場合、build.gradle(.kts) に書かれたオプションが使用されます。"
 
-#: ../../annotation-processing.md:229
+#: ../../annotation-processing.md:236
 msgid ""
 "Import your project as a Maven project. In this case, the options defined"
 " in pom.xml will be used."
 msgstr "プロジェクトを Maven プロジェクトとしてインポートします。この場合、pom.xml に書かれたオプションが使用されます。"
 
-#: ../../annotation-processing.md:232
+#: ../../annotation-processing.md:239
 msgid "Setting Options with Configuration File"
 msgstr "設定ファイルによるオプションの設定"
 
-#: ../../annotation-processing.md:234
+#: ../../annotation-processing.md:241
 msgid ""
 "Options specified in the `doma.compile.config` file are available across "
 "all build tools including Eclipse, IntelliJ IDEA, Gradle, and Maven."
 msgstr ""
-"`doma.compile.config` ファイルで指定されたオプションは、Eclipse、IntelliJ "
-"IDEA、Gradle、Maven などのすべてのビルド ツールで使用できます。"
+"`doma.compile.config` ファイルで指定されたオプションは、Eclipse、IntelliJ IDEA、Gradle、Maven"
+" などのすべてのビルド ツールで使用できます。"
 
-#: ../../annotation-processing.md:237
+#: ../../annotation-processing.md:244
 msgid ""
 "The `doma.compile.config` file must follow the properties file format and"
 " should be placed in a root directory such as `src/main/resources`."
 msgstr ""
-"`doma.compile.config` ファイルはプロパティファイル形式に従い、`src/main/resources` などのルート"
-" ディレクトリに配置する必要があります。"
+"`doma.compile.config` ファイルはプロパティファイル形式に従い、`src/main/resources` などのルート "
+"ディレクトリに配置する必要があります。"
 
-#: ../../annotation-processing.md:241
+#: ../../annotation-processing.md:248
 msgid ""
 "Options specified in the `doma.compile.config` file are overridden by any"
 " options specified directly in the build tools."
 msgstr "`doma.compile.config` ファイルで指定されたオプションは、ビルドツールに固有のオプションによって上書きされます。"
-
 


### PR DESCRIPTION
## Summary

- Add documentation for the new `doma.resources.dir.test` annotation processor option in `docs/annotation-processing.md`
- Add Japanese translation for the new option in `docs/locale/ja/LC_MESSAGES/annotation-processing.po`

## Test plan

- [x] Verify the English documentation renders correctly
- [x] Verify the Japanese documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)