### PR TITLE
feat: rename doma.resources.dir.test to doma.resources.dirs with multi-path support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out
 .factorypath
 /.claude/settings.local.json
 /.venv/
+/.claude/worktrees/

--- a/docs/annotation-processing.md
+++ b/docs/annotation-processing.md
@@ -78,12 +78,13 @@ The resource directory containing resource files such as doma.compile.config and
 Specify this option as an absolute path.
 If not specified, the resource directory defaults to the same directory where classes are generated.
 
-### doma.resources.dir.test
+### doma.resources.dirs
 
-The secondary resource directory for SQL files used during test compilation.
-Specify this option as an absolute path.
-When both `doma.resources.dir` and `doma.resources.dir.test` are specified,
-Doma first searches `doma.resources.dir`, and falls back to `doma.resources.dir.test` if the resource is not found.
+Additional resource directories for SQL files.
+Specify one or more absolute paths separated by commas.
+When both `doma.resources.dir` and `doma.resources.dirs` are specified,
+Doma first searches `doma.resources.dir`, then each directory in `doma.resources.dirs` in order.
+The first existing match is returned.
 
 ### doma.sql.validation
 

--- a/docs/locale/ja/LC_MESSAGES/annotation-processing.po
+++ b/docs/locale/ja/LC_MESSAGES/annotation-processing.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  doma-docs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-04 23:19+0900\n"
+"POT-Creation-Date: 2026-04-25 07:11+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: ja_JP\n"
@@ -192,28 +192,28 @@ msgstr ""
 "このオプションを絶対パスとして指定します。 指定しない場合、リソース ディレクトリはクラスが生成されるのと同じディレクトリです。"
 
 #: ../../annotation-processing.md:81
-msgid "doma.resources.dir.test"
-msgstr "doma.resources.dir.test"
+msgid "doma.resources.dirs"
+msgstr "doma.resources.dirs"
 
 #: ../../annotation-processing.md:83
 msgid ""
-"The secondary resource directory for SQL files used during test "
-"compilation. Specify this option as an absolute path. When both "
-"`doma.resources.dir` and `doma.resources.dir.test` are specified, Doma "
-"first searches `doma.resources.dir`, and falls back to "
-"`doma.resources.dir.test` if the resource is not found."
+"Additional resource directories for SQL files. Specify one or more "
+"absolute paths separated by commas. When both `doma.resources.dir` and "
+"`doma.resources.dirs` are specified, Doma first searches "
+"`doma.resources.dir`, then each directory in `doma.resources.dirs` in "
+"order. The first existing match is returned."
 msgstr ""
-"テストコンパイル時に使用される SQL ファイルのセカンダリリソースディレクトリです。"
-"このオプションを絶対パスとして指定します。"
-"`doma.resources.dir` と `doma.resources.dir.test` の両方が指定された場合、"
-"Doma はまず `doma.resources.dir` を検索し、リソースが見つからない場合は "
-"`doma.resources.dir.test` にフォールバックします。"
+"SQL ファイルの追加のリソースディレクトリです。"
+"1 つ以上の絶対パスをカンマ区切りで指定します。"
+"`doma.resources.dir` と `doma.resources.dirs` の両方が指定された場合、"
+"Doma はまず `doma.resources.dir` を検索し、その後 `doma.resources.dirs` の各ディレクトリを順に検索します。"
+"最初に見つかった一致を返します。"
 
-#: ../../annotation-processing.md:88
+#: ../../annotation-processing.md:89
 msgid "doma.sql.validation"
 msgstr "doma.sql.validation"
 
-#: ../../annotation-processing.md:90
+#: ../../annotation-processing.md:91
 msgid ""
 "Controls whether to validate the existence of SQL files and the grammar "
 "of SQL directives. When set to `true`, validations will run. To disable "
