### PR TITLE
Document chunked Query DSL batch operations

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/query-dsl.po
+++ b/docs/locale/ja/LC_MESSAGES/query-dsl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  doma-docs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-12 16:05+0900\n"
+"POT-Creation-Date: 2026-05-05 19:51+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language: ja_JP\n"
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../query-dsl.md:1
 msgid "Unified Criteria API"
@@ -152,12 +152,12 @@ msgstr "Select 設定"
 msgid "We support the following settings:"
 msgstr "次の設定をサポートしています。"
 
-#: ../../query-dsl.md:164 ../../query-dsl.md:1093 ../../query-dsl.md:1484
+#: ../../query-dsl.md:164 ../../query-dsl.md:1095 ../../query-dsl.md:1490
 msgid "allowEmptyWhere"
 msgstr ""
 
-#: ../../query-dsl.md:165 ../../query-dsl.md:1095 ../../query-dsl.md:1203
-#: ../../query-dsl.md:1486
+#: ../../query-dsl.md:165 ../../query-dsl.md:1097 ../../query-dsl.md:1205
+#: ../../query-dsl.md:1492
 msgid "comment"
 msgstr ""
 
@@ -169,13 +169,13 @@ msgstr ""
 msgid "maxRows"
 msgstr ""
 
-#: ../../query-dsl.md:168 ../../query-dsl.md:1097 ../../query-dsl.md:1204
-#: ../../query-dsl.md:1488
+#: ../../query-dsl.md:168 ../../query-dsl.md:1099 ../../query-dsl.md:1206
+#: ../../query-dsl.md:1494
 msgid "queryTimeout"
 msgstr ""
 
-#: ../../query-dsl.md:169 ../../query-dsl.md:1098 ../../query-dsl.md:1205
-#: ../../query-dsl.md:1489
+#: ../../query-dsl.md:169 ../../query-dsl.md:1100 ../../query-dsl.md:1207
+#: ../../query-dsl.md:1495
 msgid "sqlLogType"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgstr ""
 msgid "openStream"
 msgstr ""
 
-#: ../../query-dsl.md:238
+#: ../../query-dsl.md:240
 msgid "These methods provide efficient processing for large result sets."
 msgstr "これらのメソッドは、大きな結果セットに対して効率的な処理を提供します。"
 
-#: ../../query-dsl.md:240
+#: ../../query-dsl.md:242
 msgid "Select Expression"
 msgstr "Select 式"
 
-#: ../../query-dsl.md:242
+#: ../../query-dsl.md:244
 msgid "Entity Selection"
 msgstr "エンティティの検索"
 
-#: ../../query-dsl.md:244
+#: ../../query-dsl.md:246
 msgid ""
 "By default, the result entity type is the same as the type specified in "
 "the `from` method:"
 msgstr "デフォルトでは、結果エンティティの型は `from` メソッドで指定された型と同じです。"
 
-#: ../../query-dsl.md:256
+#: ../../query-dsl.md:258
 msgid "The above query generates the following SQL statement:"
 msgstr "上記のクエリは、次の SQL ステートメントを生成します。"
 
-#: ../../query-dsl.md:265
+#: ../../query-dsl.md:267
 msgid ""
 "To choose a joined entity type as the result entity type, use `project` "
 "or `select`:"
 msgstr "結果のエンティティタイプとして結合されたエンティティタイプを選択するには、`project` または `select` を使用します。"
 
-#: ../../query-dsl.md:278
+#: ../../query-dsl.md:280
 msgid "This query generates the following SQL:"
 msgstr "このクエリは以下のSQLを生成します。"
 
-#: ../../query-dsl.md:287
+#: ../../query-dsl.md:289
 msgid ""
 "The `project` method removes duplicate entities, while `select` does not."
 " If you call neither method, duplicates are removed by default."
@@ -267,72 +267,72 @@ msgstr ""
 "`project` メソッドは重複したエンティティを削除しますが、`select` "
 "は削除しません。どちらのメソッドも呼び出さない場合、重複はデフォルトで削除されます。"
 
-#: ../../query-dsl.md:291
+#: ../../query-dsl.md:293
 msgid "Multiple Entity Selection"
 msgstr "複数のエンティティの検索"
 
-#: ../../query-dsl.md:293
+#: ../../query-dsl.md:295
 msgid "Specify multiple entity types and fetch them as tuples:"
 msgstr "複数のエンティティタイプを指定し、タプルとしてフェッチします。"
 
-#: ../../query-dsl.md:307 ../../query-dsl.md:376 ../../query-dsl.md:573
-#: ../../query-dsl.md:625 ../../query-dsl.md:859
+#: ../../query-dsl.md:309 ../../query-dsl.md:378 ../../query-dsl.md:575
+#: ../../query-dsl.md:627 ../../query-dsl.md:861
 msgid "This query generates:"
 msgstr "このクエリは次のように生成されます。"
 
-#: ../../query-dsl.md:317
+#: ../../query-dsl.md:319
 msgid "In the tuple, an entity is null if all its properties are null."
 msgstr "タプル内では、すべてのプロパティが null の場合、エンティティは null になります。"
 
-#: ../../query-dsl.md:320
+#: ../../query-dsl.md:322
 msgid "The `select` method does not remove duplicates."
 msgstr "`select` メソッドは重複を削除しません。"
 
-#: ../../query-dsl.md:323
+#: ../../query-dsl.md:325
 msgid "Column Projection"
 msgstr "カラムの射影"
 
-#: ../../query-dsl.md:325
+#: ../../query-dsl.md:327
 msgid "To project columns, use `select`. For one column:"
 msgstr "カラムを選択するには、`select` を使用します。1つのカラムの選択は次のようにします。"
 
-#: ../../query-dsl.md:333 ../../query-dsl.md:350 ../../query-dsl.md:441
-#: ../../query-dsl.md:520 ../../query-dsl.md:541 ../../query-dsl.md:716
-#: ../../query-dsl.md:883 ../../query-dsl.md:940 ../../query-dsl.md:1016
-#: ../../query-dsl.md:1133 ../../query-dsl.md:1182 ../../query-dsl.md:1260
-#: ../../query-dsl.md:1331 ../../query-dsl.md:1406 ../../query-dsl.md:1424
-#: ../../query-dsl.md:1540 ../../query-dsl.md:1599 ../../query-dsl.md:1629
-#: ../../query-dsl.md:1657 ../../query-dsl.md:1677 ../../query-dsl.md:1709
-#: ../../query-dsl.md:1744 ../../query-dsl.md:1787 ../../query-dsl.md:1821
-#: ../../query-dsl.md:1907
+#: ../../query-dsl.md:335 ../../query-dsl.md:352 ../../query-dsl.md:443
+#: ../../query-dsl.md:522 ../../query-dsl.md:543 ../../query-dsl.md:718
+#: ../../query-dsl.md:885 ../../query-dsl.md:942 ../../query-dsl.md:1018
+#: ../../query-dsl.md:1135 ../../query-dsl.md:1184 ../../query-dsl.md:1264
+#: ../../query-dsl.md:1337 ../../query-dsl.md:1412 ../../query-dsl.md:1430
+#: ../../query-dsl.md:1548 ../../query-dsl.md:1609 ../../query-dsl.md:1639
+#: ../../query-dsl.md:1667 ../../query-dsl.md:1687 ../../query-dsl.md:1719
+#: ../../query-dsl.md:1754 ../../query-dsl.md:1797 ../../query-dsl.md:1833
+#: ../../query-dsl.md:1963
 msgid "This generates:"
 msgstr "このクエリは次のように生成されます。"
 
-#: ../../query-dsl.md:339
+#: ../../query-dsl.md:341
 msgid "For multiple columns:"
 msgstr "複数のカラムを選択する場合は次のようにします。"
 
-#: ../../query-dsl.md:356
+#: ../../query-dsl.md:358
 msgid ""
 "Columns up to 9 are held in `Tuple2` to `Tuple9`. Beyond that, they are "
 "held in `Row`."
 msgstr "9 列までは `Tuple2` から `Tuple9` で保持されます。それ以外は `Row` で保持されます。"
 
-#: ../../query-dsl.md:358
+#: ../../query-dsl.md:360
 msgid "Use `selectAsRow` for a `Row` list:"
 msgstr "`Row` リストには `selectAsRow` を使用します。"
 
-#: ../../query-dsl.md:366
+#: ../../query-dsl.md:368
 msgid "Column Projection and Mapping"
 msgstr "カラムの射影とマッピング"
 
