### PR TITLE
Run Gradle on the oldest JDK in CI and update spotless to v8.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,13 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
+          # actions/setup-java points JAVA_HOME at the last version listed here, and
+          # that is the JVM Gradle itself runs on. Keep the oldest JDK last so the
+          # build runs on the same JVM as the documented development environment.
           java-version: |
-            ${{ env.JDK_VERSION_OLDEST }}
             ${{ env.JDK_VERSION_LATEST }}
             ${{ env.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -51,7 +54,7 @@ jobs:
       - name: Assemble and Check
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           --no-configuration-cache
           assemble check
 
@@ -77,10 +80,13 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
+          # actions/setup-java points JAVA_HOME at the last version listed here, and
+          # that is the JVM Gradle itself runs on. Keep the oldest JDK last so the
+          # build runs on the same JVM as the documented development environment.
           java-version: |
-            ${{ env.JDK_VERSION_OLDEST }}
             ${{ env.JDK_VERSION_LATEST }}
             ${{ env.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -95,7 +101,7 @@ jobs:
           ./gradlew
           -Pdriver=${{ matrix.driver }}
           -PtestJavaLangVersion=${{ env.JDK_VERSION_OLDEST }}
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           integration-test-java:test
           integration-test-kotlin:test
 
@@ -104,7 +110,7 @@ jobs:
           ./gradlew
           -Pdriver=${{ matrix.driver }}
           -PtestJavaLangVersion=${{ env.JDK_VERSION_LATEST }}
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           integration-test-java:test
 
       - name: Test with the latest LTS JDK (Java)
@@ -112,6 +118,7 @@ jobs:
           ./gradlew
           -Pdriver=${{ matrix.driver }}
           -PtestJavaLangVersion=${{ env.JDK_VERSION_LATEST_LTS }}
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           integration-test-java:test
 
       - name: Upload reports
@@ -133,10 +140,13 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
+          # actions/setup-java points JAVA_HOME at the last version listed here, and
+          # that is the JVM Gradle itself runs on. Keep the oldest JDK last so the
+          # build runs on the same JVM as the documented development environment.
           java-version: |
-            ${{ env.JDK_VERSION_OLDEST }}
             ${{ env.JDK_VERSION_LATEST }}
             ${{ env.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -149,7 +159,7 @@ jobs:
       - name: Test with ECJ
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           -Pcompiler=ecj
           :doma-processor:test
           :integration-test-java:test
@@ -175,10 +185,13 @@ jobs:
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
+          # actions/setup-java points JAVA_HOME at the last version listed here, and
+          # that is the JVM Gradle itself runs on. Keep the oldest JDK last so the
+          # build runs on the same JVM as the documented development environment.
           java-version: |
-            ${{ env.JDK_VERSION_OLDEST }}
             ${{ env.JDK_VERSION_LATEST }}
             ${{ env.JDK_VERSION_LATEST_LTS }}
+            ${{ env.JDK_VERSION_OLDEST }}
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -196,7 +209,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
         run: >
           ./gradlew
-          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_${{ env.JDK_VERSION_OLDEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST }}_X64,JAVA_HOME_${{ env.JDK_VERSION_LATEST_LTS }}_X64
           -Porg.gradle.parallel=false
           --no-configuration-cache
           publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ quarkus-doma = { module = "io.quarkiverse.doma:quarkus-doma", version = "1.0.9"}
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-spotless = { id = "com.diffplug.spotless", version = "8.9.0" }
+spotless = { id = "com.diffplug.spotless", version = "8.10.1" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 release = { id = "net.researchgate.release", version = "3.1.0" }
 doma-compile = { id = "org.domaframework.doma.compile", version = "4.0.3" }


### PR DESCRIPTION
## Summary

Fixes the `Build` job failure on #1660 and lands that Spotless upgrade.

Spotless 8.10.0 tightened the google-java-format compatibility table. Decompiled from the 8.10.1 jar:

```java
Jvm.support("google-java-format")
    .addMin(21, "1.17.0")
    .addMin(25, "1.30.0")   // JVM 25+ requires gjf >= 1.30.0
    .add(17, "1.28.0")      // JVM 17: 1.28.0 is the recommended version
    .add(21, "1.30.0")
```

Three things collide:

1. We pin google-java-format to `1.28.0`.
2. That pin is deliberate — `renovate.json` caps it at `<1.29.0` because gjf 1.29.0+ needs JDK 21 to run, while `AGENTS.md` documents JDK 17 as the development JDK (see #1448, #1457).
3. CI's Gradle daemon runs on JVM 25, which is incidental: `actions/setup-java` makes the last entry of `java-version` the default `JAVA_HOME`, and the list was `17, 26, 25`.

So the fix is to stop running Spotless on JVM 25 rather than to fight the pin. On JVM 17 there is no minimum at all, and `1.28.0` is exactly the version Spotless recommends for it, which makes the existing Renovate pin consistent with upstream instead of merely tolerated.

## Changes

- **`.github/workflows/ci.yml`** — list the oldest JDK last in all four jobs so the Gradle daemon runs on JDK 17, with a comment explaining the last-wins rule. Register every installed JDK through `org.gradle.java.installations.fromEnv`, so toolchain resolution no longer depends on which JDK happens to be `JAVA_HOME`. The *Test with the latest LTS JDK* step had no `fromEnv` at all and silently relied on `JAVA_HOME` being the LTS JDK; it would have broken from the reorder otherwise.
- **`gradle/libs.versions.toml`** — spotless `8.9.0` -> `8.10.1`.

## Test plan

Reproduced both sides locally with SDKMAN JDKs:

| Daemon JVM | Result |
|---|---|
| 25 | `spotlessJava FAILED` in 11 modules, matching the CI error verbatim |
| 17 | `assemble check` (the actual Build-job command) **BUILD SUCCESSFUL** |

The JDK 17 run covered doma-core, doma-processor, integration-test-java and integration-test-kotlin (kapt), so the Kotlin plugin and kapt are fine on a JDK 17 daemon. No source files were reformatted.

## Notes

Once this merges, #1660 becomes redundant and Renovate should close it.

The alternative would be to reverse the policy: drop the Renovate pin, move gjf to >= 1.30.0, and raise the *build* JDK requirement to 21+ (updating `AGENTS.md`). Formatting churn would be near zero, since gjf 1.29.0 shipped no formatting changes and 1.30.0 only added `import module` support. This PR keeps JDK 17 instead, as deliberately chosen in #1448 and #1457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