@@ -222,11 +222,11 @@ msgstr ""
 "SQL ファイルの存在と SQL ディレクティブの文法を検証するかどうかを制御します。`true` "
 "に設定すると、検証が実行されます。検証を無効にするには、`false` に設定します。 デフォルト値は `true` です。"
 
-#: ../../annotation-processing.md:95
+#: ../../annotation-processing.md:96
 msgid "doma.trace"
 msgstr "doma.trace"
 
-#: ../../annotation-processing.md:97
+#: ../../annotation-processing.md:98
 msgid ""
 "Controls whether trace logs are output during annotation processing. When"
 " set to `true`, the annotation processors will output trace logs, "
@@ -236,11 +236,11 @@ msgstr ""
 "アノテーション処理中にトレースログを出力するかどうかを制御します。`true` "
 "に設定すると、アノテーションプロセッサはトレースログを出力し、アノテーション処理の実行時間も含まれます。デフォルト値は `false` です。"
 
-#: ../../annotation-processing.md:101
+#: ../../annotation-processing.md:102
 msgid "doma.version.validation"
 msgstr "doma.version.validation"
 
-#: ../../annotation-processing.md:103
+#: ../../annotation-processing.md:104
 msgid ""
 "Controls whether to validate version compatibility between the runtime "
 "and compile-time. When set to `true`, version validation is performed. To"
@@ -249,21 +249,21 @@ msgstr ""
 "ランタイムとコンパイル時の間のバージョン互換性を検証するかどうかを制御します。`true` "
 "に設定すると、バージョン検証が実行されます。検証を無効にするには、`false` に設定します。デフォルト値は `true` です。"
 
-#: ../../annotation-processing.md:108
+#: ../../annotation-processing.md:109
 msgid "doma.config.path"
 msgstr "doma.config.path"
 
-#: ../../annotation-processing.md:110
+#: ../../annotation-processing.md:111
 msgid ""
 "The file path of the configuration file for Doma. The default value is "
 "`doma.compile.config`."
 msgstr "Doma の構成ファイルのファイル パス。デフォルト値は `doma.compile.config` です。"
 
-#: ../../annotation-processing.md:113
+#: ../../annotation-processing.md:114
 msgid "Setting Options in Gradle"
 msgstr "Gradle でのオプションの設定"
 
-#: ../../annotation-processing.md:115
+#: ../../annotation-processing.md:116
 msgid ""
 "Use [the compilerArgs "
 "property](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgs):"
@@ -280,11 +280,11 @@ msgstr "オプション"
 msgid "Groovy"
 msgstr ""
 
-#: ../../annotation-processing.md:142
+#: ../../annotation-processing.md:143
 msgid "Setting Options in Maven"
 msgstr "Maven でのオプションの設定"
 
-#: ../../annotation-processing.md:144
+#: ../../annotation-processing.md:145
 msgid ""
 "Use [the compilerArgs parameter](https://maven.apache.org/plugins/maven-"
 "compiler-plugin/examples/pass-compiler-arguments.html):"
@@ -292,15 +292,15 @@ msgstr ""
 "[compilerArgs パラメータ](https://maven.apache.org/plugins/maven-compiler-"
 "plugin/examples/pass-compiler-arguments.html): を使用します。"
 
-#: ../../annotation-processing.md:174
+#: ../../annotation-processing.md:175
 msgid "Setting Options in Eclipse"
 msgstr "Eclipse でのオプションの設定"
 
-#: ../../annotation-processing.md:176 ../../annotation-processing.md:229
+#: ../../annotation-processing.md:177 ../../annotation-processing.md:230
 msgid "Gradle"
 msgstr "Gradle"
 
-#: ../../annotation-processing.md:178
+#: ../../annotation-processing.md:179
 msgid ""
 "Use the Gradle plugin "
 "[com.diffplug.eclipse.apt](https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt)"
@@ -310,7 +310,7 @@ msgstr ""
 "[com.diffplug.eclipse.apt](https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt)"
 " と `processorArgs` プロパティを使用します。"
 