-#: ../../query-dsl.md:368
+#: ../../query-dsl.md:370
 msgid ""
 "To project columns and map them to an entity, use the `projectTo` or "
 "`selectTo` methods:"
 msgstr "カラムを選択しエンティティにマップするには、`projectTo` または `selectTo` メソッドを使用します。"
 
-#: ../../query-dsl.md:382
+#: ../../query-dsl.md:384
 msgid ""
 "Note that the SQL select clause includes the primary key \"EMPLOYEE_ID\"."
 " The `projectTo` and `selectTo` methods always include the entity's ID "
@@ -341,81 +341,81 @@ msgstr ""
 "SQL の select 句にはプライマリキー \"EMPLOYEE_ID\" が含まれていることに注意してください。 `projectTo` と"
 " `selectTo` メソッドは、明示的に指定されていない場合でも、エンティティの ID プロパティを常に含めます。"
 
-#: ../../query-dsl.md:385
+#: ../../query-dsl.md:387
 msgid ""
 "The `projectTo` method removes duplicate entity IDs from the results, "
 "while `selectTo` does not."
 msgstr "`projectTo` メソッドは結果から重複したエンティティIDを削除しますが、`selectTo` メソッドは削除しません。"
 
-#: ../../query-dsl.md:390
+#: ../../query-dsl.md:392
 msgid "Where Expression"
 msgstr "Where 式"
 
-#: ../../query-dsl.md:392
+#: ../../query-dsl.md:394
 msgid "The following operators and predicates are supported:"
 msgstr "以下の演算子と述語がサポートされています。"
 
-#: ../../query-dsl.md:394 ../../query-dsl.md:754
+#: ../../query-dsl.md:396 ../../query-dsl.md:756
 msgid "eq - (=)"
 msgstr ""
 
-#: ../../query-dsl.md:395 ../../query-dsl.md:755
+#: ../../query-dsl.md:397 ../../query-dsl.md:757
 msgid "ne - (\\<>)"
 msgstr ""
 
-#: ../../query-dsl.md:396 ../../query-dsl.md:756
+#: ../../query-dsl.md:398 ../../query-dsl.md:758
 msgid "ge - (>=)"
 msgstr ""
 
-#: ../../query-dsl.md:397 ../../query-dsl.md:757
+#: ../../query-dsl.md:399 ../../query-dsl.md:759
 msgid "gt - (>)"
 msgstr ""
 
-#: ../../query-dsl.md:398 ../../query-dsl.md:758
+#: ../../query-dsl.md:400 ../../query-dsl.md:760
 msgid "le - (\\<=)"
 msgstr ""
 
-#: ../../query-dsl.md:399 ../../query-dsl.md:759
+#: ../../query-dsl.md:401 ../../query-dsl.md:761
 msgid "lt - (\\<)"
 msgstr ""
 
-#: ../../query-dsl.md:400
+#: ../../query-dsl.md:402
 msgid "isNull - (is null)"
 msgstr ""
 
-#: ../../query-dsl.md:401
+#: ../../query-dsl.md:403
 msgid "isNotNull - (is not null)"
 msgstr ""
 
-#: ../../query-dsl.md:402
+#: ../../query-dsl.md:404
 msgid "like"
 msgstr ""
 
-#: ../../query-dsl.md:403
+#: ../../query-dsl.md:405
 msgid "notLike - (not like)"
 msgstr ""
 
-#: ../../query-dsl.md:404
+#: ../../query-dsl.md:406
 msgid "between"
 msgstr ""
 
-#: ../../query-dsl.md:405
+#: ../../query-dsl.md:407
 msgid "in"
 msgstr ""
 
-#: ../../query-dsl.md:406
+#: ../../query-dsl.md:408
 msgid "notIn - (not in)"
 msgstr ""
 
-#: ../../query-dsl.md:407
+#: ../../query-dsl.md:409
 msgid "exists"
 msgstr ""
 
-#: ../../query-dsl.md:408
+#: ../../query-dsl.md:410
 msgid "notExists - (not exists)"
 msgstr ""
 
-#: ../../query-dsl.md:411
+#: ../../query-dsl.md:413
 msgid ""
 "If the right-hand operand is `null`, the WHERE or HAVING clause will "
 "exclude the operator. See [WhereDeclaration] and [HavingDeclaration] "
@@ -424,134 +424,134 @@ msgstr ""
 "右側のオペランドが `null` の場合、WHEREまたはHAVING句は演算子を除外します。詳細は [WhereDeclaration] と "
 "[HavingDeclaration] の javadoc を参照してください。"
 
-#: ../../query-dsl.md:414
+#: ../../query-dsl.md:416
 msgid "We also support utility operators:"
 msgstr "次のユーティリティ演算子もサポートしています。"
 
-#: ../../query-dsl.md:416
+#: ../../query-dsl.md:418
 msgid "eqOrIsNull - (\"=\" or \"is null\")"
 msgstr ""
 
-#: ../../query-dsl.md:417
+#: ../../query-dsl.md:419
 msgid "neOrIsNotNull - (\"\\<>\" or \"is not null\")"
 msgstr ""
 
-#: ../../query-dsl.md:419
+#: ../../query-dsl.md:421
 msgid "Additionally, the following logical operators are supported:"
 msgstr "さらに、以下の論理演算子がサポートされています。"
 
-#: ../../query-dsl.md:421 ../../query-dsl.md:763
+#: ../../query-dsl.md:423 ../../query-dsl.md:765
 msgid "and"
 msgstr ""
 
-#: ../../query-dsl.md:422 ../../query-dsl.md:764
+#: ../../query-dsl.md:424 ../../query-dsl.md:766
 msgid "or"
 msgstr ""
 
-#: ../../query-dsl.md:423 ../../query-dsl.md:765
+#: ../../query-dsl.md:425 ../../query-dsl.md:767
 msgid "not"
 msgstr ""
 
-#: ../../query-dsl.md:450
+#: ../../query-dsl.md:452
 msgid "Subqueries can be written as follows:"
 msgstr "サブクエリは以下のように記述できます。"
 
-#: ../../query-dsl.md:463 ../../query-dsl.md:780
+#: ../../query-dsl.md:465 ../../query-dsl.md:782
 msgid "The above query generates:"
 msgstr "上記のクエリは以下のものを生成します。"
 
-#: ../../query-dsl.md:473
+#: ../../query-dsl.md:475
 msgid "Dynamic Where Expression"
 msgstr "動的な Where 式"
 
-#: ../../query-dsl.md:475
+#: ../../query-dsl.md:477
 msgid ""
 "A WHERE expression uses only evaluated operators to build a WHERE clause."
 " When no operators are evaluated in the expression, the statement omits "
 "the WHERE clause."
 msgstr "WHERE式はWHERE句を構築するために評価された演算子のみを使用します。 式で演算子が評価されない場合は、WHERE句は省略されます。"
 
-#: ../../query-dsl.md:477
+#: ../../query-dsl.md:479
 msgid "For example, with a conditional expression:"
 msgstr "例えば、条件付き式を指定します。"
 
-#: ../../query-dsl.md:493
+#: ../../query-dsl.md:495
 msgid ""
 "If `enableNameCondition` is `false`, the `like` expression is ignored, "
 "generating:"
 msgstr "`enableNameCondition` が `false` の場合、`like` 式は無視されます。"
 
-#: ../../query-dsl.md:501
+#: ../../query-dsl.md:503
 msgid "Join Expression"
 msgstr "Join 式"
 
-#: ../../query-dsl.md:503
+#: ../../query-dsl.md:505
 msgid "We support the following join expressions:"
 msgstr "以下のjoin式をサポートします。"
 
-#: ../../query-dsl.md:505
+#: ../../query-dsl.md:507
 msgid "innerJoin - (inner join)"
 msgstr ""
 
-#: ../../query-dsl.md:506
+#: ../../query-dsl.md:508
 msgid "leftJoin - (left outer join)"
 msgstr ""
 
-#: ../../query-dsl.md:508
+#: ../../query-dsl.md:510
 msgid "Example for innerJoin:"
 msgstr "innerJoinの例:"
 
-#: ../../query-dsl.md:529
+#: ../../query-dsl.md:531
 msgid "Example for leftJoin:"
 msgstr "leftJoinの例:"
 
-#: ../../query-dsl.md:551
+#: ../../query-dsl.md:553
 msgid "Association"
 msgstr "関連付け"
 
