### PR TITLE
Remove PAT dependency from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to check out'
+        required: false
+        type: string
+      publish:
+        description: 'Publish packages after verification'
+        required: false
+        type: boolean
+        default: false
 
 env:
   JDK_DISTRIBUTION: zulu
@@ -31,6 +42,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
@@ -71,6 +84,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
@@ -125,6 +140,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
@@ -147,7 +164,7 @@ jobs:
             /home/runner/work/doma/doma/.gradle
 
   publish:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.publish
     name: Publish
     runs-on: ubuntu-latest
     needs: [ build, integration-test, ecj ]
@@ -165,6 +182,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
@@ -190,4 +209,3 @@ jobs:
           path: |
             ./**/build/reports
             /home/runner/work/doma/doma/.gradle
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
- 
+    permissions:
+      contents: write
+    outputs:
+      release_ref: ${{ steps.release-ref.outputs.release_ref }}
+
     steps:
       - name: Assign input version
-        if: github.event.inputs.version != null
-        run: echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+        if: inputs.version != ''
+        run: echo "RELEASE_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
       - name: Get latest draft release title
-        if: github.event.inputs.version == null
+        if: inputs.version == ''
         run: |
           TITLE=$(gh api repos/${{ github.repository }}/releases \
             --jq '.[] | select(.draft==true) | .name' | head -n 1)
@@ -44,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          fetch-depth: 0
 
       - name: Prepare git config
         run: |
@@ -61,9 +65,22 @@ jobs:
           --no-configuration-cache
           release
 
+      - name: Assign release ref
+        id: release-ref
+        run: echo "release_ref=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Upload reports
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build
           path: ./**/build/reports
+
+  verify-and-publish:
+    name: Verify and Publish
+    needs: release
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.release.outputs.release_ref }}
+      publish: true
+    secrets: inherit


### PR DESCRIPTION
## Summary
- remove `REPO_ACCESS_TOKEN` usage from the release workflow
- use the default `GITHUB_TOKEN` with `contents: write` for release commits/tags
- call the CI workflow as a reusable workflow to verify and publish the release tag from a single `workflow_dispatch`

## Verification
- `git diff --check`
- YAML parse check for `.github/workflows/release.yml` and `.github/workflows/ci.yml`
- commit hook ran `spotlessApply` successfully