-#: ../../annotation-processing.md:219
+#: ../../annotation-processing.md:220
 msgid ""
 "Right-click on the project in Eclipse and select Gradle > Refresh Gradle "
 "Project. This will apply the Gradle annotation processing options to "
@@ -319,11 +319,11 @@ msgstr ""
 "Eclipse でプロジェクトを右クリックし、Gradle > Refresh Gradle Project を選択します。これにより "
 "Gradle に指定したアノテーションプロセッサのオプションが Eclipse へ反映されます。"
 
-#: ../../annotation-processing.md:222 ../../annotation-processing.md:234
+#: ../../annotation-processing.md:223 ../../annotation-processing.md:235
 msgid "Maven"
 msgstr "Maven"
 
-#: ../../annotation-processing.md:224
+#: ../../annotation-processing.md:225
 msgid ""
 "Right-click on the project in Eclipse and select Maven > Update "
 "Project.... This will apply the Maven annotation processing options to "
@@ -332,27 +332,27 @@ msgstr ""
 "Eclipseでプロジェクトを右クリックし、Maven > Update "
 "Project...を選択します。これにより、Mavenのアノテーション処理オプションがEclipseに適用されます。"
 
-#: ../../annotation-processing.md:227
+#: ../../annotation-processing.md:228
 msgid "Setting Options in IntelliJ IDEA"
 msgstr "IntelliJ IDEA でのオプションの設定"
 
-#: ../../annotation-processing.md:231
+#: ../../annotation-processing.md:232
 msgid ""
 "Import your project as a Gradle project. In this case, the options "
 "defined in build.gradle(.kts) will be used."
 msgstr "Gradle プロジェクトとしてプロジェクトをインポートします。この場合、build.gradle(.kts) に書かれたオプションが使用されます。"
 
-#: ../../annotation-processing.md:236
+#: ../../annotation-processing.md:237
 msgid ""
 "Import your project as a Maven project. In this case, the options defined"
 " in pom.xml will be used."
 msgstr "プロジェクトを Maven プロジェクトとしてインポートします。この場合、pom.xml に書かれたオプションが使用されます。"
 
-#: ../../annotation-processing.md:239
+#: ../../annotation-processing.md:240
 msgid "Setting Options with Configuration File"
 msgstr "設定ファイルによるオプションの設定"
 
-#: ../../annotation-processing.md:241
+#: ../../annotation-processing.md:242
 msgid ""
 "Options specified in the `doma.compile.config` file are available across "
 "all build tools including Eclipse, IntelliJ IDEA, Gradle, and Maven."
@@ -360,7 +360,7 @@ msgstr ""
 "`doma.compile.config` ファイルで指定されたオプションは、Eclipse、IntelliJ IDEA、Gradle、Maven"
 " などのすべてのビルド ツールで使用できます。"
 
-#: ../../annotation-processing.md:244
+#: ../../annotation-processing.md:245
 msgid ""
 "The `doma.compile.config` file must follow the properties file format and"
 " should be placed in a root directory such as `src/main/resources`."
@@ -368,9 +368,12 @@ msgstr ""
 "`doma.compile.config` ファイルはプロパティファイル形式に従い、`src/main/resources` などのルート "
 "ディレクトリに配置する必要があります。"
 
-#: ../../annotation-processing.md:248
+#: ../../annotation-processing.md:249
 msgid ""
 "Options specified in the `doma.compile.config` file are overridden by any"
 " options specified directly in the build tools."
 msgstr "`doma.compile.config` ファイルで指定されたオプションは、ビルドツールに固有のオプションによって上書きされます。"
+
+#~ msgid "doma.resources.dir.test"
+#~ msgstr "doma.resources.dir.test"
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/DomaProcessor.java
@@ -74,7 +74,7 @@ import org.seasar.doma.internal.apt.processor.ScopeProcessor;
   Options.METAMODEL_PREFIX,
   Options.METAMODEL_SUFFIX,
   Options.RESOURCES_DIR,