-#: ../../query-dsl.md:553
+#: ../../query-dsl.md:555
 msgid ""
 "You can associate entities using the `associate` operation in conjunction"
 " with a join expression:"
 msgstr "joinと一緒に `associate` を使用し、エンティティを関連付けることができます"
 
-#: ../../query-dsl.md:583
+#: ../../query-dsl.md:585
 msgid "Associating Multiple Entities:"
 msgstr "複数のエンティティを関連づける場合は次のようにします。"
 
-#: ../../query-dsl.md:606
+#: ../../query-dsl.md:608
 msgid "Associating Immutable Entities"
 msgstr "不変エンティティの関連付け"
 
-#: ../../query-dsl.md:608
+#: ../../query-dsl.md:610
 msgid ""
 "To associate immutable entities, use the `associateWith` operation with a"
 " join expression:"
 msgstr "イミュータブルなエンティティを関連付けるには、joinと一緒に `associateWith` を使用します。"
 
-#: ../../query-dsl.md:639
+#: ../../query-dsl.md:641
 msgid "Dynamic Join Expression"
 msgstr "動的な Join 式"
 
-#: ../../query-dsl.md:641
+#: ../../query-dsl.md:643
 msgid ""
 "A join expression uses only evaluated operators to build a JOIN clause. "
 "When no operators are evaluated, the JOIN clause is omitted."
 msgstr "join式は、評価された演算子のみを使用してJOIN句を構築します。演算子が評価されない場合は、JOIN句は省略されます。"
 
-#: ../../query-dsl.md:643
+#: ../../query-dsl.md:645
 msgid "For example, with a conditional join:"
 msgstr "例えば、条件付きjoinを使用する場合は次のようにします。"
 
-#: ../../query-dsl.md:659
+#: ../../query-dsl.md:661
 msgid "If `join` is `false`, the `on` expression is ignored, generating:"
 msgstr "`join` が `false` の場合、`on` 式は無視されます。"
 
-#: ../../query-dsl.md:667
+#: ../../query-dsl.md:669
 msgid "Dynamic Association"
 msgstr "動的な関連付け"
 
-#: ../../query-dsl.md:669
+#: ../../query-dsl.md:671
 msgid ""
 "With dynamic join expressions, associations can be made optional. Use "
 "`AssociationOption.optional()` in the `associate` method:"
@@ -559,47 +559,47 @@ msgstr ""
 "動的なjoin式では、関連付けを任意にすることができます。`AssociationOption.optional()` を `associate`"
 " メソッドで使用します。"
 
-#: ../../query-dsl.md:693
+#: ../../query-dsl.md:695
 msgid "Aggregate Functions"
 msgstr "集約関数"
 
-#: ../../query-dsl.md:695
+#: ../../query-dsl.md:697
 msgid "The following aggregate functions are supported:"
 msgstr "次の集約関数がサポートされています。"
 
-#: ../../query-dsl.md:697
+#: ../../query-dsl.md:699
 msgid "avg(property)"
 msgstr ""
 
-#: ../../query-dsl.md:698
+#: ../../query-dsl.md:700
 msgid "avgAsDouble(property)"
 msgstr ""
 
-#: ../../query-dsl.md:699
+#: ../../query-dsl.md:701
 msgid "count()"
 msgstr ""
 
-#: ../../query-dsl.md:700
+#: ../../query-dsl.md:702
 msgid "count(property)"
 msgstr ""
 
-#: ../../query-dsl.md:701
+#: ../../query-dsl.md:703
 msgid "countDistinct(property)"
 msgstr ""
 
-#: ../../query-dsl.md:702
+#: ../../query-dsl.md:704
 msgid "max(property)"
 msgstr ""
 
-#: ../../query-dsl.md:703
+#: ../../query-dsl.md:705
 msgid "min(property)"
 msgstr ""
 
-#: ../../query-dsl.md:704
+#: ../../query-dsl.md:706
 msgid "sum(property)"
 msgstr ""
 
-#: ../../query-dsl.md:706
+#: ../../query-dsl.md:708
 msgid ""
 "These functions are defined in the "
 "`org.seasar.doma.jdbc.criteria.expression.Expressions` class and can be "
@@ -608,25 +608,25 @@ msgstr ""
 "これらは `org.seasar.doma.jdbc.criteria.expression.Expressions` "
 "クラスで定義されており、静的インポートで使用できます。"
 
-#: ../../query-dsl.md:708
+#: ../../query-dsl.md:710
 msgid "For example, to pass the `sum` function to the select method:"
 msgstr "たとえば、 `sum` 関数を select メソッドに渡すことができます。"
 
-#: ../../query-dsl.md:722
+#: ../../query-dsl.md:724
 msgid "Group By Expression"
 msgstr "Group by 式"
 
-#: ../../query-dsl.md:724
+#: ../../query-dsl.md:726
 msgid ""
 "Group by expressions allow for grouping results based on specified "
 "columns:"
 msgstr "Group by式を使うと、指定された列に基づいて結果をグループ化できます。"
 
-#: ../../query-dsl.md:736
+#: ../../query-dsl.md:738
 msgid "The above code generates:"
 msgstr "上記のコードは以下のものを生成します。"
 
-#: ../../query-dsl.md:742
+#: ../../query-dsl.md:744
 msgid ""
 "When a group by expression is not specified, the expression is inferred "
 "from the select expression automatically. Thus, the following code issues"
@@ -635,89 +635,89 @@ msgstr ""
 "group by 式を指定しない場合、group by 式は select 式から自動的に推測されます。したがって、次のコードは上記と同じ SQL"
 " ステートメントを発行します。"
 
-#: ../../query-dsl.md:750
+#: ../../query-dsl.md:752
 msgid "Having Expression"
 msgstr "Having 式"
 
-#: ../../query-dsl.md:752
+#: ../../query-dsl.md:754
 msgid "The following operators are supported in having expressions:"
 msgstr "以下の演算子は、having 式でサポートされています。"
 
-#: ../../query-dsl.md:761
+#: ../../query-dsl.md:763
 msgid "Logical operators are also supported:"
 msgstr "論理演算子もサポートされています。"
 
-#: ../../query-dsl.md:790
+#: ../../query-dsl.md:792
 msgid "Dynamic Having Expression"
 msgstr "動的な Having 式"
 
-#: ../../query-dsl.md:792
+#: ../../query-dsl.md:794
 msgid ""
 "A having expression includes only evaluated operators, omitting the "
 "HAVING clause if no operators are evaluated."
 msgstr "having 式は評価された演算子のみを含み、どの演算子も評価されない場合は HAVING 句を省略します。"
 
-#: ../../query-dsl.md:794
+#: ../../query-dsl.md:796
 msgid "For instance, a conditional expression in a having clause:"
 msgstr "例えば、HAVING句の条件式は以下の通りです。"
 
-#: ../../query-dsl.md:813
+#: ../../query-dsl.md:815
 msgid ""
 "If `countCondition` is `false`, the `having` clause is ignored in the SQL"
 " statement."
 msgstr "`countCondition` が `false` の場合、SQL文では `having` 句は無視されます。"
 
-#: ../../query-dsl.md:815
+#: ../../query-dsl.md:817
 msgid "Order By Expression"
 msgstr "Order by 式"
 
-#: ../../query-dsl.md:817
+#: ../../query-dsl.md:819
 msgid "Supported ordering operations are:"
 msgstr "サポートされている順序操作は次のとおりです。"
 
-#: ../../query-dsl.md:819
+#: ../../query-dsl.md:821
 msgid "asc"
 msgstr ""
 
-#: ../../query-dsl.md:820
+#: ../../query-dsl.md:822
 msgid "desc"
 msgstr ""
 
-#: ../../query-dsl.md:834 ../../query-dsl.md:911
+#: ../../query-dsl.md:836 ../../query-dsl.md:913
 msgid "The query above generates:"
 msgstr "上記のクエリは以下のものを生成します。"
 
-#: ../../query-dsl.md:843
+#: ../../query-dsl.md:845
 msgid "Dynamic Order By Expression"
 msgstr "動的な Order by 式"
 
-#: ../../query-dsl.md:845
+#: ../../query-dsl.md:847
 msgid ""
 "Order by expressions use only evaluated operators to build the ORDER BY "
 "clause. When no operators are evaluated, the ORDER BY clause is omitted."
 msgstr "order by式は、評価された演算子のみを使用してORDER BY句を構築します。演算子が評価されない場合は、ORDER BY句は省略されます。"
 
-#: ../../query-dsl.md:847
+#: ../../query-dsl.md:849
 msgid "Distinct Expression"
 msgstr "Distinct 式"
 
