### PR TITLE
Fix mis-tokenization of signed number literals after a comma

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/ClassicExpressionTokenizer.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/ClassicExpressionTokenizer.java
@@ -220,6 +220,9 @@ public class ClassicExpressionTokenizer {
       return;
     } else if (c == ',') {
       type = COMMA_OPERATOR;
+      // A comma starts a new operand, so a following '+'/'-' must be treated as the sign of a
+      // numeric literal rather than a binary operator.
+      binaryOpAvailable = false;
       //noinspection UnnecessaryReturnStatement
       return;
     } else if (c == '(') {

--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/ExpressionTokenizer.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/ExpressionTokenizer.java
@@ -298,6 +298,9 @@ public class ExpressionTokenizer {
         return;
       case ',':
         type = COMMA_OPERATOR;
+        // A comma starts a new operand, so a following '+'/'-' must be treated as the sign of a
+        // numeric literal rather than a binary operator.
+        binaryOpAvailable = false;
         return;
       case '(':
         type = OPENED_PARENS;

--- a/doma-core/src/test/java/org/seasar/doma/internal/expr/ClassicExpressionTokenizerTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/expr/ClassicExpressionTokenizerTest.java
@@ -245,6 +245,27 @@ public class ClassicExpressionTokenizerTest {
   }
 
   @Test
+  public void testParensWithNegativeArgument() {
+    ClassicExpressionTokenizer tokenizer = new ClassicExpressionTokenizer("aaa.bbb(2, -3)");
+    assertEquals(VARIABLE, tokenizer.next());
+    assertEquals("aaa", tokenizer.getToken());
+    assertEquals(METHOD_OPERATOR, tokenizer.next());
+    assertEquals(".bbb", tokenizer.getToken());
+    assertEquals(OPENED_PARENS, tokenizer.next());
+    assertEquals("(", tokenizer.getToken());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("2", tokenizer.getToken());
+    assertEquals(COMMA_OPERATOR, tokenizer.next());
+    assertEquals(",", tokenizer.getToken());
+    assertEquals(WHITESPACE, tokenizer.next());
+    assertEquals(" ", tokenizer.getToken());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("-3", tokenizer.getToken());
+    assertEquals(CLOSED_PARENS, tokenizer.next());
+    assertEquals(")", tokenizer.getToken());
+  }
+
+  @Test
   public void testFunctionOperator() {
     ClassicExpressionTokenizer tokenizer = new ClassicExpressionTokenizer("@startWith(aaa)");
     assertEquals(FUNCTION_OPERATOR, tokenizer.next());

--- a/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionParserTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionParserTest.java
@@ -236,6 +236,15 @@ public class ExpressionParserTest {
   }
 
   @Test
+  public void testStaticMethodWithNegativeSecondArgument() {
+    ExpressionParser parser = new ExpressionParser("@java.lang.Math@max(1, -2)");
+    ExpressionNode expression = parser.parse();
+    ExpressionEvaluator evaluator = new ExpressionEvaluator();
+    EvaluationResult evaluationResult = evaluator.evaluate(expression);
+    assertEquals(1, evaluationResult.getValue());
+  }
+
+  @Test
   public void testStaticMethod() {
     ExpressionParser parser = new ExpressionParser("@java.lang.String@valueOf(1)");
     ExpressionNode expression = parser.parse();

--- a/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionTokenizerTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionTokenizerTest.java
@@ -244,6 +244,43 @@ public class ExpressionTokenizerTest {
   }
 
   @Test
+  public void testParensWithNegativeArgument() {
+    ExpressionTokenizer tokenizer = new ExpressionTokenizer("aaa.bbb(2, -3)");
+    assertEquals(VARIABLE, tokenizer.next());
+    assertEquals("aaa", tokenizer.getToken());
+    assertEquals(METHOD_OPERATOR, tokenizer.next());
+    assertEquals(".bbb", tokenizer.getToken());
+    assertEquals(OPENED_PARENS, tokenizer.next());
+    assertEquals("(", tokenizer.getToken());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("2", tokenizer.getToken());
+    assertEquals(COMMA_OPERATOR, tokenizer.next());
+    assertEquals(",", tokenizer.getToken());
+    assertEquals(WHITESPACE, tokenizer.next());
+    assertEquals(" ", tokenizer.getToken());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("-3", tokenizer.getToken());
+    assertEquals(CLOSED_PARENS, tokenizer.next());
+    assertEquals(")", tokenizer.getToken());
+  }
+
+  @Test
+  public void testSignedNumberAfterComma() {
+    ExpressionTokenizer tokenizer = new ExpressionTokenizer("1, -2, +3");
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("1", tokenizer.getToken());
+    assertEquals(COMMA_OPERATOR, tokenizer.next());
+    assertEquals(WHITESPACE, tokenizer.next());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("-2", tokenizer.getToken());
+    assertEquals(COMMA_OPERATOR, tokenizer.next());
+    assertEquals(WHITESPACE, tokenizer.next());
+    assertEquals(INT_LITERAL, tokenizer.next());
+    assertEquals("+3", tokenizer.getToken());
+    assertEquals(EOE, tokenizer.next());
+  }
+
+  @Test
   public void testFunctionOperator() {
     ExpressionTokenizer tokenizer = new ExpressionTokenizer("@startWith(aaa)");
     assertEquals(FUNCTION_OPERATOR, tokenizer.next());


### PR DESCRIPTION
## Summary

The expression tokenizer uses a `binaryOpAvailable` flag to decide whether a `+`/`-` character starts a **signed numeric literal** or is a **binary add/subtract operator** (the expression language has no unary minus operator, so negative numbers exist only as signed literals).

The comma handler did not reset this flag, so the `true` state left by the preceding operand leaked across the comma. As a result, the **second or later argument** of a method, function, constructor, or static method call that started with `+`/`-` was tokenized as a binary operator instead of a signed literal.

### Example

```
@java.lang.Math@max(1, -2)
```

was parsed as `Math.max(1 - 2)` = `Math.max(-1)` — a single-argument call that does not exist — and threw an `ExpressionException` instead of returning `1`.

The bug only surfaced when an argument *starts* with `+`/`-`; plain digits such as `f(a, 2)` go through the number scanner regardless of the flag, which is why existing tests (all using positive arguments) never caught it.

## Fix

Reset `binaryOpAvailable` to `false` in the comma branch of both `ExpressionTokenizer` and `ClassicExpressionTokenizer`, so a following `+`/`-` is treated as the sign of a numeric literal. This only affects the token that *starts* an operand — expressions like `f(a, b - c)` still parse `b - c` as a subtraction, because `b` re-enables the flag.

## Tests

- `ExpressionTokenizerTest`: `testParensWithNegativeArgument` (`aaa.bbb(2, -3)`), `testSignedNumberAfterComma` (`1, -2, +3`)
- `ClassicExpressionTokenizerTest`: `testParensWithNegativeArgument`
- `ExpressionParserTest`: `testStaticMethodWithNegativeSecondArgument` (`@java.lang.Math@max(1, -2)` → `1`)

Verified with `./gradlew :doma-core:test` (full module suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)