-  Options.RESOURCES_DIR_TEST,
+  Options.RESOURCES_DIRS,
   Options.SQL_VALIDATION,
   Options.TEST_INTEGRATION,
   Options.TEST_UNIT,

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Options.java
@@ -66,7 +66,7 @@ public final class Options {
 
   public static final String RESOURCES_DIR = "doma.resources.dir";
 
-  public static final String RESOURCES_DIR_TEST = "doma.resources.dir.test";
+  public static final String RESOURCES_DIRS = "doma.resources.dirs";
 
   public static final String LOMBOK_ALL_ARGS_CONSTRUCTOR = "doma.lombok.AllArgsConstructor";
 

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/ProcessingContext.java
@@ -15,6 +15,7 @@
  */
 package org.seasar.doma.internal.apt;
 
+import java.util.ArrayList;
 import java.util.Objects;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
@@ -43,8 +44,17 @@ public class ProcessingContext {
     var envClassName = env.getClass().getName();
     var isRunningOnEcj = envClassName.startsWith("org.eclipse.");
     var resourceDir = env.getOptions().get(Options.RESOURCES_DIR);
-    var resourceDirTest = env.getOptions().get(Options.RESOURCES_DIR_TEST);
-    var canAcceptDirectoryPath = isRunningOnEcj || resourceDir != null;
+    var resourcesDirsValue = env.getOptions().get(Options.RESOURCES_DIRS);
+    var additionalDirs = new ArrayList<String>();
+    if (resourcesDirsValue != null && !resourcesDirsValue.isBlank()) {
+      for (var dir : resourcesDirsValue.split(",")) {
+        var trimmed = dir.trim();
+        if (!trimmed.isEmpty()) {
+          additionalDirs.add(trimmed);
+        }
+      }
+    }
+    var canAcceptDirectoryPath = isRunningOnEcj || resourceDir != null || !additionalDirs.isEmpty();
     var location = determineLocation(isRunningOnEcj);
 
     reporter = new Reporter(env.getMessager());
@@ -53,7 +63,7 @@ public class ProcessingContext {
             env.getFiler(),
             reporter,
             resourceDir,
-            resourceDirTest,
+            additionalDirs,
             canAcceptDirectoryPath,
             location,
             isDebug(env));

--- a/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
+++ b/doma-processor/src/main/java/org/seasar/doma/internal/apt/Resources.java
@@ -51,7 +51,7 @@ public class Resources {
       Filer filer,
       Reporter reporter,
       String resourcesDir,
-      String resourcesDirTest,
+      List<String> additionalResourcesDirs,
       boolean canAcceptDirectoryPath,
       JavaFileManager.Location location,
       boolean isDebug) {
@@ -62,8 +62,8 @@ public class Resources {
     if (resourcesDir != null && !resourcesDir.isEmpty()) {
       dirs.add(resourcesDir);
     }
-    if (resourcesDirTest != null && !resourcesDirTest.isEmpty()) {
-      dirs.add(resourcesDirTest);
+    if (additionalResourcesDirs != null) {
+      dirs.addAll(additionalResourcesDirs);
     }
     this.resourcesDirs = dirs.isEmpty() ? null : dirs.toArray(new String[0]);
     this.canAcceptDirectoryPath = canAcceptDirectoryPath;
@@ -88,10 +88,10 @@ public class Resources {
   /**
    * Attempts to retrieve a resource file based on the specified relative path.
    *
-   * <p>When {@code doma.resources.dir} is set, it is searched first. If {@code
-   * doma.resources.dir.test} is also set, it is searched as a fallback. The first existing match is
-   * returned. If no match is found in any directory, a {@code FileObject} pointing to the first
-   * directory is returned so that error messages contain a meaningful path.
+   * <p>When {@code doma.resources.dir} is set, it is searched first. If {@code doma.resources.dirs}
+   * is also set, each directory listed there is searched in order as a fallback. The first existing
+   * match is returned. If no match is found in any directory, a {@code FileObject} pointing to the
+   * first directory is returned so that error messages contain a meaningful path.
    *
    * @param relativePath the relative path to the desired resource; must not be null
    * @return a {@code FileObject} representing the resource located at the given relative path

--- a/doma-processor/src/test/java/org/seasar/doma/internal/apt/ResourcesTest.java
+++ b/doma-processor/src/test/java/org/seasar/doma/internal/apt/ResourcesTest.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.Test;
@@ -63,20 +64,18 @@ public class ResourcesTest {
   @Test
   public void testGetResource_multipleDirectories(@TempDir Path dir1, @TempDir Path dir2)
       throws IOException {
-    // Place a file only in the second directory (simulating doma.resources.dir.test)
+    // Place a file only in the second directory (simulating doma.resources.dirs fallback)
     Path subDir = dir2.resolve("META-INF").resolve("test");
     Files.createDirectories(subDir);
     Path sqlFile = subDir.resolve("query.sql");
     Files.writeString(sqlFile, "select 1");
 
-    // Configure two separate resource directories via doma.resources.dir and
-    // doma.resources.dir.test
     Resources resources =
         new Resources(
             new NoopFiler(),
             new Reporter(new NoopMessager()),
             dir1.toAbsolutePath().toString(),
-            dir2.toAbsolutePath().toString(),
+            List.of(dir2.toAbsolutePath().toString()),
             true,
             StandardLocation.CLASS_OUTPUT,
             false);
@@ -100,7 +99,7 @@ public class ResourcesTest {
             new NoopFiler(),
             new Reporter(new NoopMessager()),
             dir1.toAbsolutePath().toString(),
-            dir2.toAbsolutePath().toString(),
+            List.of(dir2.toAbsolutePath().toString()),
             true,
             StandardLocation.CLASS_OUTPUT,
             false);
@@ -110,6 +109,33 @@ public class ResourcesTest {
     assertTrue(
         result.toUri().getPath().contains(dir1.getFileName().toString()),
         "Should return file from first matching directory");
+  }
+
+  @Test
+  public void testGetResource_multipleAdditionalDirs(
+      @TempDir Path dir1, @TempDir Path dir2, @TempDir Path dir3) throws IOException {
+    // Place a file only in the third directory to verify all additional dirs are searched
+    Path subDir = dir3.resolve("META-INF");
+    Files.createDirectories(subDir);
+    Files.writeString(subDir.resolve("query.sql"), "select 1");
+
+    Resources resources =
+        new Resources(
+            new NoopFiler(),
+            new Reporter(new NoopMessager()),
+            dir1.toAbsolutePath().toString(),
+            List.of(dir2.toAbsolutePath().toString(), dir3.toAbsolutePath().toString()),
+            true,
+            StandardLocation.CLASS_OUTPUT,
+            false);
+
+    FileObject result = resources.getResource("META-INF/query.sql");
+    assertTrue(
+        Files.exists(Path.of(result.toUri())),
+        "Should find file in the last of multiple additional directories");
+    assertTrue(
+        result.toUri().getPath().contains(dir3.getFileName().toString()),
+        "Resolved path should belong to dir3");
   }
 
   /** Minimal Messager implementation for unit tests. */


### PR DESCRIPTION
## Summary
- Rename the annotation processor option `doma.resources.dir.test` (introduced in #1567) to `doma.resources.dirs` since the option is not test-only
- Accept a comma-separated list of paths so multiple additional resource directories can be configured; search order is `doma.resources.dir` first, then each entry of `doma.resources.dirs` in order
- Update English and Japanese documentation accordingly

## Test plan
- [x] `./gradlew :doma-processor:test`
- [x] Added `testGetResource_multipleAdditionalDirs` covering multiple entries in `additionalResourcesDirs`
- [x] Verified Japanese docs render with `sphinx-build -b html -D language=ja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)