-#: ../../query-dsl.md:849
+#: ../../query-dsl.md:851
 msgid "To select distinct rows, use `distinct()`:"
 msgstr "重複のない行を検索するには、 `distinct()` を使用します。"
 
-#: ../../query-dsl.md:868
+#: ../../query-dsl.md:870
 msgid "Limit and Offset Expression"
 msgstr "Limit および Offset 式"
 
-#: ../../query-dsl.md:870
+#: ../../query-dsl.md:872
 msgid "To limit the number of rows and specify an offset:"
 msgstr "行数を制限し、オフセットを指定するには、次のようにします。"
 
-#: ../../query-dsl.md:893
+#: ../../query-dsl.md:895
 msgid "Dynamic Limit and Offset Expression"
 msgstr "動的な Limit および Offset 式"
 
-#: ../../query-dsl.md:895
+#: ../../query-dsl.md:897
 msgid ""
 "Limit and offset expressions include only non-null values in the SQL. If "
 "either value is null, the corresponding FETCH FIRST or OFFSET clause is "
@@ -726,384 +726,384 @@ msgstr ""
 "limit および offset 式は SQL 内で null でない値のみを含みます。null の場合、対応する FETCH FIRST または"
 " OFFSET 句は省略されます。"
 
-#: ../../query-dsl.md:897
+#: ../../query-dsl.md:899
 msgid "For Update Expression"
 msgstr "For update 式"
 
-#: ../../query-dsl.md:899
+#: ../../query-dsl.md:901
 msgid "The `forUpdate` method allows row locking in SQL:"
 msgstr "`forUpdate` メソッドはSQLで行をロックできます。"
 
-#: ../../query-dsl.md:921
+#: ../../query-dsl.md:923
 msgid "Union Expression"
 msgstr "Union 式"
 
-#: ../../query-dsl.md:923
+#: ../../query-dsl.md:925
 msgid "Supported union operations include:"
 msgstr "サポートされているUNION操作は次のとおりです。"
 
-#: ../../query-dsl.md:925
+#: ../../query-dsl.md:927
 msgid "union"
 msgstr ""
 
-#: ../../query-dsl.md:926
+#: ../../query-dsl.md:928
 msgid "unionAll - (union all)"
 msgstr ""
 
-#: ../../query-dsl.md:948
+#: ../../query-dsl.md:950
 msgid "Using order by with an index in union queries:"
 msgstr "UNIONクエリでインデックスを指定してorder byを使用するには次のようにします。"
 
-#: ../../query-dsl.md:960
+#: ../../query-dsl.md:962
 msgid "Derived Table Expression"
 msgstr "派生テーブル式"
 
-#: ../../query-dsl.md:962
+#: ../../query-dsl.md:964
 msgid ""
 "Subqueries using derived tables are supported. A corresponding entity "
 "class for the derived table is required."
 msgstr "派生テーブルを使用したサブクエリがサポートされていますが、派生テーブルに対応するエンティティクラスが必要です。"
 
-#: ../../query-dsl.md:964
+#: ../../query-dsl.md:966
 msgid "Define the entity class for the derived table as follows:"
 msgstr "派生テーブルに対応するエンティティ クラスを次のように定義します。"
 
-#: ../../query-dsl.md:997
+#: ../../query-dsl.md:999
 msgid "A subquery using a derived table can be written as follows:"
 msgstr "派生テーブルを使用したサブクエリは次のように記述できます。"
 
-#: ../../query-dsl.md:1038
+#: ../../query-dsl.md:1040
 msgid "Common Table Expression"
 msgstr "共通テーブル式"
 
-#: ../../query-dsl.md:1040
+#: ../../query-dsl.md:1042
 msgid ""
 "Common Table Expressions (CTEs) are supported. To use a CTE, a "
 "corresponding entity class must be defined."
 msgstr "共通テーブル式（CTE）はサポートされています。CTEを使用するには、対応するエンティティクラスを定義する必要があります。"
 
-#: ../../query-dsl.md:1043
+#: ../../query-dsl.md:1045
 msgid "Define the entity class for the CTE as follows:"
 msgstr "CTEに対応するエンティティクラスを次のように定義します:"
 
-#: ../../query-dsl.md:1050
+#: ../../query-dsl.md:1052
 msgid "A query using the CTE can be written as follows:"
 msgstr "CTEを使用したクエリは次のように記述できます。"
 
-#: ../../query-dsl.md:1068
+#: ../../query-dsl.md:1070
 msgid "The above query generates the following SQL:"
 msgstr "上記のクエリは以下のSQLを生成します:"
 
-#: ../../query-dsl.md:1085
+#: ../../query-dsl.md:1087
 msgid "Delete Statement"
 msgstr "Delete ステートメント"
 
-#: ../../query-dsl.md:1087
+#: ../../query-dsl.md:1089
 msgid ""
 "The delete statement follows the same rules as the [Where Expression"
 "](#where-expression)."
 msgstr "DELETEステートメントは、[](#where-expression) と同じルールに従います。"
 
-#: ../../query-dsl.md:1089
+#: ../../query-dsl.md:1091
 msgid "Delete Settings"
 msgstr "Delete 設定"
 
-#: ../../query-dsl.md:1091 ../../query-dsl.md:1482
+#: ../../query-dsl.md:1093 ../../query-dsl.md:1488
 msgid "The following settings are supported:"
 msgstr "次の設定がサポートされています。"
 
-#: ../../query-dsl.md:1094 ../../query-dsl.md:1206 ../../query-dsl.md:1485
+#: ../../query-dsl.md:1096 ../../query-dsl.md:1208 ../../query-dsl.md:1491
 msgid "batchSize"
 msgstr ""
 
-#: ../../query-dsl.md:1096 ../../query-dsl.md:1487
+#: ../../query-dsl.md:1098 ../../query-dsl.md:1493
 msgid "ignoreVersion"
 msgstr ""
 
-#: ../../query-dsl.md:1099 ../../query-dsl.md:1490
+#: ../../query-dsl.md:1101 ../../query-dsl.md:1496
 msgid "suppressOptimisticLockException"
 msgstr ""
 
-#: ../../query-dsl.md:1101 ../../query-dsl.md:1212 ../../query-dsl.md:1495
+#: ../../query-dsl.md:1103 ../../query-dsl.md:1214 ../../query-dsl.md:1501
 msgid "All are optional and can be applied as follows:"
 msgstr "すべてオプションで、以下のように適用できます。"
 
-#: ../../query-dsl.md:1120
+#: ../../query-dsl.md:1122
 msgid ""
 "To allow a delete statement with an empty WHERE clause, enable the "
 "`allowEmptyWhere` setting."
 msgstr "空のWHERE句でDELETEステートメントを許可するには、 `allowEmptyWhere` 設定を有効にしてください。"
 
-#: ../../query-dsl.md:1123
+#: ../../query-dsl.md:1125
 msgid "Delete Record by Entity"
 msgstr "エンティティによるレコードの削除"
 
-#: ../../query-dsl.md:1139
+#: ../../query-dsl.md:1141
 msgid "Batch Delete is also supported:"
 msgstr "バッチ削除もサポートされています。"
 
-#: ../../query-dsl.md:1147
+#: ../../query-dsl.md:1149
 msgid "Exceptions thrown by the execute method include:"
 msgstr "execute メソッドによって投げられる例外は次のとおりです。"
 
-#: ../../query-dsl.md:1149
+#: ../../query-dsl.md:1151
 msgid ""
 "OptimisticLockException: if the entity has a version property and an "
 "update count is 0"
 msgstr "OptimisticLockException: エンティティにバージョンプロパティがあり、更新件数が 0 の場合"
 
-#: ../../query-dsl.md:1151
+#: ../../query-dsl.md:1153
 msgid "Delete Record by Entity and Retrieve the Deleted Record"
 msgstr "エンティティによるレコードの削除と削除されたレコードの取得"
 
-#: ../../query-dsl.md:1153
+#: ../../query-dsl.md:1155
 msgid ""
 "By calling the `returning` method, you can delete an entity and retrieve "
 "the deleted entity at the same time:"
 msgstr "`returning` メソッドを呼び出すことで、エンティティを削除すると同時に削除したエンティティを取得できます。"
 
-#: ../../query-dsl.md:1159 ../../query-dsl.md:1368 ../../query-dsl.md:1569
+#: ../../query-dsl.md:1161 ../../query-dsl.md:1374 ../../query-dsl.md:1579
 msgid "This generates the following SQL:"
 msgstr "このSQLを生成します。"
 
