### PR TITLE
Throw ExpressionException for field access on a null target

### DIFF
--- a/doma-core/src/main/java/org/seasar/doma/internal/expr/ExpressionEvaluator.java
+++ b/doma-core/src/main/java/org/seasar/doma/internal/expr/ExpressionEvaluator.java
@@ -690,9 +690,18 @@ public class ExpressionEvaluator implements ExpressionNodeVisitor<EvaluationResu
 
   @Override
   public EvaluationResult visitFieldOperatorNode(FieldOperatorNode node, Void p) {
-    EvaluationResult targetResult = node.getTargetObjectNode().accept(this, p);
+    ExpressionNode targetObjectNode = node.getTargetObjectNode();
+    EvaluationResult targetResult = targetObjectNode.accept(this, p);
     Object target = targetResult.getValue();
     ExpressionLocation location = node.getLocation();
+    if (target == null) {
+      throw new ExpressionException(
+          Message.DOMA3034,
+          location.getExpression(),
+          location.getPosition(),
+          targetObjectNode.getExpression(),
+          node.getFieldName());
+    }
     Field field = findField(node.getFieldName(), target.getClass());
     if (field == null) {
       throw new ExpressionException(

--- a/doma-core/src/main/java/org/seasar/doma/message/Message.java
+++ b/doma-core/src/main/java/org/seasar/doma/message/Message.java
@@ -397,6 +397,9 @@ public enum Message implements MessageResource {
   DOMA3033(
       "Failed to evaluate the expression \"{0}\" at column {1}. "
           + "The static field \"{3}\" is not found in the class \"{2}\". Check that the field name is correct."),
+  DOMA3034(
+      "Failed to evaluate the expression \"{0}\" at column {1}. "
+          + "Cannot access the field \"{3}\" because the expression \"{2}\" is evaluated as null."),
 
   // annotation processing
   DOMA4001("The return type must be int that indicates the affected rows count."),

--- a/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionParserTest.java
+++ b/doma-core/src/test/java/org/seasar/doma/internal/expr/ExpressionParserTest.java
@@ -1011,6 +1011,20 @@ public class ExpressionParserTest {
   }
 
   @Test
+  public void testFieldAccess_targetObjectIsNull() {
+    ExpressionParser parser = new ExpressionParser("null.publicField");
+    ExpressionNode node = parser.parse();
+    ExpressionEvaluator evaluator = new ExpressionEvaluator();
+    try {
+      evaluator.evaluate(node);
+      fail();
+    } catch (ExpressionException expected) {
+      System.out.println(expected.getMessage());
+      assertEquals(Message.DOMA3034, expected.getMessageResource());
+    }
+  }
+
+  @Test
   public void testMethodChaining() {
     ExpressionParser parser = new ExpressionParser("str.toUpperCase().length()");
     ExpressionNode node = parser.parse();


### PR DESCRIPTION
## What

When an expression evaluates a field access such as `a.fieldName` and the target object `a` evaluates to `null`, `ExpressionEvaluator.visitFieldOperatorNode` previously called `target.getClass()` without a null check. This let a raw `NullPointerException` propagate instead of the framework's descriptive `ExpressionException`.

This change makes field access consistent with method access, which already guards the null target in `visitMethodOperatorNode` and reports `DOMA3027`.

## Changes

- **`Message.java`**: Added `DOMA3034`, a new message analogous to `DOMA3027` but for field access:
  > `Cannot access the field "{3}" because the expression "{2}" is evaluated as null.`
- **`ExpressionEvaluator.java`**: Added a `target == null` guard in `visitFieldOperatorNode` that throws an `ExpressionException` (`DOMA3034`) carrying the expression, position, target expression text, and field name — mirroring the existing guard in `visitMethodOperatorNode`.
- **`ExpressionParserTest.java`**: Added `testFieldAccess_targetObjectIsNull`, which evaluates `null.publicField` and asserts the descriptive `DOMA3034` exception is thrown.

## Why a new message code

`DOMA3018` ("field not found in class") describes a different cause — the target exists but lacks the field. Reusing it would mislead users into checking the field name when the real issue is a null receiver. A distinct `DOMA3034` keeps the diagnostic accurate, matching the method side's split between `DOMA3002` (method not found) and `DOMA3027` (null target).

Per `doma-core/AGENTS.md`, existing `Message` entries are not modified; only a new entry is appended, so no processor or integration test expectations change.

## Testing

- `./gradlew :doma-core:test` — passed
- `./gradlew :doma-core:spotlessApply` — no changes