-#: ../../query-dsl.md:1166 ../../query-dsl.md:1375 ../../query-dsl.md:1577
+#: ../../query-dsl.md:1168 ../../query-dsl.md:1381 ../../query-dsl.md:1587
 msgid "You can also specify which properties to return in the `returning` method."
 msgstr "`returning` メソッドで返すプロパティを指定することもできます。"
 
-#: ../../query-dsl.md:1168 ../../query-dsl.md:1377 ../../query-dsl.md:1579
+#: ../../query-dsl.md:1170 ../../query-dsl.md:1383 ../../query-dsl.md:1589
 msgid ""
 "To receive the result as an `Optional`, use the `fetchOptional` method "
 "instead of `fetchOne`."
 msgstr "結果を `Optional` として受け取るには、`fetchOne` の代わりに `fetchOptional` メソッドを使用します。"
 
-#: ../../query-dsl.md:1171 ../../query-dsl.md:1387 ../../query-dsl.md:1582
+#: ../../query-dsl.md:1173 ../../query-dsl.md:1393 ../../query-dsl.md:1592
 msgid ""
 "Only H2 Database, PostgreSQL, SQL Server, and SQLite Dialects support "
 "this feature."
 msgstr "この機能は、H2 Database、PostgreSQL、SQL Server、およびSQLiteのダイアレクトのみがサポートしています。"
 
-#: ../../query-dsl.md:1174
+#: ../../query-dsl.md:1176
 msgid "Delete Records by Where Expression"
 msgstr "Where 式によるレコードの削除"
 
-#: ../../query-dsl.md:1176
+#: ../../query-dsl.md:1178
 msgid "To delete by a condition:"
 msgstr "条件で削除するには次のようにします。"
 
-#: ../../query-dsl.md:1188
+#: ../../query-dsl.md:1190
 msgid "To delete all records, use the `all` method:"
 msgstr "すべてのレコードを削除するには、`all` メソッドを使用します。"
 
-#: ../../query-dsl.md:1194
+#: ../../query-dsl.md:1196
 msgid "Insert Statement"
 msgstr "Insert ステートメント"
 
-#: ../../query-dsl.md:1196
+#: ../../query-dsl.md:1198
 msgid ""
 "If a unique constraint violation occurs during the execution of an insert"
 " statement, a `UniqueConstraintException` will be thrown."
 msgstr "INSERT文の実行中に一意制約違反が発生すると、`UniqueConstraintException` がスローされます。"
 
-#: ../../query-dsl.md:1199
+#: ../../query-dsl.md:1201
 msgid "Insert Settings"
 msgstr "Insert 設定"
 
-#: ../../query-dsl.md:1201
+#: ../../query-dsl.md:1203
 msgid "Supported insert settings include:"
 msgstr "サポートされている追加の設定は次のとおりです:"
 
-#: ../../query-dsl.md:1207 ../../query-dsl.md:1491
+#: ../../query-dsl.md:1209 ../../query-dsl.md:1497
 msgid "excludeNull"
 msgstr ""
 
-#: ../../query-dsl.md:1208 ../../query-dsl.md:1492
+#: ../../query-dsl.md:1210 ../../query-dsl.md:1498
 msgid "include"
 msgstr ""
 
-#: ../../query-dsl.md:1209 ../../query-dsl.md:1493
+#: ../../query-dsl.md:1211 ../../query-dsl.md:1499
 msgid "exclude"
 msgstr ""
 
-#: ../../query-dsl.md:1210
+#: ../../query-dsl.md:1212
 msgid "ignoreGeneratedKeys"
 msgstr ""
 
-#: ../../query-dsl.md:1234
+#: ../../query-dsl.md:1236
 msgid "You can specify excluded columns:"
 msgstr "除外するカラムを指定できます。"
 
-#: ../../query-dsl.md:1244
+#: ../../query-dsl.md:1246
 msgid "Insert Record with Entity"
 msgstr "エンティティによるレコードの追加"
 
-#: ../../query-dsl.md:1246
+#: ../../query-dsl.md:1248
 msgid "single"
 msgstr "single"
 
-#: ../../query-dsl.md:1248
+#: ../../query-dsl.md:1250
 msgid "Inserting a single entity:"
 msgstr "単一のエンティティの追加:"
 
-#: ../../query-dsl.md:1267 ../../query-dsl.md:1301 ../../query-dsl.md:1338
-#: ../../query-dsl.md:1432
+#: ../../query-dsl.md:1271 ../../query-dsl.md:1307 ../../query-dsl.md:1344
+#: ../../query-dsl.md:1438
 msgid "Functionality equivalent to `INSERT ... ON CONFLICT` is supported."
 msgstr "`INSERT ... ON CONFLICT` に相当する機能がサポートされています。"
 
-#: ../../query-dsl.md:1269
+#: ../../query-dsl.md:1273
 msgid ""
 "Use the `onDuplicateKeyUpdate` method to update the existing record when "
 "a duplicate key is found:"
 msgstr "重複したキーが見つかった場合、既存のレコードを更新するために `onDuplicateKeyUpdate` メソッドを使用します。"
 
-#: ../../query-dsl.md:1279
+#: ../../query-dsl.md:1283
 msgid ""
 "Use the `onDuplicateKeyIgnore` method when you want to do nothing in case"
 " of a duplicate key:"
 msgstr "重複したキーが見つかった場合、何もしないことを表すには `onDuplicateKeyIgnore` メソッドを使用します。"
 
-#: ../../query-dsl.md:1289
+#: ../../query-dsl.md:1293
 msgid "batch"
 msgstr "batch"
 
-#: ../../query-dsl.md:1291
+#: ../../query-dsl.md:1295
 msgid "Batch Insert is also supported:"
 msgstr "バッチ追加もサポートされています。"
 
-#: ../../query-dsl.md:1303 ../../query-dsl.md:1340
+#: ../../query-dsl.md:1309 ../../query-dsl.md:1346
 msgid ""
 "Use the `onDuplicateKeyUpdate` method to update existing records when "
 "duplicate keys are found:"
 msgstr "重複したキーが見つかった場合、既存のレコードを更新するために `onDuplicateKeyUpdate` メソッドを使用します。"
 
-#: ../../query-dsl.md:1313
+#: ../../query-dsl.md:1319
 msgid ""
 "Use the `onDuplicateKeyIgnore` method to skip the insert operation when a"
 " duplicate key is found:"
 msgstr "重複したキーが見つかった場合、何もしないことを表すには `onDuplicateKeyIgnore` メソッドを使用します。"
 
-#: ../../query-dsl.md:1323
+#: ../../query-dsl.md:1329
 msgid "multi"
 msgstr "multi"
 
-#: ../../query-dsl.md:1325
+#: ../../query-dsl.md:1331
 msgid "Multi-row Insert is also supported:"
 msgstr "複数行追加もサポートされています。"
 
-#: ../../query-dsl.md:1350 ../../query-dsl.md:1456
+#: ../../query-dsl.md:1356 ../../query-dsl.md:1462
 msgid ""
 "Use the `onDuplicateKeyIgnore` method to skip insert operations when "
 "duplicate keys are found:"
 msgstr "重複したキーが見つかった場合、何もしないことを表すには `onDuplicateKeyIgnore` メソッドを使用します。"
 
-#: ../../query-dsl.md:1360
+#: ../../query-dsl.md:1366
 msgid "Insert Record with Entity and Retrieve the Inserted Record"
 msgstr "エンティティでレコードを追加し、追加されたレコードを取得する"
 
-#: ../../query-dsl.md:1362
+#: ../../query-dsl.md:1368
 msgid ""
 "By calling the `returning` method, you can insert an entity and retrieve "
 "the inserted entity at the same time:"
 msgstr "`returning` メソッドを呼び出すことで、エンティティを追加すると同時に追加したエンティティを取得できます。"
 
-#: ../../query-dsl.md:1379
+#: ../../query-dsl.md:1385
 msgid ""
 "The `returning` method is also supported for multi-row inserts. In that "
 "case, the `fetch` method returns a List of inserted entities:"
 msgstr "`returning` メソッドは複数行追加にも対応しています。その場合、 `fetch` メソッドは、挿入されたエンティティのリストを返します。"
 
-#: ../../query-dsl.md:1390
+#: ../../query-dsl.md:1396
 msgid "Insert Record with Specified Values"
 msgstr "指定された値によるレコードの追加"
 
-#: ../../query-dsl.md:1392
+#: ../../query-dsl.md:1398
 msgid "Inserting records by specifying values:"
 msgstr "値を指定してレコードを追加するには次のようにします。"
 
-#: ../../query-dsl.md:1413
+#: ../../query-dsl.md:1419
 msgid "We also support the INSERT SELECT syntax:"
 msgstr "INSERT SELECT 構文もサポートしています。"
 
-#: ../../query-dsl.md:1434
+#: ../../query-dsl.md:1440
 msgid ""
 "Use the `onDuplicateKeyUpdate` method when you want to perform an update "
 "in case of a duplicate key:"
 msgstr "重複したキーが見つかった場合、既存のレコードを更新するために `onDuplicateKeyUpdate` メソッドを使用します。"
 
-#: ../../query-dsl.md:1473
+#: ../../query-dsl.md:1479
 msgid "Update Statement"
 msgstr "Update ステートメント"
 
-#: ../../query-dsl.md:1475
+#: ../../query-dsl.md:1481
 msgid ""
 "If a unique constraint violation occurs during the execution of an update"
 " statement, a `UniqueConstraintException` will be thrown."
 msgstr "UPDATE文の実行中に一意制約違反が発生すると、`UniqueConstraintException` がスローされます。"
 
-#: ../../query-dsl.md:1478
+#: ../../query-dsl.md:1484
 msgid ""
 "The update statement follows the same specifications as the [Where "
 "Expression](#where-expression)."
 msgstr "UPDATEステートメントは、[](#where-expression) と同じルールに従います。"
 
-#: ../../query-dsl.md:1480
+#: ../../query-dsl.md:1486
 msgid "Update Settings"
 msgstr "Update 設定"
 
-#: ../../query-dsl.md:1514
+#: ../../query-dsl.md:1520
 msgid "You can also specify excluded columns:"
 msgstr "除外するカラムを指定することもできます。"
 
-#: ../../query-dsl.md:1525
+#: ../../query-dsl.md:1531
 msgid ""
 "To perform an update without a WHERE clause, enable the `allowEmptyWhere`"
 " setting."
 msgstr "WHERE句なしで更新を実行するには、 `allowEmptyWhere` の設定を有効にしてください。"
 
-#: ../../query-dsl.md:1528
+#: ../../query-dsl.md:1534
 msgid "Update Record by Entity"
 msgstr "エンティティによるレコードの更新"
 
-#: ../../query-dsl.md:1530
+#: ../../query-dsl.md:1536
 msgid "Updating a single entity:"
 msgstr "単一のエンティティを更新するには次のようにします。"
 
-#: ../../query-dsl.md:1547
+#: ../../query-dsl.md:1555
 msgid "Batch Update is also supported:"
 msgstr "バッチ更新もサポートされています。"
 
-#: ../../query-dsl.md:1557
+#: ../../query-dsl.md:1567
 msgid "Exceptions from the execute method may include:"
 msgstr "execute メソッドによって投げられる例外は次のとおりです。"
 
-#: ../../query-dsl.md:1559
+#: ../../query-dsl.md:1569
 msgid ""
 "OptimisticLockException: if the entity has a version property and the "
 "update count is 0"
 msgstr "OptimisticLockException: エンティティにバージョンプロパティがあり、更新件数が 0 の場合"
 
-#: ../../query-dsl.md:1561
+#: ../../query-dsl.md:1571
 msgid "Update Record by Entity and Retrieve the Updated Record"
 msgstr "エンティティによるレコードの更新と更新されたレコードの取得"
 
-#: ../../query-dsl.md:1563
+#: ../../query-dsl.md:1573
 msgid ""
 "By calling the `returning` method, you can update an entity and retrieve "
 "the updated entity at the same time:"
 msgstr "`returning` メソッドを呼び出すことで、エンティティを更新すると同時に更新したエンティティを取得できます。"
 
-#: ../../query-dsl.md:1585
+#: ../../query-dsl.md:1595
 msgid "Update Records by Where Expression"
 msgstr "Where 式によるレコードの更新"
 
-#: ../../query-dsl.md:1587
+#: ../../query-dsl.md:1597
 msgid "To update records based on a condition:"
 msgstr "条件に基づいてレコードを更新するには次のようにします。"
 
-#: ../../query-dsl.md:1606
+#: ../../query-dsl.md:1616
 msgid "Property Expressions"
 msgstr "プロパティ式"
 
-#: ../../query-dsl.md:1608
+#: ../../query-dsl.md:1618
 msgid ""
 "All property expression methods are in the "
 "`org.seasar.doma.jdbc.criteria.expression.Expressions` class and can be "
@@ -1112,177 +1112,177 @@ msgstr ""
 "すべてのプロパティ式メソッドは `org.seasar.doma.jdbc.criteria.expression.Expressions` "
 "クラスにあり、静的なインポートで使用できます。"
 
-#: ../../query-dsl.md:1610
+#: ../../query-dsl.md:1620
 msgid "Arithmetic Expressions"
 msgstr "算術式"
 
-#: ../../query-dsl.md:1612
+#: ../../query-dsl.md:1622
 msgid "The following methods are available for arithmetic expressions:"
 msgstr "算術式には以下のメソッドがあります。"
 
-#: ../../query-dsl.md:1614
+#: ../../query-dsl.md:1624
 msgid "add - (+)"
 msgstr ""
 
-#: ../../query-dsl.md:1615
+#: ../../query-dsl.md:1625
 msgid "sub - (-)"
 msgstr ""
 
-#: ../../query-dsl.md:1616
+#: ../../query-dsl.md:1626
 msgid "mul - (\\*)"
 msgstr ""
 
-#: ../../query-dsl.md:1617
+#: ../../query-dsl.md:1627
 msgid "div - (/)"
 msgstr ""
 
-#: ../../query-dsl.md:1618
+#: ../../query-dsl.md:1628
 msgid "mod - (%)"
 msgstr ""
 
-#: ../../query-dsl.md:1620
+#: ../../query-dsl.md:1630
 msgid "Example of using the `add` method:"
 msgstr "`add` メソッドを使用する例です。"
 
-#: ../../query-dsl.md:1637
+#: ../../query-dsl.md:1647
 msgid "String Functions"
 msgstr "文字列関数"
 
-#: ../../query-dsl.md:1639
+#: ../../query-dsl.md:1649
 msgid "The following string functions are provided:"
 msgstr "次の文字列関数が提供されます。"
 
-#: ../../query-dsl.md:1641
+#: ../../query-dsl.md:1651
 msgid "concat"
 msgstr ""
 
-#: ../../query-dsl.md:1642
+#: ../../query-dsl.md:1652
 msgid "lower"
 msgstr ""
 
-#: ../../query-dsl.md:1643
+#: ../../query-dsl.md:1653
 msgid "upper"
 msgstr ""
 
-#: ../../query-dsl.md:1644
+#: ../../query-dsl.md:1654
 msgid "trim"
 msgstr ""
 
-#: ../../query-dsl.md:1645
+#: ../../query-dsl.md:1655
 msgid "ltrim"
 msgstr ""
 
-#: ../../query-dsl.md:1646
+#: ../../query-dsl.md:1656
 msgid "rtrim"
 msgstr ""
 
-#: ../../query-dsl.md:1648
+#: ../../query-dsl.md:1658
 msgid "Example using `concat`:"
 msgstr "`concat` を使用した例です。"
 
-#: ../../query-dsl.md:1665
+#: ../../query-dsl.md:1675
 msgid "Literal Expression"
 msgstr "リテラル式"
 
-#: ../../query-dsl.md:1667
+#: ../../query-dsl.md:1677
 msgid "The `literal` method supports all basic data types."
 msgstr "`literal` メソッドはすべての基本データ型をサポートしています。"
 
-#: ../../query-dsl.md:1669
+#: ../../query-dsl.md:1679
 msgid "Example of using `literal`:"
 msgstr "`literal` を使用する例です。"
 
-#: ../../query-dsl.md:1687
+#: ../../query-dsl.md:1697
 msgid ""
 "Note that literal expressions are directly embedded in the SQL rather "
 "than being treated as bind variables."
 msgstr "リテラル式はバインド変数として扱われるのではなく、SQLに直接埋め込まれることに注意してください。"
 
-#: ../../query-dsl.md:1690
+#: ../../query-dsl.md:1700
 msgid "Case Expression"
 msgstr "Case 式"
 
-#: ../../query-dsl.md:1692
+#: ../../query-dsl.md:1702
 msgid "The following method is supported for case expressions:"
 msgstr "以下のメソッドがcase式でサポートされています。"
 
-#: ../../query-dsl.md:1694
+#: ../../query-dsl.md:1704
 msgid "when"
 msgstr ""
 
-#: ../../query-dsl.md:1696
+#: ../../query-dsl.md:1706
 msgid "Example of using `when`:"
 msgstr "`when` を使用する例は次のとおりです。"
 
-#: ../../query-dsl.md:1719
+#: ../../query-dsl.md:1729
 msgid "Subquery Select Expression"
 msgstr "サブクエリ select 式"
 
-#: ../../query-dsl.md:1721
+#: ../../query-dsl.md:1731
 msgid "The `select` method supports subquery select expressions."
 msgstr "`select` メソッドはサブクエリのselect式をサポートします。"
 
-#: ../../query-dsl.md:1723
+#: ../../query-dsl.md:1733
 msgid "Example usage:"
 msgstr "使用例です。"
 
-#: ../../query-dsl.md:1758
+#: ../../query-dsl.md:1768
 msgid "User-Defined Expressions"
 msgstr "ユーザー定義式"
 
-#: ../../query-dsl.md:1760
+#: ../../query-dsl.md:1770
 msgid "You can define user-defined expressions using `Expressions.userDefined`."
 msgstr "`Expressions.userDefined` を利用することで、ユーザー定義の式を定義できます。"
 
-#: ../../query-dsl.md:1762
+#: ../../query-dsl.md:1772
 msgid "Example of defining a custom `replace` function:"
 msgstr "カスタムの `replace` 関数を定義する例です。"
 
-#: ../../query-dsl.md:1778
+#: ../../query-dsl.md:1788
 msgid "Using the custom `replace` function in a query:"
 msgstr "クエリでカスタムの `replace` 関数を使用します。"
 
-#: ../../query-dsl.md:1793
+#: ../../query-dsl.md:1803
 msgid "Scopes"
 msgstr "スコープ"
 
-#: ../../query-dsl.md:1795
+#: ../../query-dsl.md:1805
 msgid "Scopes allow you to specify commonly used query conditions."
 msgstr "スコープを使用すると、よく使用されるクエリ条件を指定できます。"
 
-#: ../../query-dsl.md:1797
+#: ../../query-dsl.md:1807
 msgid "To define a scope, create a class with a method annotated with `@Scope`:"
 msgstr "スコープを定義するには、 `@Scope` で注釈されたメソッドを持つクラスを作成します。"
 
-#: ../../query-dsl.md:1808
+#: ../../query-dsl.md:1818
 msgid ""
 "To enable the scope, specify the scope class in the `scopes` element of "
 "`@Metamodel`:"
 msgstr "スコープを有効にするには、`@Metamodel` の `scopes` 要素にスコープクラスを指定します。"
 
-#: ../../query-dsl.md:1815
+#: ../../query-dsl.md:1827
 msgid ""
 "Now `Department_` includes the `onlyTokyo` method, which can be used as "
 "follows:"
 msgstr "`Department_` には `onlyTokyo` メソッドが含まれています。このメソッドは以下のように使用できます。"
 
-#: ../../query-dsl.md:1828
+#: ../../query-dsl.md:1840
 msgid "To combine other query conditions with scopes, use the `andThen` method:"
 msgstr "他のクエリ条件をスコープと組み合わせるには、`andThen` メソッドを使用します。"
 
-#: ../../query-dsl.md:1837
+#: ../../query-dsl.md:1849
 msgid "Defining multiple scopes within a class:"
 msgstr "クラス内で複数のスコープを定義する:"
 
-#: ../../query-dsl.md:1858
+#: ../../query-dsl.md:1870
 msgid "Tips"
 msgstr "ちょっとした便利機能"
 
-#: ../../query-dsl.md:1860
+#: ../../query-dsl.md:1872
 msgid "Execution in DAO"
 msgstr "DAO での実行"
 
-#: ../../query-dsl.md:1862
+#: ../../query-dsl.md:1874
 msgid ""
 "It can be useful to execute DSLs within a default method of the DAO "
 "interface. To obtain a `config` object, call `Config.get(this)` within "
@@ -1291,7 +1291,7 @@ msgstr ""
 "DAOインタフェースのデフォルトメソッド内でDSLを実行すると便利です。 `config` オブジェクトを取得するには、デフォルトメソッド内で "
 "`Config.get(this)` を呼び出します。"
 
-#: ../../query-dsl.md:1878
+#: ../../query-dsl.md:1890
 msgid ""
 "You can also use `QueryDsl.of(this)` as a shortcut for `new "
 "QueryDsl(Config.get(this))`."
@@ -1299,27 +1299,83 @@ msgstr ""
 "また、 `QueryDsl.of(this)` を `new QueryDsl(Config.get(this))` "
 "のショートカットとして使用することもできます。"
 
-#: ../../query-dsl.md:1891
+#: ../../query-dsl.md:1903
+msgid "Reducing Memory for Very Large Batches"
+msgstr "非常に大きなバッチでメモリ使用量を抑える"
+
+#: ../../query-dsl.md:1905
+msgid ""
+"Query DSL entity batch operations use the auto-batch query "
+"implementations provided by `Config.getQueryImplementors()`. By default, "
+"those implementations build all `PreparedSql` objects for a batch up "
+"front before any SQL is sent to the database. For very large entity lists"
+" (hundreds of thousands of rows) this can exhaust the heap even when "
+"`batchSize` is set, because `batchSize` controls only how many rows are "
+"flushed to the JDBC driver per `executeBatch()` call -- not how many "
+"`PreparedSql` objects coexist in memory."
+msgstr ""
+"Query DSL のエンティティバッチ操作では、`Config.getQueryImplementors()` "
+"が提供する自動バッチクエリ実装が使用されます。デフォルトでは、これらの実装はバッチに含まれるすべての `PreparedSql` "
+"をデータベースへの送信前にあらかじめ構築します。数十万件規模の非常に大きなエンティティリストでは、`batchSize` "
+"を設定していてもヒープを使い切る可能性があります。`batchSize` は `executeBatch()` 1 回あたりに JDBC "
+"ドライバへ送る件数を決めるだけで、メモリ上に同時に存在する `PreparedSql` の数を制御するものではないからです。"
+
+#: ../../query-dsl.md:1909
+msgid ""
+"To bound peak memory for Query DSL batch operations, you can opt in to "
+"chunked query implementations by overriding [Query "
+"implementors](config.md#query-implementors) in your `Config`:"
+msgstr ""
+"Query DSL のバッチ操作でピーク時のメモリ使用量を抑えるには、`Config` で [Query "
+"implementors](config.md#query-implementors) "
+"をオーバーライドして、チャンク化されたクエリ実装をオプトインで利用できます:"
+
+#: ../../query-dsl.md:1941
+msgid ""
+"With this override, Query DSL entity batch operations such as "
+"`queryDsl.insert(e).batch(entities)`, "
+"`queryDsl.update(e).batch(entities)`, and "
+"`queryDsl.delete(e).batch(entities)` prepare only the first SQL statement"
+" up front so the command can create a representative `PreparedStatement`."
+" The remaining SQL statements are built one entity at a time during "
+"execution, bound, added to the JDBC batch, and then allowed to become "
+"eligible for garbage collection. JDBC batch flush boundaries still follow"
+" `batchSize`, but the in-memory representation of the SQL list itself "
+"stays at `O(1)`."
+msgstr ""
+"このオーバーライドを適用すると、`queryDsl.insert(e).batch(entities)`、`queryDsl.update(e).batch(entities)`、`queryDsl.delete(e).batch(entities)`"
+" などの Query DSL のエンティティバッチ操作では、コマンドが代表となる `PreparedStatement` "
+"を作成できるように、最初の SQL 文だけがあらかじめ準備されます。残りの SQL 文は実行中にエンティティ 1 "
+"件ずつ構築され、バインド・JDBC バッチへの追加を行ったのち、GC 対象になります。JDBC "
+"バッチのフラッシュ境界は引き続き `batchSize` に従いますが、メモリ上の SQL リスト自体は `O(1)` に保たれます。"
+
+#: ../../query-dsl.md:1945
+msgid ""
+"This is purely opt-in; no behavior changes unless you swap the "
+"`QueryImplementors`."
+msgstr "これは完全なオプトインです。`QueryImplementors` を差し替えない限り、挙動は変わりません。"
+
+#: ../../query-dsl.md:1947
 msgid "Overwriting the Table Name"
 msgstr "テーブル名の上書き"
 
-#: ../../query-dsl.md:1893
+#: ../../query-dsl.md:1949
 msgid ""
 "A metamodel constructor can accept a qualified table name, which allows "
 "the metamodel to overwrite its default table name."
 msgstr "メタモデルのコンストラクタは修飾されたテーブル名を受け付けることができます。これにより、デフォルトのテーブル名を上書きできます。"
 
-#: ../../query-dsl.md:1895
+#: ../../query-dsl.md:1951
 msgid ""
 "This feature is useful for working with two tables that share the same "
 "structure:"
 msgstr "この機能は、同じ構造を共有する2つのテーブルを扱う場合に便利です。"
 
-#: ../../query-dsl.md:1915
+#: ../../query-dsl.md:1971
 msgid "User-Defined Operators"
 msgstr "ユーザー定義演算子"
 
-#: ../../query-dsl.md:1917
+#: ../../query-dsl.md:1973
 msgid ""
 "User-defined operators can be implemented as methods in a class that "
 "accepts a `UserDefinedCriteriaContext` instance via its constructor."
@@ -1327,29 +1383,29 @@ msgstr ""
 "ユーザー定義の演算子は、 `UserDefinedCriteriaContext` "
 "インスタンスをコンストラクタを介して受け入れるクラスのメソッドとして実装することができます。"
 
-#: ../../query-dsl.md:1932
+#: ../../query-dsl.md:1988
 msgid ""
 "The class above can be used in the WHERE, JOIN, or HAVING clause of a "
 "query as follows:"
 msgstr "上記のクラスは、クエリの WHERE、JOIN、または HAVING 句で次のように使用できます。"
 
-#: ../../query-dsl.md:1946
+#: ../../query-dsl.md:2002
 msgid "The query above is translated into the following SQL:"
 msgstr "上記のクエリは次の SQL に変換されます。"
 
-#: ../../query-dsl.md:1954
+#: ../../query-dsl.md:2010
 msgid "Debugging"
 msgstr "デバッグ"
 
-#: ../../query-dsl.md:1956
+#: ../../query-dsl.md:2012
 msgid "To inspect the SQL statement generated by DSLs, use the `asSql` method:"
 msgstr "DSL によって生成される SQL ステートメントを調べるには、`asSql` メソッドを使用します。"
 
-#: ../../query-dsl.md:1968
+#: ../../query-dsl.md:2026
 msgid "The code above outputs the following:"
 msgstr "上記のコードは以下を出力します。"
 
-#: ../../query-dsl.md:1975
+#: ../../query-dsl.md:2033
 msgid ""
 "The `asSql` method does not execute the SQL statement against the "
 "database; instead, it only constructs the SQL statement and returns it as"
@@ -1358,27 +1414,27 @@ msgstr ""
 "`asSql` メソッドはSQLステートメントをデータベースに対して実行しません。代わりに、SQLステートメントを構築し、`Sql` "
 "オブジェクトとして返します。"
 
-#: ../../query-dsl.md:1977
+#: ../../query-dsl.md:2035
 msgid "You can also obtain the `Sql` object by using the `peek` method:"
 msgstr "`peek` メソッドを使用して `Sql` オブジェクトを取得することもできます。"
 
-#: ../../query-dsl.md:1992
+#: ../../query-dsl.md:2050
 msgid "The code above outputs SQL statements at various stages of the query:"
 msgstr "上記のコードは、クエリの様々な段階で SQL ステートメントを出力します。"
 
-#: ../../query-dsl.md:2001
+#: ../../query-dsl.md:2059
 msgid "Sample Projects"
 msgstr "サンプルプロジェクト"
 
-#: ../../query-dsl.md:2003
+#: ../../query-dsl.md:2061
 msgid "You can refer to the following sample projects for additional guidance:"
 msgstr "追加のガイダンスについては、以下のサンプルプロジェクトを参照してください。"
 
-#: ../../query-dsl.md:2005
+#: ../../query-dsl.md:2063
 msgid "[simple-examples](https://github.com/domaframework/simple-examples)"
 msgstr ""
 
-#: ../../query-dsl.md:2006
+#: ../../query-dsl.md:2064
 msgid "[kotlin-sample](https://github.com/domaframework/kotlin-sample)"
 msgstr ""
 
@@ -1403,3 +1459,11 @@ msgstr ""
 #~ msgid "`kotlin-sample <https://github.com/domaframework/kotlin-sample>`_"
 #~ msgstr ""
 
+#~ msgid ""
+#~ "JDBC batch flush boundaries still follow"
+#~ " `batchSize`, but the in-memory "
+#~ "representation of the SQL list itself"
+#~ " stays at `O(1)`."
+#~ msgstr ""
+#~ "JDBC バッチのフラッシュ境界は引き続き `batchSize` に従いますが、メモリ上の "
+#~ "SQL リスト自体は `O(1)` に保たれます。"

--- a/docs/query-dsl.md
+++ b/docs/query-dsl.md
@@ -1900,6 +1900,50 @@ public interface EmployeeDao {
 }
 ```
 
+### Reducing Memory for Very Large Batches
+
+Query DSL entity batch operations use the auto-batch query implementations provided by `Config.getQueryImplementors()`.
+By default, those implementations build all `PreparedSql` objects for a batch up front before any SQL is sent to the database.
+For very large entity lists (hundreds of thousands of rows) this can exhaust the heap even when `batchSize` is set, because `batchSize` controls only how many rows are flushed to the JDBC driver per `executeBatch()` call -- not how many `PreparedSql` objects coexist in memory.
+
+To bound peak memory for Query DSL batch operations, you can opt in to chunked query implementations by overriding [Query implementors](config.md#query-implementors) in your `Config`:
+
+```java
+public class MyConfig implements Config {
+    private final QueryImplementors queryImplementors = new QueryImplementors() {
+        @Override
+        public <ENTITY> AutoBatchInsertQuery<ENTITY> createAutoBatchInsertQuery(
+                Method method, EntityType<ENTITY> entityType) {
+            return new ChunkedAutoBatchInsertQuery<>(entityType);
+        }
+
+        @Override
+        public <ENTITY> AutoBatchUpdateQuery<ENTITY> createAutoBatchUpdateQuery(
+                Method method, EntityType<ENTITY> entityType) {
+            return new ChunkedAutoBatchUpdateQuery<>(entityType);
+        }
+
+        @Override
+        public <ENTITY> AutoBatchDeleteQuery<ENTITY> createAutoBatchDeleteQuery(
+                Method method, EntityType<ENTITY> entityType) {
+            return new ChunkedAutoBatchDeleteQuery<>(entityType);
+        }
+    };
+
+    @Override
+    public QueryImplementors getQueryImplementors() {
+        return queryImplementors;
+    }
+    // ... other Config methods ...
+}
+```
+
+With this override, Query DSL entity batch operations such as `queryDsl.insert(e).batch(entities)`, `queryDsl.update(e).batch(entities)`, and `queryDsl.delete(e).batch(entities)` prepare only the first SQL statement up front so the command can create a representative `PreparedStatement`.
+The remaining SQL statements are built one entity at a time during execution, bound, added to the JDBC batch, and then allowed to become eligible for garbage collection.
+JDBC batch flush boundaries still follow `batchSize`, but the in-memory representation of the SQL list itself stays at `O(1)`.
+
+This is purely opt-in; no behavior changes unless you swap the `QueryImplementors`.
+
 ### Overwriting the Table Name
 
 A metamodel constructor can accept a qualified table name, which allows the metamodel to overwrite its default table name.


### PR DESCRIPTION
## Summary

- Add a Query DSL Tips section describing how chunked auto-batch query implementations reduce peak memory for very large entity batches.
- Document that Query DSL entity batch operations use `Config.getQueryImplementors()` and can opt in to `ChunkedAutoBatchInsertQuery`, `ChunkedAutoBatchUpdateQuery`, and `ChunkedAutoBatchDeleteQuery`.
- Update the Japanese translation catalog using the documented gettext and `sphinx-intl` workflow.

## Validation

- `../.venv/bin/sphinx-build -b gettext . _build/gettext` from `docs/`
- `../.venv/bin/sphinx-intl update -p _build/gettext -l ja` from `docs/`
- `msgfmt --check-format -o /tmp/query-dsl.mo docs/locale/ja/LC_MESSAGES/query-dsl.po`
- `./gradlew spotlessApply`
- `git diff --check`